### PR TITLE
fix: Address code review findings — session isolation, reconnect, Dremio PAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to OrionBelt Analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2026-03-28
+
+### Fixed
+- Clear OBQC validator on connection change to prevent cross-database validation
+- Clear Oxigraph store on connection change to prevent cross-connection RDF contamination
+- Extend `_reconnect()` for BigQuery, DuckDB, Databricks, and MySQL backends
+- Add DREMIO_URI + DREMIO_PAT auth support to main connect_database handler
+
+### Added
+- 11 regression tests for code review findings
+
 ## [1.1.2] - 2026-03-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center"><strong>The Ontology-based MCP server for your Text-2-SQL convenience.</strong></p>
 
-[![Version 1.1.2](https://img.shields.io/badge/version-1.1.2-purple.svg)](https://github.com/ralfbecher/orionbelt-analytics/releases)
+[![Version 1.1.3](https://img.shields.io/badge/version-1.1.3-purple.svg)](https://github.com/ralfbecher/orionbelt-analytics/releases)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralfbecher/orionbelt-analytics/blob/main/LICENSE)
 [![FastMCP](https://img.shields.io/badge/FastMCP-3.1+-blue)](https://github.com/jlowin/fastmcp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-analytics"
-version = "1.1.2"
+version = "1.1.3"
 description = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "ralf.becher@web.de"}]
 readme = "README.md"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """OrionBelt Analytics - Ontology-based MCP server for your Text-2-SQL convenience."""
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 __author__ = "OrionBelt Analytics Contributors"
 __email__ = "contributors@example.com"
 __description__ = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"

--- a/src/database_manager.py
+++ b/src/database_manager.py
@@ -315,6 +315,29 @@ class DatabaseManager:
                     params.get("username"), params.get("password"),
                     params.get("ssl", True),
                 )
+        elif params["type"] == "bigquery":
+            success = self.connect_bigquery(
+                params["project_id"], params.get("dataset", ""),
+                params.get("credentials_path"), params.get("credentials_json"),
+            )
+        elif params["type"] == "duckdb":
+            success = self.connect_duckdb(
+                params.get("database_path", ":memory:"),
+                params.get("motherduck_token"),
+                params.get("read_only", False),
+            )
+        elif params["type"] == "databricks":
+            success = self.connect_databricks(
+                params["server_hostname"], params["http_path"],
+                params["access_token"], params.get("catalog", "hive_metastore"),
+                params.get("schema", "default"),
+            )
+        elif params["type"] == "mysql":
+            success = self.connect_mysql(
+                params["host"], params["port"], params["database"],
+                params["username"], params["password"],
+                params.get("charset", "utf8mb4"),
+            )
         else:
             raise RuntimeError(f"Unsupported database type for reconnection: {params['type']}")
 

--- a/src/handlers/connection.py
+++ b/src/handlers/connection.py
@@ -108,30 +108,41 @@ async def connect_database(
         db_name = database
 
     elif db_type == "dremio":
-        host = os.getenv("DREMIO_HOST")
-        port = os.getenv("DREMIO_PORT")
-        username = os.getenv("DREMIO_USERNAME")
-        password = os.getenv("DREMIO_PASSWORD")
+        # Prefer PAT-based authentication (DREMIO_URI + DREMIO_PAT)
+        dremio_uri = os.getenv("DREMIO_URI")
+        dremio_pat = os.getenv("DREMIO_PAT")
 
-        required_params = {
-            "DREMIO_HOST": host,
-            "DREMIO_PORT": port,
-            "DREMIO_USERNAME": username,
-            "DREMIO_PASSWORD": password,
-        }
-        missing_params = [k for k, v in required_params.items() if not v]
-        if missing_params:
-            return ValidationError(
-                f"Missing required environment variables for Dremio: {', '.join(missing_params)}. Please check your .env file."
-            ).to_response()
+        if dremio_uri and dremio_pat:
+            success = db_manager.connect_dremio(uri=dremio_uri, pat=dremio_pat)
+            db_name = "DREMIO"
+        else:
+            # Fall back to legacy username/password authentication
+            host = os.getenv("DREMIO_HOST")
+            port = os.getenv("DREMIO_PORT")
+            username = os.getenv("DREMIO_USERNAME")
+            password = os.getenv("DREMIO_PASSWORD")
 
-        success = db_manager.connect_dremio(
-            host=str(host),
-            port=int(port),
-            username=str(username),
-            password=str(password),
-        )
-        db_name = "DREMIO"
+            required_params = {
+                "DREMIO_HOST": host,
+                "DREMIO_PORT": port,
+                "DREMIO_USERNAME": username,
+                "DREMIO_PASSWORD": password,
+            }
+            missing_params = [k for k, v in required_params.items() if not v]
+            if missing_params:
+                return ValidationError(
+                    f"Missing required environment variables for Dremio: {', '.join(missing_params)}. "
+                    "Please check your .env file. "
+                    "For PAT-based auth, set DREMIO_URI and DREMIO_PAT instead."
+                ).to_response()
+
+            success = db_manager.connect_dremio(
+                host=str(host),
+                port=int(port),
+                username=str(username),
+                password=str(password),
+            )
+            db_name = "DREMIO"
 
     elif db_type == "clickhouse":
         host = os.getenv("CLICKHOUSE_HOST")

--- a/src/main.py
+++ b/src/main.py
@@ -268,6 +268,11 @@ def _clear_session_state(session: SessionData, reason: str = "connection change"
     session.loaded_ontology = None
     session.loaded_ontology_path = None
 
+    session.obqc_validator = None
+
+    session.oxigraph_store = None
+    session.oxigraph_initialized = False
+
     session.graphrag_manager = None
     session.graphrag_initialized = False
 

--- a/tests/test_code_review_fixes.py
+++ b/tests/test_code_review_fixes.py
@@ -1,0 +1,244 @@
+"""Regression tests for code review findings (2026-03-28).
+
+Covers:
+1. _clear_session_state clears OBQC validator on connection change
+2. _clear_session_state clears Oxigraph store on connection change
+3. _reconnect() supports BigQuery, DuckDB, Databricks, MySQL
+4. Dremio PAT auth in the main connect_database handler
+"""
+
+import unittest
+from unittest.mock import Mock, patch, AsyncMock, MagicMock
+import os
+
+from src.session import SessionData
+from src.database_manager import DatabaseManager
+
+
+class TestClearSessionStateResetsValidator(unittest.TestCase):
+    """Issue 1: OBQC validator must be cleared on connection change."""
+
+    def test_clear_session_state_resets_obqc_validator(self):
+        """After _clear_session_state, obqc_validator should be None."""
+        from src.main import _clear_session_state
+
+        session = SessionData()
+        session.obqc_validator = Mock()  # simulate a live validator
+
+        _clear_session_state(session, reason="test")
+
+        self.assertIsNone(session.obqc_validator)
+
+    def test_clear_session_state_resets_oxigraph_store(self):
+        """After _clear_session_state, oxigraph_store and flag should be cleared."""
+        from src.main import _clear_session_state
+
+        session = SessionData()
+        session.oxigraph_store = Mock()
+        session.oxigraph_initialized = True
+
+        _clear_session_state(session, reason="test")
+
+        self.assertIsNone(session.oxigraph_store)
+        self.assertFalse(session.oxigraph_initialized)
+
+    def test_clear_session_state_still_clears_original_fields(self):
+        """Existing fields (schema, ontology, graphrag) must still be cleared."""
+        from src.main import _clear_session_state
+
+        session = SessionData()
+        session.schema_file = "schema.json"
+        session.ontology_file = "ontology.ttl"
+        session.r2rml_file = "r2rml.ttl"
+        session.loaded_ontology = "<ttl>"
+        session.loaded_ontology_path = "/tmp/onto.ttl"
+        session.graphrag_manager = Mock()
+        session.graphrag_initialized = True
+
+        _clear_session_state(session, reason="test")
+
+        self.assertIsNone(session.schema_file)
+        self.assertIsNone(session.ontology_file)
+        self.assertIsNone(session.r2rml_file)
+        self.assertIsNone(session.loaded_ontology)
+        self.assertIsNone(session.loaded_ontology_path)
+        self.assertIsNone(session.graphrag_manager)
+        self.assertFalse(session.graphrag_initialized)
+
+
+class TestReconnectAllBackends(unittest.TestCase):
+    """Issue 3: _reconnect() must cover all 8 supported database types."""
+
+    def setUp(self):
+        self.db_manager = DatabaseManager()
+
+    def test_reconnect_bigquery(self):
+        self.db_manager._last_connection_params = {
+            "type": "bigquery",
+            "project_id": "my-project",
+            "dataset": "my_dataset",
+            "credentials_path": "/path/to/creds.json",
+            "credentials_json": None,
+        }
+        with patch.object(self.db_manager, "connect_bigquery", return_value=True) as m:
+            self.db_manager._reconnect()
+            m.assert_called_once_with(
+                "my-project", "my_dataset", "/path/to/creds.json", None,
+            )
+
+    def test_reconnect_duckdb(self):
+        self.db_manager._last_connection_params = {
+            "type": "duckdb",
+            "database_path": "/tmp/test.duckdb",
+            "motherduck_token": None,
+            "read_only": False,
+        }
+        with patch.object(self.db_manager, "connect_duckdb", return_value=True) as m:
+            self.db_manager._reconnect()
+            m.assert_called_once_with("/tmp/test.duckdb", None, False)
+
+    def test_reconnect_databricks(self):
+        self.db_manager._last_connection_params = {
+            "type": "databricks",
+            "server_hostname": "host.databricks.com",
+            "http_path": "/sql/1.0/warehouses/abc",
+            "access_token": "dapi123",
+            "catalog": "main",
+            "schema": "default",
+        }
+        with patch.object(self.db_manager, "connect_databricks", return_value=True) as m:
+            self.db_manager._reconnect()
+            m.assert_called_once_with(
+                "host.databricks.com", "/sql/1.0/warehouses/abc",
+                "dapi123", "main", "default",
+            )
+
+    def test_reconnect_mysql(self):
+        self.db_manager._last_connection_params = {
+            "type": "mysql",
+            "host": "localhost",
+            "port": 3306,
+            "database": "testdb",
+            "username": "root",
+            "password": "secret",
+            "charset": "utf8mb4",
+        }
+        with patch.object(self.db_manager, "connect_mysql", return_value=True) as m:
+            self.db_manager._reconnect()
+            m.assert_called_once_with(
+                "localhost", 3306, "testdb", "root", "secret", "utf8mb4",
+            )
+
+    def test_reconnect_unsupported_type_raises(self):
+        self.db_manager._last_connection_params = {"type": "oracle"}
+        with self.assertRaises(RuntimeError) as ctx:
+            self.db_manager._reconnect()
+        self.assertIn("Unsupported database type", str(ctx.exception))
+
+    def test_reconnect_failure_raises(self):
+        self.db_manager._last_connection_params = {
+            "type": "mysql",
+            "host": "localhost",
+            "port": 3306,
+            "database": "testdb",
+            "username": "root",
+            "password": "secret",
+            "charset": "utf8mb4",
+        }
+        with patch.object(self.db_manager, "connect_mysql", return_value=False):
+            with self.assertRaises(RuntimeError) as ctx:
+                self.db_manager._reconnect()
+            self.assertIn("Failed to reconnect", str(ctx.exception))
+
+
+class TestDremioPATHandler(unittest.IsolatedAsyncioTestCase):
+    """Issue 4: connect_database handler should prefer DREMIO_URI + DREMIO_PAT."""
+
+    async def test_dremio_pat_auth_preferred(self):
+        """When DREMIO_URI and DREMIO_PAT are set, PAT-based auth is used."""
+        from src.handlers.connection import connect_database
+
+        mock_ctx = Mock()
+        mock_ctx.info = AsyncMock()
+        mock_ctx.warning = AsyncMock()
+
+        mock_db_manager = Mock()
+        mock_db_manager.connect_dremio = Mock(return_value=True)
+        mock_db_manager._connection_id = "test123"
+
+        mock_session = SessionData()
+        mock_get_db_manager = Mock(return_value=mock_db_manager)
+        mock_get_session_data = Mock(return_value=mock_session)
+        mock_create_error = Mock()
+        mock_fingerprint = Mock(return_value="fp1")
+        mock_clear = Mock()
+
+        env = {
+            "DREMIO_URI": "https://dremio.example.com",
+            "DREMIO_PAT": "my-secret-pat",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            result = await connect_database(
+                ctx=mock_ctx,
+                db_type="dremio",
+                get_session_db_manager=mock_get_db_manager,
+                get_session_data=mock_get_session_data,
+                create_error_response=mock_create_error,
+                _get_connection_fingerprint=mock_fingerprint,
+                _clear_session_state=mock_clear,
+            )
+
+        mock_db_manager.connect_dremio.assert_called_once_with(
+            uri="https://dremio.example.com", pat="my-secret-pat",
+        )
+
+    async def test_dremio_falls_back_to_legacy(self):
+        """When DREMIO_URI/PAT are absent, legacy host/user/password auth is used."""
+        from src.handlers.connection import connect_database
+
+        mock_ctx = Mock()
+        mock_ctx.info = AsyncMock()
+        mock_ctx.warning = AsyncMock()
+
+        mock_db_manager = Mock()
+        mock_db_manager.connect_dremio = Mock(return_value=True)
+        mock_db_manager._connection_id = "test456"
+
+        mock_session = SessionData()
+        mock_get_db_manager = Mock(return_value=mock_db_manager)
+        mock_get_session_data = Mock(return_value=mock_session)
+        mock_create_error = Mock()
+        mock_fingerprint = Mock(return_value="fp2")
+        mock_clear = Mock()
+
+        env = {
+            "DREMIO_HOST": "dremio-host",
+            "DREMIO_PORT": "9047",
+            "DREMIO_USERNAME": "admin",
+            "DREMIO_PASSWORD": "pass123",
+        }
+        # Ensure PAT vars are absent
+        cleaned = {k: v for k, v in os.environ.items()
+                   if k not in ("DREMIO_URI", "DREMIO_PAT")}
+        cleaned.update(env)
+        with patch.dict(os.environ, cleaned, clear=True):
+            result = await connect_database(
+                ctx=mock_ctx,
+                db_type="dremio",
+                get_session_db_manager=mock_get_db_manager,
+                get_session_data=mock_get_session_data,
+                create_error_response=mock_create_error,
+                _get_connection_fingerprint=mock_fingerprint,
+                _clear_session_state=mock_clear,
+            )
+
+        mock_db_manager.connect_dremio.assert_called_once_with(
+            host="dremio-host",
+            port=9047,
+            username="admin",
+            password="pass123",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/uv.lock
+++ b/uv.lock
@@ -2390,7 +2390,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-analytics"
-version = "1.1.2"
+version = "1.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -2390,7 +2390,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-analytics"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Clear OBQC validator and Oxigraph store on connection change to prevent cross-database/cross-connection contamination
- Extend `_reconnect()` for BigQuery, DuckDB, Databricks, and MySQL (all 8 backends now supported)
- Add `DREMIO_URI` + `DREMIO_PAT` auth precedence to the main `connect_database` handler
- Bump version to 1.1.3

## Test plan
- [x] 11 new regression tests in `tests/test_code_review_fixes.py`
- [x] All 68 tests pass (57 existing + 11 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)