### PR TITLE
Release v1.1.0: Add MySQL database support

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -168,6 +168,25 @@ DATABRICKS_ACCESS_TOKEN=your_access_token
 DATABRICKS_CATALOG=hive_metastore
 DATABRICKS_SCHEMA=default
 
+# MySQL Configuration
+# -------------------
+# Required for MySQL connections
+MYSQL_HOST=localhost
+MYSQL_PORT=3306
+MYSQL_DATABASE=mydb
+MYSQL_USERNAME=root
+MYSQL_PASSWORD=your_password
+# Optional: Character set (default: utf8mb4 for full Unicode support)
+MYSQL_CHARSET=utf8mb4
+
+# Troubleshooting MySQL:
+# - Connection refused: Check MySQL server is running (sudo systemctl status mysql)
+# - Access denied: Verify username/password and user privileges (GRANT ALL ON mydb.* TO 'user'@'%')
+# - Unknown database: Ensure database exists (CREATE DATABASE mydb;)
+# - Character encoding issues: Use MYSQL_CHARSET=utf8mb4 for full Unicode support (including emojis)
+# - Connection timeouts: Check firewall rules and network connectivity
+# - Too many connections: Increase max_connections in MySQL config or reduce pool_size
+
 # Security Notes:
 # ---------------
 # - Never commit this file with real credentials

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0] - 2026-03-22
 
 ### Added
-- **MySQL Support** - Full support for MySQL 5.7+, 8.0+, and MariaDB 10.3+
+- **MySQL Support** - Full support for MySQL 8.0+ and MariaDB 10.5+
+  - MySQL 5.7 reached EOL in October 2023 (no longer supported)
+  - MySQL 8.0+ provides CTEs, window functions, and improved performance
 - New MySQL database driver: `mysql.py` with PyMySQL connector
 - Connection method: `connect_mysql()` with charset configuration (default: utf8mb4)
 - MySQL configuration section in `.env.template` with troubleshooting guide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to OrionBelt Analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-03-22
+
+### Added
+- **MySQL Support** - Full support for MySQL 5.7+, 8.0+, and MariaDB 10.3+
+- New MySQL database driver: `mysql.py` with PyMySQL connector
+- Connection method: `connect_mysql()` with charset configuration (default: utf8mb4)
+- MySQL configuration section in `.env.template` with troubleshooting guide
+- MySQL system schema exclusions: `information_schema`, `mysql`, `performance_schema`, `sys`
+- MySQL badge and documentation in README
+- Connection pooling with automatic reconnection for MySQL (pool_pre_ping=True)
+
+### Changed
+- Supported databases expanded from 7 to 8
+- README updated with MySQL in all database lists
+- Version bumped to 1.1.0
+- Project keywords expanded to include `mysql`
+
+### Dependencies
+- Added `pymysql>=1.1.0` for MySQL connectivity (pure Python, cross-platform)
+
+### Database Support Summary
+OrionBelt Analytics v1.1.0 now supports:
+1. PostgreSQL
+2. **MySQL** (NEW)
+3. Snowflake
+4. ClickHouse
+5. Dremio
+6. BigQuery
+7. DuckDB/MotherDuck
+8. Databricks SQL
+
 ## [1.0.0] - 2026-03-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center"><strong>The Ontology-based MCP server for your Text-2-SQL convenience.</strong></p>
 
-[![Version 1.0.0](https://img.shields.io/badge/version-1.0.0-purple.svg)](https://github.com/ralfbecher/orionbelt-analytics/releases)
+[![Version 1.1.0](https://img.shields.io/badge/version-1.1.0-purple.svg)](https://github.com/ralfbecher/orionbelt-analytics/releases)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralfbecher/orionbelt-analytics/blob/main/LICENSE)
 [![FastMCP](https://img.shields.io/badge/FastMCP-3.1+-blue)](https://github.com/jlowin/fastmcp)
@@ -15,15 +15,16 @@
 
 [![BigQuery](https://img.shields.io/badge/BigQuery-669DF6.svg?logo=googlebigquery&logoColor=white)](https://cloud.google.com/bigquery)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1.svg?logo=postgresql&logoColor=white)](https://www.postgresql.org)
+[![MySQL](https://img.shields.io/badge/MySQL-4479A1.svg?logo=mysql&logoColor=white)](https://www.mysql.com)
 [![Snowflake](https://img.shields.io/badge/Snowflake-29B5E8.svg?logo=snowflake&logoColor=white)](https://www.snowflake.com)
 [![ClickHouse](https://img.shields.io/badge/ClickHouse-FFCC01.svg?logo=clickhouse&logoColor=black)](https://clickhouse.com)
 [![Dremio](https://img.shields.io/badge/Dremio-31B48D.svg)](https://www.dremio.com)
 [![Databricks](https://img.shields.io/badge/Databricks-FF3621.svg?logo=databricks&logoColor=white)](https://www.databricks.com)
 [![DuckDB](https://img.shields.io/badge/DuckDB-FFF000.svg?logo=duckdb&logoColor=black)](https://duckdb.org)
 
-This project provides a production-ready Python-based MCP (Model Context Protocol) server that analyzes relational database schemas (PostgreSQL, Snowflake, ClickHouse, Dremio, BigQuery, DuckDB/MotherDuck, and Databricks SQL) and automatically generates comprehensive ontologies in RDF/Turtle format with direct SQL mappings.
+This project provides a production-ready Python-based MCP (Model Context Protocol) server that analyzes relational database schemas (PostgreSQL, MySQL, Snowflake, ClickHouse, Dremio, BigQuery, DuckDB/MotherDuck, and Databricks SQL) and automatically generates comprehensive ontologies in RDF/Turtle format with direct SQL mappings.
 
-> **Better Together:** Combine with [**OrionBelt Semantic Layer**](https://github.com/ralfbecher/orionbelt-semantic-layer) for a complete AI-powered analytics stack. The Semantic Layer compiles declarative YAML models into dialect-specific, optimized SQL — ensuring correct joins, aggregations, and fan-trap-free queries across PostgreSQL, Snowflake, ClickHouse, Dremio, BigQuery, DuckDB, and Databricks. Run both MCP servers side-by-side in Claude Desktop for schema-aware ontology generation **and** guaranteed-correct SQL compilation.
+> **Better Together:** Combine with [**OrionBelt Semantic Layer**](https://github.com/ralfbecher/orionbelt-semantic-layer) for a complete AI-powered analytics stack. The Semantic Layer compiles declarative YAML models into dialect-specific, optimized SQL — ensuring correct joins, aggregations, and fan-trap-free queries across PostgreSQL, MySQL, Snowflake, ClickHouse, Dremio, BigQuery, DuckDB, and Databricks. Run both MCP servers side-by-side in Claude Desktop for schema-aware ontology generation **and** guaranteed-correct SQL compilation.
 
 ### GraphRAG: The Foundation for OBML Model Creation
 
@@ -85,7 +86,7 @@ OrionBelt Analytics combines multiple AI-powered technologies to provide intelli
 
 ### 🔗 Database Connectivity
 
-- **PostgreSQL**, **Snowflake**, **ClickHouse**, **Dremio**, **BigQuery**, **DuckDB/MotherDuck**, and **Databricks SQL** support with connection pooling
+- **PostgreSQL**, **MySQL**, **Snowflake**, **ClickHouse**, **Dremio**, **BigQuery**, **DuckDB/MotherDuck**, and **Databricks SQL** support with connection pooling
 - **Environment variable fallback** - parameters optional, uses .env when not provided
 - **Enhanced connection management** with retry logic and timeout handling
 - **Automatic dependency management** for all database connectors
@@ -171,7 +172,7 @@ WHERE {
 uv sync
 ```
 
-**Key dependencies:** FastMCP, SQLAlchemy, database connectors (PostgreSQL, Snowflake, ClickHouse, Dremio, BigQuery, DuckDB, Databricks), RDFLib, Pydantic
+**Key dependencies:** FastMCP, SQLAlchemy, database connectors (PostgreSQL, MySQL, Snowflake, ClickHouse, Dremio, BigQuery, DuckDB, Databricks), RDFLib, Pydantic
 
 ## Project Structure
 
@@ -211,7 +212,7 @@ orionbelt-analytics/
 
 - **Python 3.13 or higher** (required)
 - **uv** package manager (recommended) - [Install uv](https://github.com/astral-sh/uv)
-- Database access: PostgreSQL, Snowflake, ClickHouse, Dremio, BigQuery, DuckDB/MotherDuck, or Databricks SQL
+- Database access: PostgreSQL, MySQL, Snowflake, ClickHouse, Dremio, BigQuery, DuckDB/MotherDuck, or Databricks SQL
 
 ### Installation
 
@@ -280,6 +281,14 @@ POSTGRES_PORT=5432
 POSTGRES_DATABASE=postgres
 POSTGRES_USERNAME=postgres
 POSTGRES_PASSWORD=postgres
+
+# MySQL Configuration (optional - can provide via tool parameters)
+MYSQL_HOST=localhost
+MYSQL_PORT=3306
+MYSQL_DATABASE=mydb
+MYSQL_USERNAME=root
+MYSQL_PASSWORD=your_password
+MYSQL_CHARSET=utf8mb4  # Recommended for full Unicode support
 
 # Snowflake Configuration (optional - can provide via tool parameters)
 SNOWFLAKE_ACCOUNT=CLYKFLK-KA74251    # Use your actual account identifier
@@ -456,7 +465,7 @@ The server provides **built-in workflow guidance** through FastMCP Context integ
 
 #### 1. `connect_database`
 
-Connect to PostgreSQL, Snowflake, ClickHouse, Dremio, BigQuery, DuckDB/MotherDuck, or Databricks SQL with environment variable fallback.
+Connect to PostgreSQL, MySQL, Snowflake, ClickHouse, Dremio, BigQuery, DuckDB/MotherDuck, or Databricks SQL with environment variable fallback.
 
 **Key Feature**: Parameters are optional - uses .env values when not provided.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "orionbelt-analytics"
-version = "1.0.0"
+version = "1.1.0"
 description = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "ralf.becher@web.de"}]
 readme = "README.md"
 requires-python = ">=3.13"
-keywords = ["mcp", "database", "ontology", "rdf", "schema-analysis", "postgresql", "snowflake", "clickhouse", "bigquery", "duckdb", "databricks"]
+keywords = ["mcp", "database", "ontology", "rdf", "schema-analysis", "postgresql", "snowflake", "clickhouse", "bigquery", "duckdb", "databricks", "mysql"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -36,6 +36,8 @@ dependencies = [
     "duckdb-engine>=0.13.0",
     # Databricks connectivity
     "databricks-sql-connector>=3.5.0",
+    # MySQL connectivity
+    "pymysql>=1.1.0",
     # Security dependencies
     "cryptography>=46.0.5",
     # Configuration and validation

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """OrionBelt Analytics - Ontology-based MCP server for your Text-2-SQL convenience."""
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 __author__ = "OrionBelt Analytics Contributors"
 __email__ = "contributors@example.com"
 __description__ = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"

--- a/src/constants.py
+++ b/src/constants.py
@@ -5,6 +5,7 @@ DEFAULT_POSTGRES_PORT = 5432
 DEFAULT_SNOWFLAKE_SCHEMA = "PUBLIC"
 DEFAULT_DREMIO_PORT = 9047  # Dremio REST API port
 DEFAULT_CLICKHOUSE_PORT = 8123  # ClickHouse HTTP protocol port
+DEFAULT_MYSQL_PORT = 3306  # MySQL default port
 
 # Data sampling limits
 MIN_SAMPLE_LIMIT = 1
@@ -31,7 +32,7 @@ DEFAULT_OUTPUT_DIR = "tmp"
 IDENTIFIER_PATTERN = r'^[a-zA-Z_][a-zA-Z0-9_-]*$'
 
 # Supported database types
-SUPPORTED_DB_TYPES = ["postgresql", "snowflake", "dremio", "clickhouse", "bigquery", "duckdb", "databricks"]
+SUPPORTED_DB_TYPES = ["postgresql", "snowflake", "dremio", "clickhouse", "bigquery", "duckdb", "databricks", "mysql"]
 
 # System schemas to exclude
 POSTGRES_SYSTEM_SCHEMAS = ["information_schema", "pg_catalog", "pg_toast"]
@@ -41,3 +42,4 @@ CLICKHOUSE_SYSTEM_SCHEMAS = ["system", "INFORMATION_SCHEMA", "information_schema
 BIGQUERY_SYSTEM_SCHEMAS = ["INFORMATION_SCHEMA", "information_schema"]
 DUCKDB_SYSTEM_SCHEMAS = ["information_schema", "pg_catalog"]
 DATABRICKS_SYSTEM_SCHEMAS = ["information_schema", "default"]
+MYSQL_SYSTEM_SCHEMAS = ["information_schema", "mysql", "performance_schema", "sys"]

--- a/src/database_manager.py
+++ b/src/database_manager.py
@@ -669,6 +669,63 @@ class DatabaseManager:
             }
         return success
 
+    def connect_mysql(self, host: str, port: int, database: str,
+                      username: str, password: str, charset: str = "utf8mb4") -> bool:
+        """Connect to MySQL database.
+
+        Args:
+            host: MySQL server hostname or IP
+            port: MySQL server port (default: 3306)
+            database: Database name
+            username: MySQL username
+            password: MySQL password
+            charset: Character set (default: utf8mb4 for full Unicode support)
+
+        Returns:
+            True if connection successful, False otherwise
+        """
+        from .drivers.mysql import MySQLDriver
+
+        driver = MySQLDriver(
+            pool_size=self._connection_pool_size,
+            max_overflow=self._max_overflow,
+        )
+        success = driver.connect(
+            host=host,
+            port=port,
+            database=database,
+            username=username,
+            password=password,
+            charset=charset,
+        )
+        if success:
+            self._driver = driver
+            self._dremio_rest_connection = None
+            self._sync_engine_from_driver()
+
+            self.connection_info = {
+                "type": "mysql",
+                "host": host,
+                "port": port,
+                "database": database,
+                "username": username,
+                "charset": charset,
+            }
+            self._connection_id = hashlib.sha256(
+                f"{host}:{port}:{database}:{username}".encode()
+            ).hexdigest()[:16]
+
+            self._last_connection_params = {
+                "type": "mysql",
+                "host": host,
+                "port": port,
+                "database": database,
+                "username": username,
+                "password": password,
+                "charset": charset,
+            }
+        return success
+
     # ------------------------------------------------------------------
     # Schema introspection (delegated to driver)
     # ------------------------------------------------------------------

--- a/src/database_manager.py
+++ b/src/database_manager.py
@@ -671,7 +671,7 @@ class DatabaseManager:
 
     def connect_mysql(self, host: str, port: int, database: str,
                       username: str, password: str, charset: str = "utf8mb4") -> bool:
-        """Connect to MySQL database.
+        """Connect to MySQL 8.0+ or MariaDB 10.5+ database.
 
         Args:
             host: MySQL server hostname or IP
@@ -683,6 +683,10 @@ class DatabaseManager:
 
         Returns:
             True if connection successful, False otherwise
+
+        Note:
+            MySQL 5.7 reached EOL in October 2023 and is not supported.
+            Requires MySQL 8.0+ or MariaDB 10.5+.
         """
         from .drivers.mysql import MySQLDriver
 

--- a/src/drivers/__init__.py
+++ b/src/drivers/__init__.py
@@ -12,6 +12,7 @@ from .dremio import DremioDriver
 from .bigquery import BigQueryDriver
 from .duckdb import DuckDBDriver
 from .databricks import DatabricksDriver
+from .mysql import MySQLDriver
 
 __all__ = [
     "DatabaseDriver",
@@ -22,4 +23,5 @@ __all__ = [
     "BigQueryDriver",
     "DuckDBDriver",
     "DatabricksDriver",
+    "MySQLDriver",
 ]

--- a/src/drivers/mysql.py
+++ b/src/drivers/mysql.py
@@ -1,4 +1,8 @@
-"""MySQL database driver."""
+"""MySQL database driver.
+
+Supports MySQL 8.0+ and MariaDB 10.5+.
+MySQL 5.7 reached EOL in October 2023 and is not supported.
+"""
 
 import hashlib
 import logging
@@ -48,9 +52,11 @@ class MySQLDriver(DatabaseDriver):
     # ------------------------------------------------------------------
 
     def connect(self, **params) -> bool:
-        """Connect to MySQL.
+        """Connect to MySQL 8.0+ or MariaDB 10.5+.
 
         Expected params: host, port, database, username, password, charset (optional).
+
+        Note: MySQL 5.7 reached EOL in October 2023 and is not supported.
         """
         host = params["host"]
         port = params["port"]

--- a/src/drivers/mysql.py
+++ b/src/drivers/mysql.py
@@ -1,0 +1,447 @@
+"""MySQL database driver."""
+
+import hashlib
+import logging
+import re
+from typing import Any, Dict, List, Optional
+from urllib.parse import quote_plus
+
+from sqlalchemy import create_engine, text, MetaData, inspect
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import SQLAlchemyError, OperationalError, DatabaseError
+from sqlalchemy.pool import QueuePool
+
+from ..constants import (
+    CONNECTION_TIMEOUT,
+    MYSQL_SYSTEM_SCHEMAS,
+    MIN_SAMPLE_LIMIT,
+    MAX_SAMPLE_LIMIT,
+    DEFAULT_SAMPLE_LIMIT,
+)
+from ..serialization import serialize_rows
+from ..security import (
+    SecureCredentialManager,
+    identifier_validator,
+    audit_log_security_event,
+    SecurityLevel,
+)
+from ..database_manager import ColumnInfo, TableInfo
+from .base import DatabaseDriver
+
+logger = logging.getLogger(__name__)
+
+
+class MySQLDriver(DatabaseDriver):
+    """MySQL-specific database operations."""
+
+    db_type = "mysql"
+
+    def __init__(self, pool_size: int = 5, max_overflow: int = 10):
+        self.engine: Optional[Engine] = None
+        self.metadata: Optional[MetaData] = None
+        self._pool_size = pool_size
+        self._max_overflow = max_overflow
+        self._credential_manager = SecureCredentialManager()
+
+    # ------------------------------------------------------------------
+    # Connection
+    # ------------------------------------------------------------------
+
+    def connect(self, **params) -> bool:
+        """Connect to MySQL.
+
+        Expected params: host, port, database, username, password, charset (optional).
+        """
+        host = params["host"]
+        port = params["port"]
+        database = params["database"]
+        username = params["username"]
+        password = params["password"]
+        charset = params.get("charset", "utf8mb4")
+
+        try:
+            if not all([host, port, database, username]):
+                logger.error("Missing required MySQL connection parameters")
+                return False
+
+            if not identifier_validator.validate_identifier(database):
+                audit_log_security_event(
+                    "invalid_identifier_attempt",
+                    {"identifier": database[:50]},
+                    SecurityLevel.MEDIUM,
+                )
+                logger.error(f"Invalid database name: {database}")
+                return False
+
+            safe_username = quote_plus(username)
+            safe_password = quote_plus(password)
+            connection_string = (
+                f"mysql+pymysql://{safe_username}:{safe_password}@{host}:{port}/{database}?charset={charset}"
+            )
+
+            self.engine = create_engine(
+                connection_string,
+                poolclass=QueuePool,
+                pool_size=self._pool_size,
+                max_overflow=self._max_overflow,
+                pool_timeout=CONNECTION_TIMEOUT,
+                pool_pre_ping=True,
+                pool_recycle=3600,
+                echo=False,
+                connect_args={
+                    "connect_timeout": CONNECTION_TIMEOUT,
+                },
+            )
+            self.metadata = MetaData()
+
+            # Initialize encryption
+            try:
+                if not self._credential_manager._cipher:
+                    key_material = f"{host}:{database}:{username}"
+                    self._credential_manager._initialize_encryption(key_material)
+                logger.info(
+                    f"MySQL connection established successfully to {host}:{port}/{database}"
+                )
+            except Exception as e:
+                logger.warning(f"Could not initialize credential encryption: {e}")
+
+            # Test connection
+            with self.engine.connect() as conn:
+                result = conn.execute(text("SELECT 1"))
+                result.fetchone()
+
+            logger.info(f"Connected to MySQL database: {database} at {host}:{port}")
+            return True
+
+        except (SQLAlchemyError, OperationalError, DatabaseError) as e:
+            logger.error(
+                f"Failed to connect to MySQL {host}:{port}/{database}: "
+                f"{type(e).__name__}: {e}"
+            )
+            self.engine = None
+            return False
+        except Exception as e:
+            logger.error(
+                f"Unexpected error connecting to MySQL: {type(e).__name__}: {e}"
+            )
+            self.engine = None
+            return False
+
+    # ------------------------------------------------------------------
+    # Schema introspection
+    # ------------------------------------------------------------------
+
+    def get_schemas(self) -> List[str]:
+        excluded_schemas = "', '".join(MYSQL_SYSTEM_SCHEMAS)
+        query = text(f"""
+            SELECT SCHEMA_NAME
+            FROM information_schema.SCHEMATA
+            WHERE SCHEMA_NAME NOT IN ('{excluded_schemas}')
+            ORDER BY SCHEMA_NAME
+        """)
+        try:
+            with self.engine.connect() as conn:
+                result = conn.execute(query)
+                return [row[0] for row in result.fetchall()]
+        except SQLAlchemyError as e:
+            logger.error(f"Failed to get schemas: {e}")
+            return []
+
+    def get_tables(self, schema_name: Optional[str] = None) -> List[str]:
+        try:
+            with self.engine.connect() as conn:
+                if schema_name:
+                    query = text("""
+                        SELECT TABLE_NAME
+                        FROM information_schema.TABLES
+                        WHERE TABLE_SCHEMA = :schema_name
+                        AND TABLE_TYPE = 'BASE TABLE'
+                        ORDER BY TABLE_NAME
+                    """)
+                    result = conn.execute(query, {"schema_name": schema_name})
+                else:
+                    query = text("""
+                        SELECT TABLE_NAME
+                        FROM information_schema.TABLES
+                        WHERE TABLE_TYPE = 'BASE TABLE'
+                        ORDER BY TABLE_NAME
+                    """)
+                    result = conn.execute(query)
+                return [row[0] for row in result.fetchall()]
+        except SQLAlchemyError as e:
+            logger.error(f"Failed to get tables: {e}")
+            return []
+
+    def analyze_table(
+        self, table_name: str, schema_name: Optional[str] = None
+    ) -> Optional[TableInfo]:
+        try:
+            with self.engine.connect() as conn:
+                inspector = inspect(self.engine)
+
+                if schema_name:
+                    if not inspector.has_table(table_name, schema=schema_name):
+                        logger.error(f"Table {schema_name}.{table_name} not found")
+                        return None
+                    table_columns = inspector.get_columns(table_name, schema=schema_name)
+                    table_pk = inspector.get_pk_constraint(table_name, schema=schema_name)
+                    table_fks = inspector.get_foreign_keys(table_name, schema=schema_name)
+                else:
+                    if not inspector.has_table(table_name):
+                        logger.error(f"Table {table_name} not found")
+                        return None
+                    table_columns = inspector.get_columns(table_name)
+                    table_pk = inspector.get_pk_constraint(table_name)
+                    table_fks = inspector.get_foreign_keys(table_name)
+
+                primary_keys = table_pk.get("constrained_columns", []) if table_pk else []
+                primary_keys_upper = [pk.upper() for pk in primary_keys]
+
+                logger.info(
+                    f"Table {schema_name}.{table_name}: PKs={primary_keys}, "
+                    f"FKs={len(table_fks)} constraints"
+                )
+                if table_fks:
+                    for fk in table_fks:
+                        logger.info(f"  FK: {fk}")
+
+                columns = []
+                foreign_keys = []
+                for col_info in table_columns:
+                    column_name = col_info["name"]
+                    is_pk = column_name.upper() in primary_keys_upper
+
+                    fk_table = None
+                    fk_column = None
+                    is_fk = False
+                    for fk in table_fks:
+                        constrained_cols_upper = [
+                            c.upper() for c in fk.get("constrained_columns", [])
+                        ]
+                        if column_name.upper() in constrained_cols_upper:
+                            is_fk = True
+                            fk_idx = constrained_cols_upper.index(column_name.upper())
+                            fk_table = fk.get("referred_table")
+                            referred_cols = fk.get("referred_columns", [])
+                            fk_column = (
+                                referred_cols[fk_idx]
+                                if fk_idx < len(referred_cols)
+                                else None
+                            )
+                            fk_schema = fk.get("referred_schema")
+                            if fk_table:
+                                foreign_keys.append(
+                                    {
+                                        "column": column_name,
+                                        "referenced_table": fk_table,
+                                        "referenced_column": fk_column,
+                                        "referenced_schema": fk_schema,
+                                    }
+                                )
+                                logger.debug(
+                                    f"Added FK: {column_name} -> "
+                                    f"{fk_schema}.{fk_table}.{fk_column}"
+                                )
+                            break
+
+                    columns.append(
+                        ColumnInfo(
+                            name=column_name,
+                            data_type=str(col_info["type"]),
+                            is_nullable=col_info["nullable"],
+                            is_primary_key=is_pk,
+                            is_foreign_key=is_fk,
+                            foreign_key_table=fk_table,
+                            foreign_key_column=fk_column,
+                            comment=col_info.get("comment"),
+                        )
+                    )
+
+                return TableInfo(
+                    name=table_name,
+                    schema=schema_name or "",
+                    columns=columns,
+                    primary_keys=primary_keys,
+                    foreign_keys=foreign_keys,
+                    comment=None,
+                    row_count=None,
+                    sample_data=None,
+                )
+
+        except SQLAlchemyError as e:
+            logger.error(f"Failed to analyze table {table_name}: {e}")
+            return None
+
+    # ------------------------------------------------------------------
+    # Query validation & execution
+    # ------------------------------------------------------------------
+
+    def validate_sql_syntax(
+        self, sql_query: str, validation_result: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        try:
+            with self.engine.connect() as conn:
+                # Use EXPLAIN for MySQL syntax validation
+                explain_sql = f"EXPLAIN {sql_query}"
+                try:
+                    conn.execute(text(explain_sql))
+                    validation_result["is_valid"] = True
+                except Exception as explain_error:
+                    error_msg = str(explain_error)
+                    validation_result["database_error"] = error_msg
+                    validation_result["error"] = f"MySQL syntax error: {error_msg}"
+                    validation_result["error_type"] = "syntax_error"
+
+                    if (
+                        "table" in error_msg.lower()
+                        and "doesn't exist" in error_msg.lower()
+                    ):
+                        validation_result["suggestions"].append(
+                            "Check table/column names - they may not exist or may need proper schema qualification"
+                        )
+                    elif "syntax" in error_msg.lower() or "error" in error_msg.lower():
+                        validation_result["suggestions"].append(
+                            "Review SQL syntax - check for missing commas, parentheses, or keywords"
+                        )
+                    elif "access denied" in error_msg.lower():
+                        validation_result["suggestions"].append(
+                            "Insufficient permissions to access the specified tables"
+                        )
+        except Exception as conn_error:
+            validation_result["error"] = (
+                f"Database connection error during validation: {conn_error}"
+            )
+            validation_result["error_type"] = "connection_error"
+
+        return validation_result
+
+    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> Dict[str, Any]:
+        """Execute query - delegated from DatabaseManager which handles validation."""
+        import time as time_mod
+
+        result_data: Dict[str, Any] = {
+            "success": False,
+            "data": [],
+            "columns": [],
+            "row_count": 0,
+            "execution_time_ms": None,
+            "error": None,
+            "error_type": None,
+            "warnings": [],
+            "query_plan": None,
+            "limit_applied": False,
+        }
+
+        try:
+            start_time = time_mod.time()
+            db_type = self.db_type.upper()
+
+            with self.engine.connect() as conn:
+                logger.info(f"🐬 {db_type} SQL QUERY: {sql_query}")
+                result = conn.execute(text(sql_query))
+
+                try:
+                    if result.returns_rows:
+                        result_data["columns"] = list(result.keys())
+                        try:
+                            raw_rows = result.fetchall()
+                        except Exception as fetch_error:
+                            logger.error(f"Error fetching results: {fetch_error}")
+                            try:
+                                result.close()
+                            except Exception:
+                                pass
+                            raise
+
+                        result_data["data"] = serialize_rows(
+                            raw_rows, result_data["columns"]
+                        )
+                        result_data["row_count"] = len(result_data["data"])
+                    else:
+                        result_data["row_count"] = getattr(result, "rowcount", 0)
+                finally:
+                    try:
+                        result.close()
+                    except Exception:
+                        pass
+
+                end_time = time_mod.time()
+                result_data["execution_time_ms"] = round(
+                    (end_time - start_time) * 1000, 2
+                )
+                result_data["success"] = True
+                logger.info(
+                    f"SQL query executed: {result_data['row_count']} rows "
+                    f"in {result_data['execution_time_ms']}ms"
+                )
+
+        except SQLAlchemyError as e:
+            result_data["error"] = str(e)
+            result_data["error_type"] = "execution_error"
+            logger.error(f"SQL execution failed: {e}")
+        except Exception as e:
+            result_data["error"] = f"Unexpected execution error: {str(e)}"
+            result_data["error_type"] = "internal_error"
+            logger.error(f"Unexpected SQL execution error: {e}")
+
+        return result_data
+
+    def sample_table_data(
+        self,
+        table_name: str,
+        schema_name: Optional[str] = None,
+        limit: int = DEFAULT_SAMPLE_LIMIT,
+    ) -> List[Dict[str, Any]]:
+        if not isinstance(limit, int) or limit < MIN_SAMPLE_LIMIT:
+            limit = DEFAULT_SAMPLE_LIMIT
+        elif limit > MAX_SAMPLE_LIMIT:
+            limit = MAX_SAMPLE_LIMIT
+            logger.warning(f"Sample limit capped at {MAX_SAMPLE_LIMIT}")
+
+        try:
+            with self.engine.connect() as conn:
+                if schema_name:
+                    # MySQL uses backticks for identifier quoting
+                    full_table_name = f"`{schema_name}`.`{table_name}`"
+                else:
+                    full_table_name = f"`{table_name}`"
+
+                query_str = f"SELECT * FROM {full_table_name} LIMIT :limit"
+                params = {"limit": limit}
+                logger.info(f"🐬 {self.db_type.upper()} SQL QUERY: {query_str} | PARAMS: {params}")
+                result = conn.execute(text(query_str), params)
+                columns = list(result.keys())
+                return serialize_rows(result.fetchall(), columns)
+
+        except (SQLAlchemyError, ValueError) as e:
+            logger.error(
+                f"Failed to sample data from {table_name}: {type(e).__name__}: {e}"
+            )
+            return []
+        except Exception as e:
+            logger.error(
+                f"Unexpected error sampling {table_name}: {type(e).__name__}: {e}"
+            )
+            return []
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def test_connection(self) -> bool:
+        if not self.engine:
+            return False
+        try:
+            with self.engine.connect() as conn:
+                conn.execute(text("SELECT 1"))
+                return True
+        except Exception as e:
+            logger.warning(f"Connection health check failed: {e}")
+            return False
+
+    def disconnect(self) -> None:
+        if self.engine:
+            self.engine.dispose()
+            self.engine = None
+            self.metadata = None
+            logger.info("MySQL connection closed")


### PR DESCRIPTION
## Summary
- Add MySQL 8.0+ and MariaDB 10.5+ database support with PyMySQL connector
- New MySQL driver with connection pooling, charset configuration (utf8mb4), and system schema exclusions
- Update MySQL support to 8.0+ only (MySQL 5.7 EOL dropped)
- Expand supported databases from 7 to 8

## Changes
- New `src/drivers/mysql.py` driver implementation
- Updated `src/database_manager.py` with MySQL connection support
- Updated CHANGELOG, README, and `.env.template` with MySQL documentation
- Added `pymysql>=1.1.0` dependency

## Test plan
- [x] MySQL 8.0+ connection and schema analysis verified
- [x] Connection pooling with `pool_pre_ping=True` tested
- [x] System schema exclusions working correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)