### PR TITLE
feat: multi-schema session state, auto-restore, and cleanup_workspace

### DIFF
--- a/.claude/skills/analytical-workflow.md
+++ b/.claude/skills/analytical-workflow.md
@@ -696,7 +696,7 @@ SELECT c.id, c.name FROM customers c JOIN orders o ON c.id = o.customer_id
 
 | Tool | Purpose |
 |------|---------|
-| `restore_workspace()` | Restore previous session (schema, ontology, GraphRAG) |
+| `cleanup_workspace()` | Delete workspace files and start fresh (keeps connection) |
 | `save_semantic_model()` | Save semantic model YAML (e.g., OBML) for cross-session reuse |
 | `get_semantic_model()` | Retrieve stored model YAML by name |
 | `list_semantic_models()` | List all stored models for current connection |
@@ -969,10 +969,9 @@ When available, prefer Semantic Layer MCP for business-friendly queries and metr
 5. generate_chart()
 ```
 
-**Resume Workflow (2 steps):**
+**Resume Workflow (1 step):**
 ```
-1. connect_database()  // detects existing workspace
-2. restore_workspace()  // restores schema, ontology, GraphRAG, lists models
+1. connect_database()  // auto-restores workspace if one exists
 ```
 
 **Advanced Workflow (7+ steps):**

--- a/.claude/skills/analytical-workflow.md
+++ b/.claude/skills/analytical-workflow.md
@@ -665,6 +665,21 @@ SELECT c.id, c.name FROM customers c JOIN orders o ON c.id = o.customer_id
 
 ---
 
+### Multi-Schema Support
+
+**Ontology state is per-schema; GraphRAG is connection-scoped and accumulative.** Each `analyze_schema()` adds tables to the same graph, enabling cross-schema join path discovery:
+
+```
+analyze_schema(schema_name="public")     # → ontology for public, GraphRAG adds public tables
+analyze_schema(schema_name="analytics")  # → ontology for analytics, GraphRAG adds analytics tables
+graphrag_search("customers")             # → searches across ALL analyzed schemas
+graphrag_find_join_path("public.orders", "analytics.events")  # → cross-schema path
+```
+
+Ontology state is isolated per schema — switching schemas does not destroy the previous schema's ontology. GraphRAG and the RDF store are connection-scoped and support all schemas simultaneously.
+
+---
+
 ## Tool Reference
 
 ### Core Tools (Most Used)

--- a/.env.template
+++ b/.env.template
@@ -34,7 +34,8 @@ ONTOLOGY_MAX_AGE_DAYS=60          # Delete versions older than 60 days
 WORKSPACE_MAX_AGE_DAYS=30         # Remove workspaces not updated in this many days
 
 # Cleanup Triggers
-AUTO_CLEANUP_ON_STARTUP=false     # Run retention cleanup when server starts (removes stale workspaces)
+# Options: false (default), true (retention-based), all (remove everything)
+AUTO_CLEANUP_ON_STARTUP=false
 
 # MCP Transport Configuration
 # Options: http, sse (Server-Sent Events)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Each handler maps to a group of MCP tools:
 - `chart.py` - `generate_chart`
 - `rdf.py` - SPARQL query tools, RDF store operations
 - `graphrag.py` - GraphRAG initialization and context retrieval
-- `workspace.py` - `restore_workspace`, `save_semantic_model`, `get_semantic_model`, `list_semantic_models`
+- `workspace.py` - `cleanup_workspace`, `save_semantic_model`, `get_semantic_model`, `list_semantic_models`
 - `info.py` - `get_server_info`
 
 ### Database Driver Pattern (`src/drivers/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ server.py → src/main.py (@mcp.tool decorators)
 ### Core Modules
 
 - **`src/main.py`** - FastMCP server setup, tool registration, resource/prompt definitions
-- **`src/session.py`** - `SessionData` class for per-session state isolation
+- **`src/session.py`** - `SessionData` class for per-session state isolation with multi-schema support (per-schema ontology and GraphRAG via `SchemaState`)
 - **`src/database_manager.py`** - Connection pooling, schema analysis, SQLAlchemy integration
 - **`src/ontology_generator.py`** - RDF/OWL generation using rdflib with `oba:` (OrionBelt Analytics) namespace annotations
 - **`src/oxigraph_store.py`** - Persistent RDF storage with SPARQL 1.1 query support
@@ -110,7 +110,7 @@ Graph-based Retrieval Augmented Generation for schema intelligence:
 
 ### Key Patterns
 
-**Per-Session State Isolation**: Each MCP session maintains isolated `SessionData` (in `src/session.py`) with its own `DatabaseManager`, GraphRAG manager, and file paths, preventing cross-session interference.
+**Per-Session State Isolation**: Each MCP session maintains isolated `SessionData` (in `src/session.py`) with its own `DatabaseManager`, GraphRAG manager, and file paths, preventing cross-session interference. Ontology state is per-schema via `SchemaState` — switching schemas does not destroy the previous schema's ontology. GraphRAG and Oxigraph RDF store are connection-scoped and accumulative: each `analyze_schema()` adds tables to the same graph, enabling cross-schema join path discovery and unified semantic search.
 
 **Fan-Trap Prevention**: Multi-step validation prevents data multiplication errors:
 1. `analyze_schema()` extracts FK relationships

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Run Analytics and Semantic Layer side-by-side in Claude Desktop for schema-aware
 - **SPARQL 1.1** query interface via persistent Oxigraph RDF store
 - **Fan-trap prevention** -- automatic detection and safe query pattern suggestions
 - **Interactive charting** -- Plotly charts with MCP-UI rendering in Claude Desktop
+- **Multi-schema support** -- analyze multiple schemas simultaneously; ontology and GraphRAG state are isolated per schema
 - **Workspace persistence** -- reconnect to the same database and restore your previous session
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ OrionBelt exposes 32 MCP tools. Here is a summary by category:
 | `reset_cache` | Clear cached schema and ontology data for the current session |
 | `analyze_schema` | Analyze schema structure with automatic GraphRAG + ontology generation |
 | `get_table_details` | Get detailed column, key, and constraint info for a specific table |
-| `restore_workspace` | Restore a previous session's schema cache, ontology, GraphRAG, and RDF store |
+| `cleanup_workspace` | Delete all workspace files for the current connection and start fresh |
 
 ### Ontology & Semantic
 
@@ -213,9 +213,9 @@ connect_database("duckdb") -> list_schemas() -> sample_table_data("events")
 validate_sql_syntax(query) -> execute_sql_query(query) -> generate_chart(data, "bar", ...)
 ```
 
-**Resume a previous session:**
+**Resume a previous session (auto-restores workspace):**
 ```
-connect_database("postgresql") -> restore_workspace("public")
+connect_database("postgresql") -> execute_sql_query(...)
 ```
 
 ## Documentation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,7 +50,8 @@ ONTOLOGY_KEEP_VERSIONS=5          # Keep last 5 versions
 ONTOLOGY_MAX_AGE_DAYS=60          # Delete versions older than 60 days
 
 # Cleanup Triggers
-AUTO_CLEANUP_ON_STARTUP=false     # Run retention cleanup when server starts (removes stale workspaces)
+# Options: false (default), true (retention-based), all (remove everything)
+AUTO_CLEANUP_ON_STARTUP=false
 
 # MCP Transport Configuration
 # Options: http, sse (Server-Sent Events)
@@ -196,7 +197,7 @@ DATABRICKS_SCHEMA=default
 | `GRAPHRAG_MAX_AGE_DAYS` | `30` | Maximum age in days for GraphRAG versions |
 | `ONTOLOGY_KEEP_VERSIONS` | `5` | Number of ontology versions to retain |
 | `ONTOLOGY_MAX_AGE_DAYS` | `60` | Maximum age in days for ontology versions |
-| `AUTO_CLEANUP_ON_STARTUP` | `false` | Run retention cleanup on startup (removes stale workspaces) |
+| `AUTO_CLEANUP_ON_STARTUP` | `false` | Startup cleanup: `false` (none), `true` (retention-based), `all` (remove all workspaces) |
 | `WORKSPACE_MAX_AGE_DAYS` | `30` | Maximum age in days for workspace directories |
 | `ONTOLOGY_BASE_URI` | `http://example.com/ontology/` | Base URI for generated RDF ontologies |
 | `R2RML_BASE_IRI` | `http://mycompany.com/` | Base IRI for R2RML subject templates |

--- a/docs/development.md
+++ b/docs/development.md
@@ -162,7 +162,7 @@ orionbelt-analytics/
 |-- src/
 |   |-- __init__.py                  # Package version (__version__)
 |   |-- main.py                      # FastMCP server setup, @mcp.tool() registration
-|   |-- session.py                   # SessionData -- per-session state isolation
+|   |-- session.py                   # SessionData -- per-session + per-schema state isolation
 |   |-- config.py                    # Configuration management, .env loading
 |   |-- constants.py                 # Shared constants
 |   |-- paths.py                     # Centralized path resolution (output, skills, config)
@@ -283,11 +283,15 @@ Adding a new database requires implementing the `BaseDriver` interface and regis
 
 Each MCP session maintains its own `SessionData` instance (`src/session.py`), which contains:
 
-- **ConnectionState** -- active database manager, connection ID
-- **OntologyState** -- generated ontology content, file paths, OBQC validator
-- **SchemaCache** -- cached schema analysis results
-- **GraphRAGState** -- GraphRAG manager instance, initialization status
-- **RDFStoreState** -- Oxigraph store instance, initialization status
+- **ConnectionState** -- active database manager, connection ID (session-scoped)
+- **SchemaCache** -- cached schema analysis results (multi-schema, dict-based)
+- **SchemaState** (per schema) -- bundles:
+  - **OntologyState** -- generated ontology content, file paths, OBQC validator
+  - **schema_file** -- saved schema JSON reference
+- **GraphRAGState** -- GraphRAG manager instance, initialization status (connection-scoped, accumulative)
+- **RDFStoreState** -- Oxigraph store instance (connection-scoped, multi-schema via named graphs)
+
+Ontology state is isolated per schema via `SchemaState`. GraphRAG and the Oxigraph RDF store are connection-scoped: each `analyze_schema()` call accumulates tables into the same graph and vector store, enabling cross-schema join path discovery and unified semantic search. Switching schemas (e.g., `analyze_schema("analytics")` after `analyze_schema("public")`) does not destroy the previous schema's ontology state, and both schemas' tables are searchable in GraphRAG simultaneously.
 
 This isolation prevents cross-session interference when multiple clients connect to the server simultaneously. Idle sessions are automatically evicted based on `SESSION_IDLE_TIMEOUT_SECONDS`.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -192,7 +192,7 @@ orionbelt-analytics/
 |   |   |-- chart.py                 #   generate_chart
 |   |   |-- rdf.py                   #   SPARQL tools, RDF store operations
 |   |   |-- graphrag.py              #   GraphRAG initialization, context retrieval
-|   |   |-- workspace.py             #   restore_workspace, save/get/list_semantic_model
+|   |   |-- workspace.py             #   cleanup_workspace, save/get/list_semantic_model
 |   |   +-- info.py                  #   get_server_info
 |   |
 |   |-- drivers/                     # Database-specific drivers (abstract base pattern)

--- a/docs/graphrag.md
+++ b/docs/graphrag.md
@@ -155,10 +155,11 @@ ChromaDB uses its own persistent storage that reconnects automatically when a ne
 
 ### Restoring a Workspace
 
-When reconnecting to the same database in a new session, use `restore_workspace()` to reload all persisted state:
+When reconnecting to the same database in a new session, `connect_database()` automatically detects and restores the workspace:
 
 ```
-restore_workspace(schema_name="public")
+connect_database("postgresql")
+# → auto-restores schema cache, ontology, RDF store, and GraphRAG
 ```
 
 This restores:
@@ -168,6 +169,6 @@ This restores:
 3. **RDF store** -- The Oxigraph triple store with SPARQL query support.
 4. **GraphRAG** -- Vector embeddings (via ChromaDB reconnection), relationship graph (rebuilt from saved `tables_info`), and community assignments.
 
-After restore, all GraphRAG tools (`graphrag_search`, `graphrag_query_context`, `graphrag_find_join_path`, `graphrag_overview`) work immediately without re-analysis. The workspace metadata file tracks which components were initialized and when, so `restore_workspace()` knows exactly what to reload.
+After auto-restore, all GraphRAG tools (`graphrag_search`, `graphrag_query_context`, `graphrag_find_join_path`, `graphrag_overview`) work immediately without re-analysis. The workspace metadata file tracks which components were initialized and when.
 
-If no `schema_name` is provided, `restore_workspace()` picks the first available schema. When multiple schemas exist, it reports the available options so you can call it again with a specific schema.
+If multiple schemas exist in the workspace, the first schema is auto-restored and the response lists the alternatives. Use `analyze_schema(schema_name)` to switch to a different schema.

--- a/docs/graphrag.md
+++ b/docs/graphrag.md
@@ -146,12 +146,15 @@ GraphRAG state persists across sessions. All three components -- vector store, r
 tmp/
   chromadb/{connection_id}/       # ChromaDB persistent storage (automatic)
   {connection_id}/
-    vector_store_{schema}.json    # Vector store JSON export (backup)
-    graph_{schema}.json           # Graph structure with tables_info
+    graph_combined.json           # Combined graph (all schemas, with schema_names list)
+    vector_store_{schema}.json    # Vector store JSON export (backup, per-schema)
+    graph_{schema}.json           # Per-schema graph backup (backward compat)
     communities_{schema}.json     # Community assignments and summaries
 ```
 
-ChromaDB uses its own persistent storage that reconnects automatically when a new `GraphRAGManager` is created with the same `connection_id` and `schema_name`. The JSON files serve as backup and contain the `tables_info` needed to rebuild the NetworkX graph and community assignments.
+GraphRAG is connection-scoped and accumulative. Each `analyze_schema()` call adds tables to the same graph and vector store, enabling cross-schema join path discovery and unified semantic search. The combined state file (`graph_combined.json`) stores all accumulated schemas in a single graph; per-schema files are saved alongside for backward compatibility.
+
+ChromaDB uses its own persistent storage that reconnects automatically when a new `GraphRAGManager` is created with the same `connection_id`. The JSON files serve as backup and contain the `tables_info` needed to rebuild the NetworkX graph and community assignments.
 
 ### Restoring a Workspace
 
@@ -171,4 +174,4 @@ This restores:
 
 After auto-restore, all GraphRAG tools (`graphrag_search`, `graphrag_query_context`, `graphrag_find_join_path`, `graphrag_overview`) work immediately without re-analysis. The workspace metadata file tracks which components were initialized and when.
 
-If multiple schemas exist in the workspace, the first schema is auto-restored and the response lists the alternatives. Use `analyze_schema(schema_name)` to switch to a different schema.
+If multiple schemas exist in the workspace, all schemas are auto-restored on reconnect -- each schema's cache and ontology are loaded, and the connection-scoped GraphRAG state (covering all schemas) is restored once. Ontology state is per-schema (switching schemas preserves each schema's ontology), while GraphRAG is accumulative (all schemas share one graph for cross-schema discovery).

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -21,9 +21,8 @@ Complete reference for all OrionBelt Analytics MCP tools. These tools are invoke
 
 ### Resuming a Previous Session
 
-1. **connect_database** -- reconnect to the same database
-2. **restore_workspace** -- reload schema cache, ontology, GraphRAG, and RDF store from disk
-3. Continue with **execute_sql_query**, **generate_chart**, etc.
+1. **connect_database** -- reconnect (auto-restores workspace if one exists)
+2. Continue with **execute_sql_query**, **generate_chart**, etc.
 
 ### Quick Data Exploration
 
@@ -403,30 +402,19 @@ Generate interactive Plotly charts rendered via MCP Apps, or export as static PN
 
 ---
 
-### 14. restore_workspace
+### 14. cleanup_workspace
 
-Restore a workspace from a previous session's artifacts, avoiding the cost of re-analyzing the schema and regenerating the ontology.
+Delete all workspace files for the current database connection and clear session state. The database connection remains active.
 
-**Parameters:**
+**Parameters:** None
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `schema_name` | string | No | Auto-selects first available | Schema to restore |
-
-**Returns:** Markdown-formatted summary listing what was restored and what is ready to use.
+**Returns:** Markdown-formatted summary of what was removed.
 
 **Key Features:**
-- Requires `connect_database` first (same database as the previous session)
-- Restores up to four components from disk:
-  - **Schema cache** -- cached table metadata from `analyze_schema`
-  - **Ontology** -- generated or loaded `.ttl` ontology file (tracks enrichment state)
-  - **RDF store** -- Oxigraph persistent SPARQL database
-  - **GraphRAG** -- graph index and vector embeddings
-- Lists available **semantic models** stored via `save_semantic_model`
-- If multiple schemas exist in the workspace, auto-selects the first one and reports alternatives
-- Reports "DO NOT CALL" tools (already restored) and "Ready to Use" tools
-- After restoration, tools like `validate_sql_syntax`, `graphrag_search`, and `execute_sql_query` work immediately without re-running the analysis pipeline
-- Workspace data persists across server restarts (chart images are cleaned on startup)
+- Removes the workspace directory (`tmp/{connection_id}/`), Oxigraph RDF store, and ChromaDB vector store
+- Clears all in-memory session state (schema cache, ontology, GraphRAG, RDF store)
+- Database connection stays active -- call `analyze_schema()` to start fresh
+- Safe: only affects the current connection's workspace, not other sessions
 
 ---
 
@@ -446,7 +434,7 @@ Save a semantic model definition (e.g., OBML YAML) to the workspace for reuse ac
 
 **Key Features:**
 - Stores model YAML in `tmp/{connection_id}/models/{name}.yaml`
-- Tracks models in workspace metadata for `restore_workspace` discovery
+- Tracks models in workspace metadata for auto-restore discovery
 - Model content is treated as opaque -- no parsing or validation of the YAML structure
 - Enables cross-session model persistence for use with external Semantic Layer tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-analytics"
-version = "1.3.0"
+version = "1.3.1"
 description = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "ralf.becher@web.de"}]
 readme = "README.md"

--- a/server.py
+++ b/server.py
@@ -58,7 +58,7 @@ def print_startup_info():
             "analyze_schema - Analyze schema with auto GraphRAG + ontology",
             "get_table_details - Detailed table metadata and columns",
             "reset_cache - Clear cached schema and ontology data",
-            "restore_workspace - Restore a previous session's artifacts",
+            "cleanup_workspace - Delete workspace files and start fresh",
         ],
         "Ontology & Semantic": [
             "generate_ontology - Generate RDF/OWL ontology with SQL annotations",
@@ -124,7 +124,7 @@ def cleanup_tmp_folder():
 
     Connection-scoped directories (tmp/{connection_id}/) contain workspace
     artifacts (metadata.json, schema JSON, ontology TTL, Oxigraph store,
-    ChromaDB) that must survive server restarts for restore_workspace() to work.
+    ChromaDB) that must survive server restarts for workspace auto-restore to work.
 
     Only removes top-level files that are not inside a connection directory.
 

--- a/server.py
+++ b/server.py
@@ -128,9 +128,10 @@ def cleanup_tmp_folder():
 
     Only removes top-level files that are not inside a connection directory.
 
-    When CLEANUP_ON_STARTUP=true, also applies retention-based cleanup to
-    workspace directories: removes connection dirs whose workspace data
-    exceeds WORKSPACE_MAX_AGE_DAYS (default: 30).
+    AUTO_CLEANUP_ON_STARTUP controls workspace cleanup:
+    - "false" (default): no workspace cleanup, only top-level files and charts
+    - "true": retention-based — removes workspaces older than WORKSPACE_MAX_AGE_DAYS
+    - "all": removes ALL workspace directories (fresh start)
     """
     import os
     tmp_dir = Path(__file__).parent / "tmp"
@@ -175,11 +176,26 @@ def cleanup_tmp_folder():
     if workspace_dirs:
         logger.info(f"Found {len(workspace_dirs)} workspace directory/directories")
 
-    # Phase 2: Retention-based workspace cleanup (opt-in via AUTO_CLEANUP_ON_STARTUP)
-    cleanup_enabled = os.getenv("AUTO_CLEANUP_ON_STARTUP", "false").lower() == "true"
-    if not cleanup_enabled:
+    # Phase 2: Workspace cleanup (opt-in via AUTO_CLEANUP_ON_STARTUP)
+    cleanup_mode = os.getenv("AUTO_CLEANUP_ON_STARTUP", "false").lower()
+    if cleanup_mode == "false":
         return
 
+    if cleanup_mode == "all":
+        # Remove ALL workspace directories (fresh start)
+        logger.info(f"Full cleanup enabled, removing {len(workspace_dirs)} workspace(s)...")
+        cleaned = 0
+        for conn_dir in workspace_dirs:
+            try:
+                shutil.rmtree(conn_dir)
+                cleaned += 1
+                logger.info(f"Removed workspace: {conn_dir.name}")
+            except Exception as e:
+                logger.warning(f"Failed to remove workspace {conn_dir.name}: {e}")
+        logger.info(f"Full cleanup: removed {cleaned} workspace(s)")
+        return
+
+    # cleanup_mode == "true": retention-based cleanup
     max_age_days = int(os.getenv("WORKSPACE_MAX_AGE_DAYS", "30"))
     logger.info(
         f"Retention cleanup enabled (WORKSPACE_MAX_AGE_DAYS={max_age_days}), "

--- a/server.py
+++ b/server.py
@@ -181,6 +181,10 @@ def cleanup_tmp_folder():
         return
 
     max_age_days = int(os.getenv("WORKSPACE_MAX_AGE_DAYS", "30"))
+    logger.info(
+        f"Retention cleanup enabled (WORKSPACE_MAX_AGE_DAYS={max_age_days}), "
+        f"scanning {len(workspace_dirs)} workspace(s)..."
+    )
     cutoff = datetime.now() - timedelta(days=max_age_days)
     cleaned = 0
 
@@ -217,6 +221,8 @@ def cleanup_tmp_folder():
 
     if cleaned > 0:
         logger.info(f"Retention cleanup: removed {cleaned} stale workspace(s)")
+    else:
+        logger.info("Retention cleanup: all workspaces within retention period")
 
 def main():
     """Start the OrionBelt Analytics MCP server."""

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """OrionBelt Analytics - Ontology-based MCP server for your Text-2-SQL convenience."""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __author__ = "OrionBelt Analytics Contributors"
 __email__ = "contributors@example.com"
 __description__ = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"

--- a/src/graphrag/manager.py
+++ b/src/graphrag/manager.py
@@ -68,6 +68,7 @@ class GraphRAGManager:
 
         self._initialized = False
         self._schema_name: Optional[str] = schema_name
+        self._schema_names: List[str] = []
         self._connection_id: Optional[str] = connection_id or "default"
 
     def initialize_from_schema(
@@ -107,7 +108,58 @@ class GraphRAGManager:
         self.community_detector.detect_communities(method="label_propagation")
 
         self._initialized = True
+        if schema_name not in self._schema_names:
+            self._schema_names.append(schema_name)
         logger.info("GraphRAG initialization complete")
+
+    def accumulate_schema(
+        self,
+        tables_info: List[Dict[str, Any]],
+        schema_name: str = "default"
+    ):
+        """Add a schema's tables to an already-initialized GraphRAG (accumulative).
+
+        Unlike initialize_from_schema(), this does not clear existing data.
+        New tables and embeddings are added alongside existing ones, enabling
+        cross-schema join path discovery and unified semantic search.
+
+        Args:
+            tables_info: List of table metadata dictionaries
+            schema_name: Schema identifier being added
+        """
+        logger.info(
+            f"Accumulating schema '{schema_name}' into GraphRAG "
+            f"({len(tables_info)} tables, existing schemas: {self._schema_names})"
+        )
+
+        # Step 1: Create embeddings for new tables
+        logger.info("Creating embeddings for new schema...")
+        embeddings = self.embedder.batch_embed_schema(tables_info)
+
+        # Step 2: Add to vector store (ChromaDB upserts by ID, JSON appends)
+        self.vector_store.add_elements_batch(embeddings["tables"])
+        self.vector_store.add_elements_batch(embeddings["columns"])
+        self.vector_store.add_elements_batch(embeddings["relationships"])
+        self.vector_store.build_index()
+
+        # Step 3: Add to graph (accumulative, no clear)
+        logger.info("Adding to relationship graph...")
+        self.graph_retriever.add_to_graph(tables_info)
+
+        # Step 4: Re-detect communities on the combined graph
+        logger.info("Re-detecting communities on combined graph...")
+        self.community_detector = CommunityDetector(self.graph_retriever.graph)
+        self.community_detector.detect_communities(method="label_propagation")
+
+        self._schema_name = schema_name  # Last added schema
+        if schema_name not in self._schema_names:
+            self._schema_names.append(schema_name)
+        self._initialized = True
+
+        logger.info(
+            f"Schema '{schema_name}' accumulated. Total schemas: {self._schema_names}, "
+            f"Total tables: {self.graph_retriever.graph.number_of_nodes()}"
+        )
 
     def search_schema(
         self,
@@ -339,6 +391,9 @@ class GraphRAGManager:
         """
         Save GraphRAG state to disk.
 
+        Saves combined state (all accumulated schemas) plus per-schema files
+        for backward compatibility with workspace metadata.
+
         Args:
             output_dir: Output directory
         """
@@ -348,22 +403,22 @@ class GraphRAGManager:
         connection_dir = output_dir / self._connection_id
         connection_dir.mkdir(parents=True, exist_ok=True)
 
-        # Save vector store
-        vector_store_path = connection_dir / f"vector_store_{self._schema_name}.json"
-        self.vector_store.save(vector_store_path)
+        # Combined graph with all schemas' tables_info
+        all_tables_info = list(self.graph_retriever._tables_info.values())
 
-        # Save graph (includes tables_info for clean restore)
-        graph_path = connection_dir / f"graph_{self._schema_name}.json"
+        # Save combined graph
+        graph_path = connection_dir / "graph_combined.json"
         graph_data = {
-            "tables_info": list(self.graph_retriever._tables_info.values()),
+            "schema_names": self._schema_names,
+            "tables_info": all_tables_info,
             "visualization": self.graph_retriever.export_graph_for_visualization(),
         }
         with open(graph_path, 'w') as f:
             json.dump(graph_data, f, indent=2)
 
-        # Save communities
+        # Save combined communities
         if self.community_detector:
-            communities_path = connection_dir / f"communities_{self._schema_name}.json"
+            communities_path = connection_dir / "communities_combined.json"
             communities_data = {
                 "summaries": self.community_detector.get_all_summaries(),
                 "domain_names": self.community_detector.suggest_domain_names()
@@ -371,12 +426,42 @@ class GraphRAGManager:
             with open(communities_path, 'w') as f:
                 json.dump(communities_data, f, indent=2)
 
-        logger.info(f"Saved GraphRAG state to {connection_dir}")
+        # Also save per-schema files (backward compat with workspace metadata)
+        for schema_name in self._schema_names:
+            vector_store_path = connection_dir / f"vector_store_{schema_name}.json"
+            self.vector_store.save(vector_store_path)
+
+            # Per-schema graph subset
+            schema_tables = [t for t in all_tables_info if t.get("schema") == schema_name]
+            if not schema_tables:
+                schema_tables = all_tables_info  # Fallback for single schema
+            per_schema_graph_path = connection_dir / f"graph_{schema_name}.json"
+            per_schema_data = {
+                "tables_info": schema_tables,
+                "visualization": self.graph_retriever.export_graph_for_visualization(),
+            }
+            with open(per_schema_graph_path, 'w') as f:
+                json.dump(per_schema_data, f, indent=2)
+
+            if self.community_detector:
+                communities_path = connection_dir / f"communities_{schema_name}.json"
+                communities_data = {
+                    "summaries": self.community_detector.get_all_summaries(),
+                    "domain_names": self.community_detector.suggest_domain_names()
+                }
+                with open(communities_path, 'w') as f:
+                    json.dump(communities_data, f, indent=2)
+
+        logger.info(
+            f"Saved GraphRAG state to {connection_dir} "
+            f"(schemas: {self._schema_names})"
+        )
 
     def load_state(self, output_dir: Path) -> bool:
         """Restore GraphRAG state from disk.
 
-        Rebuilds graph and communities from saved JSON files.
+        Prefers combined state (graph_combined.json) for multi-schema support.
+        Falls back to per-schema files (graph_{schema}.json) for backward compat.
         ChromaDB vector store reconnects implicitly via get_or_create_collection.
 
         Args:
@@ -406,20 +491,29 @@ class GraphRAGManager:
         except Exception as e:
             logger.warning(f"Failed to verify ChromaDB: {e}")
 
-        # 2. Load graph from saved tables_info
-        graph_path = connection_dir / f"graph_{schema_name}.json"
+        # 2. Load graph — prefer combined, fallback to per-schema
+        combined_graph_path = connection_dir / "graph_combined.json"
+        per_schema_graph_path = connection_dir / f"graph_{schema_name}.json"
+
+        graph_path = combined_graph_path if combined_graph_path.exists() else per_schema_graph_path
+
         if graph_path.exists():
             try:
                 with open(graph_path, 'r') as f:
                     graph_data = json.load(f)
 
-                # New format: {"tables_info": [...], "visualization": {...}}
                 tables_info = graph_data.get("tables_info")
                 if tables_info:
                     self.graph_retriever.load_graph(tables_info)
                     restored_components.append(
                         f"graph ({self.graph_retriever.graph.number_of_nodes()} tables)"
                     )
+                    # Restore schema names list
+                    saved_schemas = graph_data.get("schema_names")
+                    if saved_schemas:
+                        self._schema_names = saved_schemas
+                    elif schema_name not in self._schema_names:
+                        self._schema_names.append(schema_name)
                 else:
                     logger.warning("Graph file missing tables_info — graph not restored")
             except Exception as e:
@@ -427,8 +521,11 @@ class GraphRAGManager:
         else:
             logger.warning(f"Graph file not found: {graph_path}")
 
-        # 3. Load communities
-        communities_path = connection_dir / f"communities_{schema_name}.json"
+        # 3. Load communities — prefer combined, fallback to per-schema
+        combined_communities_path = connection_dir / "communities_combined.json"
+        per_schema_communities_path = connection_dir / f"communities_{schema_name}.json"
+        communities_path = combined_communities_path if combined_communities_path.exists() else per_schema_communities_path
+
         if communities_path.exists():
             try:
                 with open(communities_path, 'r') as f:
@@ -450,7 +547,8 @@ class GraphRAGManager:
         if self.graph_retriever.graph.number_of_nodes() > 0:
             self._initialized = True
             logger.info(
-                f"Restored GraphRAG state: {', '.join(restored_components)}"
+                f"Restored GraphRAG state: {', '.join(restored_components)} "
+                f"(schemas: {self._schema_names})"
             )
             return True
 

--- a/src/graphrag/retriever.py
+++ b/src/graphrag/retriever.py
@@ -65,6 +65,53 @@ class GraphRetriever:
             f"and {self.graph.number_of_edges()} edges"
         )
 
+    def add_to_graph(self, tables_info: List[Dict[str, Any]]):
+        """Add tables and relationships to the existing graph (accumulative).
+
+        Unlike build_graph(), this does NOT clear the graph first.
+        Duplicate nodes are updated, new edges are added.
+
+        Args:
+            tables_info: List of table metadata with columns and foreign keys
+        """
+        added_nodes = 0
+        added_edges = 0
+
+        for table in tables_info:
+            table_name = table['name']
+            self._tables_info[table_name] = table
+
+            if table_name not in self.graph:
+                added_nodes += 1
+            self.graph.add_node(
+                table_name,
+                node_type='table',
+                column_count=len(table.get('columns', [])),
+                has_comment=bool(table.get('comment')),
+                comment=table.get('comment', '')
+            )
+
+        for table in tables_info:
+            table_name = table['name']
+            for fk in table.get('foreign_keys', []):
+                referenced_table = fk['referenced_table']
+                if referenced_table in self.graph:
+                    if not self.graph.has_edge(table_name, referenced_table):
+                        added_edges += 1
+                    self.graph.add_edge(
+                        table_name,
+                        referenced_table,
+                        edge_type='foreign_key',
+                        column=fk['column'],
+                        referenced_column=fk['referenced_column']
+                    )
+
+        logger.info(
+            f"Added to graph: +{added_nodes} nodes, +{added_edges} edges "
+            f"(total: {self.graph.number_of_nodes()} nodes, "
+            f"{self.graph.number_of_edges()} edges)"
+        )
+
     def find_join_path(
         self,
         from_table: str,

--- a/src/handlers/connection.py
+++ b/src/handlers/connection.py
@@ -10,6 +10,7 @@ from ..exceptions import ConnectionError, ValidationError
 from ..lifecycle.metadata import VersionMetadataManager
 from ..paths import OUTPUT_DIR
 from ..workspace import detect_workspace, format_workspace_summary
+from .workspace import _restore_workspace_core, _format_restore_summary
 
 logger = logging.getLogger(__name__)
 
@@ -22,8 +23,12 @@ async def connect_database(
     create_error_response,
     _get_connection_fingerprint,
     _clear_session_state,
+    get_oxigraph_store=None,
 ) -> str:
     """Connect to a database using credentials from environment variables.
+
+    If a previous workspace exists for this connection, it is automatically
+    restored (schema cache, ontology, GraphRAG, RDF store).
 
     Args:
         ctx: FastMCP context
@@ -33,6 +38,7 @@ async def connect_database(
         create_error_response: Error response helper
         _get_connection_fingerprint: Connection fingerprint function
         _clear_session_state: State clearing function
+        get_oxigraph_store: Function to get/init Oxigraph store (for auto-restore)
 
     Returns:
         Connection status message or error JSON
@@ -289,10 +295,24 @@ async def connect_database(
         except Exception as e:
             logger.warning(f"Failed to write workspace connection info: {e}")
 
-        # Detect existing workspace for this connection
+        # Detect and auto-restore existing workspace
         response = f"Successfully connected to {db_type} database: {db_name}"
         workspace = detect_workspace(new_conn_id)
-        if workspace:
+        if workspace and get_oxigraph_store:
+            try:
+                restore_result = await _restore_workspace_core(
+                    ctx, session, new_conn_id, None, get_oxigraph_store
+                )
+                if restore_result:
+                    response += "\n\n" + _format_restore_summary(restore_result)
+                else:
+                    # Workspace detected but restore returned nothing
+                    response += "\n\n" + format_workspace_summary(workspace)
+            except Exception as e:
+                logger.warning(f"Auto-restore failed: {e}")
+                response += "\n\n" + format_workspace_summary(workspace)
+        elif workspace:
+            # No get_oxigraph_store available (e.g., tests) — show summary only
             response += "\n\n" + format_workspace_summary(workspace)
 
         return response

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -56,7 +56,11 @@ async def _auto_generate_ontology_background(
     session: Any,
     ctx: Context,
 ) -> None:
-    """Background task: Auto-generate ontology after GraphRAG completes."""
+    """Background task: Auto-generate ontology after GraphRAG completes.
+
+    Uses direct schema state access (not convenience properties) to avoid
+    race conditions when the user switches schemas during background work.
+    """
     from ..config import config_manager
 
     try:
@@ -79,12 +83,14 @@ async def _auto_generate_ontology_background(
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         ontology_file = conn_dir / f"ontology_{schema_name}_{timestamp}.ttl"
         ontology_file.write_text(ontology_ttl, encoding="utf-8")
-        session.ontology_file = ontology_file.name
+
+        # Write to the specific schema's state (not current schema)
+        schema_state = session.get_or_create_schema_state(schema_name)
+        schema_state.ontology.ontology_file = ontology_file.name
 
         if OXIGRAPH_AVAILABLE:
             try:
-
-                # Direct store access for background task
+                # Direct store access for background task (connection-scoped)
                 if session.oxigraph_store:
                     graph_uri = f"{base_uri}{schema_name}"
                     triple_count = session.oxigraph_store.load_ontology(
@@ -109,23 +115,32 @@ async def _auto_initialize_graphrag_background(
     session: Any,
     ctx: Context,
 ) -> None:
-    """Background task: Auto-initialize GraphRAG after schema analysis."""
+    """Background task: Auto-initialize or accumulate GraphRAG after schema analysis.
+
+    GraphRAG is connection-scoped and accumulative. If already initialized,
+    new schema tables are added to the existing graph and vector store.
+    """
     try:
         start_time = time.time()
-        logger.info(f"Auto-initializing GraphRAG for schema '{schema_name}'...")
+        tables_dict = [_table_info_to_dict(t) for t in tables_info]
 
         if session.graphrag_manager is None:
+            # First schema — initialize from scratch
+            logger.info(f"Initializing GraphRAG for schema '{schema_name}'...")
             session.graphrag_manager = GraphRAGManager(
                 embedding_model="tfidf",
                 connection_id=session.connection_id,
                 schema_name=schema_name,
             )
-
-        tables_dict = [_table_info_to_dict(t) for t in tables_info]
-
-        session.graphrag_manager.initialize_from_schema(
-            tables_info=tables_dict, schema_name=schema_name
-        )
+            session.graphrag_manager.initialize_from_schema(
+                tables_info=tables_dict, schema_name=schema_name
+            )
+        else:
+            # Additional schema — accumulate into existing graph
+            logger.info(f"Accumulating schema '{schema_name}' into existing GraphRAG...")
+            session.graphrag_manager.accumulate_schema(
+                tables_info=tables_dict, schema_name=schema_name
+            )
 
         output_dir = ensure_output_dir()
         session.graphrag_manager.save_state(output_dir)
@@ -133,8 +148,12 @@ async def _auto_initialize_graphrag_background(
         elapsed = time.time() - start_time
         session.graphrag_initialized = True
 
-        logger.info(f"GraphRAG auto-initialized successfully ({elapsed:.2f}s)")
-        logger.info(f"Indexed {len(tables_dict)} tables with their metadata")
+        total_tables = session.graphrag_manager.graph_retriever.graph.number_of_nodes()
+        schemas = session.graphrag_manager._schema_names
+        logger.info(
+            f"GraphRAG auto-initialized successfully ({elapsed:.2f}s) — "
+            f"{total_tables} tables across schemas: {schemas}"
+        )
 
         # Write workspace metadata for graphrag section
         if session.connection_id:
@@ -149,6 +168,7 @@ async def _auto_initialize_graphrag_background(
                         "initialized": True,
                         "table_count": len(tables_dict),
                         "embedding_count": stats.get("total_elements", 0),
+                        "schemas": schemas,
                         "initialized_at": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
                     },
                 )
@@ -194,6 +214,9 @@ async def initialize_graphrag(
         if effective_schema:
             logger.info(f"Using last analyzed schema: {effective_schema}")
 
+    # Set current schema for per-schema state isolation
+    session.set_current_schema(effective_schema or "default")
+
     tables_info = session.get_cached_schema(effective_schema or "")
 
     if not tables_info:
@@ -226,23 +249,32 @@ async def initialize_graphrag(
     # Convert TableInfo objects to dictionaries
     tables_dict = [_table_info_to_dict(t) for t in tables_info]
 
+    eff_schema = effective_schema or "default"
+
     try:
         if session.graphrag_manager is None:
             session.graphrag_manager = GraphRAGManager(
                 embedding_model=embedding_model,
                 embedding_dimension=384,
                 connection_id=session.connection_id,
-                schema_name=effective_schema or "default",
+                schema_name=eff_schema,
             )
-
-        session.graphrag_manager.initialize_from_schema(
-            tables_info=tables_dict, schema_name=effective_schema or "default"
-        )
+            session.graphrag_manager.initialize_from_schema(
+                tables_info=tables_dict, schema_name=eff_schema
+            )
+        else:
+            # Accumulate into existing graph
+            session.graphrag_manager.accumulate_schema(
+                tables_info=tables_dict, schema_name=eff_schema
+            )
 
         session.graphrag_initialized = True
 
         output_dir = ensure_output_dir()
         session.graphrag_manager.save_state(output_dir)
+
+        total_tables = session.graphrag_manager.graph_retriever.graph.number_of_nodes()
+        schemas = session.graphrag_manager._schema_names
 
         # Write workspace metadata for graphrag section
         if session.connection_id:
@@ -251,12 +283,13 @@ async def initialize_graphrag(
                 await update_workspace_section(
                     connection_id=session.connection_id,
                     output_dir=OUTPUT_DIR,
-                    schema_name=effective_schema or "default",
+                    schema_name=eff_schema,
                     section="graphrag",
                     data={
                         "initialized": True,
                         "table_count": len(tables_dict),
                         "embedding_count": stats.get("total_elements", 0),
+                        "schemas": schemas,
                         "initialized_at": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
                     },
                 )
@@ -264,18 +297,21 @@ async def initialize_graphrag(
                 logger.warning(f"Failed to write workspace metadata: {e}")
 
         await ctx.info(
-            f"GraphRAG initialized for schema '{effective_schema or 'default'}' with {len(tables_dict)} tables"
+            f"GraphRAG initialized for schema '{eff_schema}' with {len(tables_dict)} tables "
+            f"(total: {total_tables} tables across {len(schemas)} schema(s))"
         )
 
         return (
             f"GraphRAG initialized successfully!\n\n"
-            f"Schema: {effective_schema or 'default'}\n"
-            f"Tables: {len(tables_dict)}\n"
+            f"Schema: {eff_schema}\n"
+            f"Tables added: {len(tables_dict)}\n"
+            f"Total tables in graph: {total_tables}\n"
+            f"Schemas: {', '.join(schemas)}\n"
             f"Embedding model: {embedding_model}\n\n"
             f"You can now use:\n"
-            f"- graphrag_search() for semantic search\n"
+            f"- graphrag_search() for semantic search across all schemas\n"
             f"- graphrag_query_context() for optimized query context\n"
-            f"- graphrag_find_join_path() for relationship discovery\n"
+            f"- graphrag_find_join_path() for cross-schema relationship discovery\n"
             f"- graphrag_overview() for schema statistics"
         )
 

--- a/src/handlers/ontology.py
+++ b/src/handlers/ontology.py
@@ -107,8 +107,15 @@ async def generate_ontology(
 
     Extracts implementation from main.py's generate_ontology tool.
     """
-    # Check if ontology is already generated
+    # Resolve effective schema and set current schema for state isolation
     session = get_session_data(ctx)
+    effective_schema_for_state = schema_name
+    if not effective_schema_for_state:
+        effective_schema_for_state = session.get_last_analyzed_schema()
+    if effective_schema_for_state:
+        session.set_current_schema(effective_schema_for_state)
+
+    # Check if ontology is already generated
     if session.ontology_file:
         if session.ontology_enriched:
             await ctx.info("Ontology CACHED and already enriched — ready to use")

--- a/src/handlers/schema.py
+++ b/src/handlers/schema.py
@@ -33,10 +33,11 @@ async def reset_cache(
     cache_type_lower = (cache_type or "all").lower()
 
     if cache_type_lower in ("schema", "all"):
-        session.clear_schema_cache()
+        # Clear current schema's cache only
+        current = session.current_schema
+        session.clear_schema_cache(current)
         session.schema_file = None
         session.r2rml_file = None
-        session.schema_cache._last_analyzed_schema = None
         cleared.append("schema")
 
     if cache_type_lower in ("ontology", "all"):
@@ -84,6 +85,10 @@ async def analyze_schema(
     # Check cache
     session = get_session_data(ctx)
     effective_schema = schema_name or ""
+
+    # Set current schema so per-schema state (ontology, GraphRAG) is isolated
+    session.set_current_schema(effective_schema or "default")
+
     cached_tables = session.get_cached_schema(effective_schema)
 
     logger.debug(f"Cache check result - cached_tables: {bool(cached_tables)} (count: {len(cached_tables) if cached_tables else 0})")

--- a/src/handlers/workspace.py
+++ b/src/handlers/workspace.py
@@ -1,7 +1,8 @@
-"""Workspace restore and semantic model storage handler implementation."""
+"""Workspace restore, cleanup, and semantic model storage handler implementation."""
 
 import json
 import logging
+import shutil
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -16,37 +17,29 @@ from ..paths import OUTPUT_DIR, get_connection_dir, get_models_dir, ensure_outpu
 logger = logging.getLogger(__name__)
 
 
-async def restore_workspace(
+async def _restore_workspace_core(
     ctx: Context,
+    session,
+    connection_id: str,
     schema_name: Optional[str],
-    get_session_data,
     get_oxigraph_store,
-    create_error_response,
-) -> str:
-    """Restore workspace from previous session artifacts.
+) -> Optional[Dict[str, Any]]:
+    """Core workspace restore logic shared by connect_database and cleanup recovery.
 
-    Reloads schema cache, ontology, GraphRAG, and RDF store from disk
-    so the user can continue where they left off without re-analyzing.
+    Loads schema cache, ontology, GraphRAG, and RDF store from disk into
+    the session. Returns a structured result dict, or None if no workspace
+    or schemas exist.
 
     Args:
         ctx: FastMCP context
-        schema_name: Schema to restore (uses first available if not specified)
-        get_session_data: Function to get session data
+        session: SessionData instance (already resolved)
+        connection_id: Database connection fingerprint
+        schema_name: Schema to restore (auto-selects first if None)
         get_oxigraph_store: Function to get/init Oxigraph store
-        create_error_response: Function to create error response
 
     Returns:
-        Restore status summary
+        Dict with restore results, or None if workspace is empty/missing.
     """
-    session = get_session_data(ctx)
-
-    if not session.connection_id:
-        return create_error_response(
-            "No database connection. Call connect_database first.",
-            "connection_error",
-        )
-
-    connection_id = session.connection_id
     conn_dir = get_connection_dir(connection_id)
 
     # Load workspace metadata
@@ -54,37 +47,28 @@ async def restore_workspace(
     workspace = mgr.get_workspace()
 
     if not workspace:
-        return create_error_response(
-            "No workspace found for this connection. Use analyze_schema to start fresh.",
-            "workspace_not_found",
-        )
+        return None
 
     schemas = workspace.get("schemas", {})
     if not schemas:
-        return create_error_response(
-            "Workspace has no schema data. Use analyze_schema to start fresh.",
-            "workspace_empty",
-        )
+        return None
 
     # Resolve schema name
+    all_schemas = list(schemas.keys())
     if not schema_name:
-        schema_name = list(schemas.keys())[0]
-        if len(schemas) > 1:
+        schema_name = all_schemas[0]
+        if len(all_schemas) > 1:
             await ctx.info(
-                f"Multiple schemas available: {', '.join(schemas.keys())}. "
-                f"Restoring '{schema_name}'. Call again with schema_name to restore a different one."
+                f"Multiple schemas available: {', '.join(all_schemas)}. "
+                f"Auto-restoring '{schema_name}'."
             )
 
     schema_data = schemas.get(schema_name)
     if not schema_data:
-        available = ", ".join(schemas.keys())
-        return create_error_response(
-            f"Schema '{schema_name}' not found in workspace. Available: {available}",
-            "schema_not_found",
-        )
+        return None
 
-    restored = []
-    failed = []
+    restored: List[str] = []
+    failed: List[str] = []
 
     # 1. Restore schema cache
     schema_section = schema_data.get("schema", {})
@@ -96,15 +80,12 @@ async def restore_workspace(
                 with open(schema_path, "r", encoding="utf-8") as f:
                     schema_json = json.load(f)
 
-                # Deserialize to List[TableInfo]
                 tables_raw = schema_json.get("tables", [])
                 tables_info = [TableInfo.from_dict(t) for t in tables_raw]
 
                 session.cache_schema_analysis(schema_name, tables_info)
                 session.schema_file = schema_file
-                restored.append(
-                    f"Schema analysis: {len(tables_info)} tables"
-                )
+                restored.append(f"Schema analysis: {len(tables_info)} tables")
             except Exception as e:
                 logger.error(f"Failed to restore schema cache: {e}")
                 failed.append(f"Schema cache: {e}")
@@ -124,7 +105,6 @@ async def restore_workspace(
                 enriched_tag = " (enriched)" if is_enriched else ""
                 restored.append(f"Ontology file{enriched_tag}")
 
-                # Also read content for loaded_ontology state
                 ontology_content = ontology_path.read_text(encoding="utf-8")
                 session.loaded_ontology = ontology_content
                 session.loaded_ontology_path = str(ontology_path)
@@ -147,7 +127,6 @@ async def restore_workspace(
             if store:
                 graph_uri = ontology_section.get("graph_uri")
                 if graph_uri:
-                    # Verify graph exists in store
                     try:
                         graph_data = store.export_graph(graph_uri, format="turtle")
                         if graph_data and len(graph_data) > 100:
@@ -186,61 +165,189 @@ async def restore_workspace(
             logger.error(f"Failed to restore GraphRAG: {e}")
             failed.append(f"GraphRAG: {e}")
 
-    # Build response
-    result = "# Workspace Restored\n\n"
-    result += f"Connection: {connection_id[:8]}...\n"
-    result += f"Schema: {schema_name}\n\n"
+    # Collect semantic models
+    models = workspace.get("models", {})
+
+    return {
+        "schema_name": schema_name,
+        "all_schemas": all_schemas,
+        "restored": restored,
+        "failed": failed,
+        "ontology_enriched": session.ontology_enriched,
+        "models": models,
+    }
+
+
+def _format_restore_summary(result: Dict[str, Any]) -> str:
+    """Format a restore result dict into a user-facing markdown summary.
+
+    Args:
+        result: Dict from _restore_workspace_core()
+
+    Returns:
+        Formatted markdown string
+    """
+    schema_name = result["schema_name"]
+    restored = result["restored"]
+    failed = result["failed"]
+    ontology_enriched = result.get("ontology_enriched", False)
+    models = result.get("models", {})
+    all_schemas = result.get("all_schemas", [schema_name])
+
+    lines = ["# Workspace Auto-Restored", ""]
+    lines.append(f"Schema: {schema_name}")
+
+    if len(all_schemas) > 1:
+        others = [s for s in all_schemas if s != schema_name]
+        lines.append(f"Other schemas available: {', '.join(others)}")
+        lines.append("Use analyze_schema(schema_name) to switch schemas.")
+    lines.append("")
 
     if restored:
-        result += "## Restored\n"
+        lines.append("## Restored")
         for item in restored:
-            result += f"- {item}\n"
+            lines.append(f"- {item}")
 
     if failed:
-        result += "\n## Not Restored\n"
+        lines.append("")
+        lines.append("## Not Restored")
         for item in failed:
-            result += f"- {item}\n"
-        result += "\nUse the relevant tools to regenerate missing components.\n"
+            lines.append(f"- {item}")
+        lines.append("")
+        lines.append("Use the relevant tools to regenerate missing components.")
 
     if not restored and not failed:
-        result += "No artifacts found to restore.\n"
+        lines.append("No artifacts found to restore.")
 
-    # Build "do not call" list based on what was restored
+    # Build "do not call" list
     skip_tools = []
     if "Schema analysis" in str(restored):
         skip_tools.append("analyze_schema()")
     if "Ontology" in str(restored):
         skip_tools.append("generate_ontology()")
-        if session.ontology_enriched:
+        if ontology_enriched:
             skip_tools.append("suggest_semantic_names()")
             skip_tools.append("apply_semantic_names()")
     if skip_tools:
-        result += "\n## DO NOT CALL (already restored)\n"
+        lines.append("")
+        lines.append("## DO NOT CALL (already restored)")
         for tool in skip_tools:
-            result += f"- {tool}\n"
+            lines.append(f"- {tool}")
 
-    result += "\n## Ready to Use\n"
+    lines.append("")
+    lines.append("## Ready to Use")
     if "Schema analysis" in str(restored):
-        if not session.ontology_enriched and "Ontology" not in str(restored):
-            result += "- generate_ontology() to create ontology from cached schema\n"
-        if not session.ontology_enriched and "Ontology" in str(restored):
-            result += "- suggest_semantic_names() to enrich the ontology\n"
+        if not ontology_enriched and "Ontology" not in str(restored):
+            lines.append("- generate_ontology() to create ontology from cached schema")
+        if not ontology_enriched and "Ontology" in str(restored):
+            lines.append("- suggest_semantic_names() to enrich the ontology")
     if "Ontology" in str(restored):
-        result += "- query_sparql() for semantic queries\n"
-        result += "- validate_sql_syntax() with ontology-aware validation\n"
-        result += "- execute_sql_query() for data queries\n"
+        lines.append("- query_sparql() for semantic queries")
+        lines.append("- validate_sql_syntax() with ontology-aware validation")
+        lines.append("- execute_sql_query() for data queries")
     if "GraphRAG" in str(restored):
-        result += "- graphrag_search() for semantic schema search\n"
+        lines.append("- graphrag_search() for semantic schema search")
 
-    # 5. List available semantic models (names only, no content)
-    models_section = workspace.get("models", {})
-    if models_section:
-        result += "\n## Semantic Models Available\n"
-        for model_name, model_info in models_section.items():
+    if models:
+        lines.append("")
+        lines.append("## Semantic Models Available")
+        for model_name, model_info in models.items():
             saved_at = model_info.get("saved_at", "unknown")
             model_schema = model_info.get("schema_name", "")
-            result += f"- **{model_name}** (schema: {model_schema}, saved: {saved_at})\n"
-        result += "\nUse get_semantic_model(model_name) to retrieve model YAML.\n"
+            lines.append(
+                f"- **{model_name}** (schema: {model_schema}, saved: {saved_at})"
+            )
+        lines.append("")
+        lines.append("Use get_semantic_model(model_name) to retrieve model YAML.")
+
+    return "\n".join(lines)
+
+
+async def cleanup_workspace(
+    ctx: Context,
+    get_session_data,
+    create_error_response,
+) -> str:
+    """Delete all workspace files for the current connection and clear session state.
+
+    Removes schema JSON, ontology TTL, R2RML mappings, GraphRAG data,
+    ChromaDB vectors, Oxigraph RDF store, semantic models, and metadata.
+    The database connection itself remains active.
+
+    Args:
+        ctx: FastMCP context
+        get_session_data: Function to get session data
+        create_error_response: Function to create error response
+
+    Returns:
+        Summary of what was removed
+    """
+    session = get_session_data(ctx)
+
+    if not session.connection_id:
+        return create_error_response(
+            "No database connection. Call connect_database first.",
+            "connection_error",
+        )
+
+    connection_id = session.connection_id
+    removed = []
+
+    # 1. Close live resources before deleting their files
+    if session.oxigraph_store is not None:
+        try:
+            session.oxigraph_store.close()
+        except Exception as e:
+            logger.debug(f"Oxigraph close during cleanup: {e}")
+
+    # Drop GraphRAG reference (releases ChromaDB handle)
+    session.graphrag_manager = None
+
+    # 2. Delete workspace directories
+    dirs_to_remove = [
+        (OUTPUT_DIR / connection_id, "workspace"),
+        (OUTPUT_DIR / "oxigraph" / connection_id, "Oxigraph RDF store"),
+        (OUTPUT_DIR / "chromadb" / connection_id, "ChromaDB vector store"),
+    ]
+    for dir_path, label in dirs_to_remove:
+        if dir_path.exists():
+            try:
+                shutil.rmtree(dir_path, ignore_errors=True)
+                removed.append(label)
+                logger.info(f"Cleaned up {label}: {dir_path}")
+            except Exception as e:
+                logger.warning(f"Failed to remove {label}: {e}")
+
+    # 3. Clear all in-memory session state (keep connection alive)
+    session.clear_schema_cache()
+    session.schema_file = None
+    session.ontology_file = None
+    session.r2rml_file = None
+    session.loaded_ontology = None
+    session.loaded_ontology_path = None
+    session.ontology_enriched = False
+    session.obqc_validator = None
+    session.oxigraph_store = None
+    session.oxigraph_initialized = False
+    session.graphrag_manager = None
+    session.graphrag_initialized = False
+
+    await ctx.info(f"Workspace cleaned for connection {connection_id[:8]}...")
+
+    # 4. Build response
+    result = "# Workspace Cleaned\n\n"
+    result += f"Connection: {connection_id[:8]}... (still active)\n\n"
+
+    if removed:
+        result += "## Removed\n"
+        for item in removed:
+            result += f"- {item}\n"
+    else:
+        result += "No workspace files found to remove.\n"
+
+    result += "\n## Session State Cleared\n"
+    result += "- Schema cache, ontology, GraphRAG, RDF store\n\n"
+    result += "Call analyze_schema() to start building a new workspace.\n"
 
     return result
 

--- a/src/handlers/workspace.py
+++ b/src/handlers/workspace.py
@@ -27,14 +27,16 @@ async def _restore_workspace_core(
     """Core workspace restore logic shared by connect_database and cleanup recovery.
 
     Loads schema cache, ontology, GraphRAG, and RDF store from disk into
-    the session. Returns a structured result dict, or None if no workspace
-    or schemas exist.
+    the session. When schema_name is None, restores ALL schemas in the
+    workspace. Per-schema state (schema cache, ontology) is restored for
+    each schema; connection-scoped state (GraphRAG, RDF store) is restored
+    once.
 
     Args:
         ctx: FastMCP context
         session: SessionData instance (already resolved)
         connection_id: Database connection fingerprint
-        schema_name: Schema to restore (auto-selects first if None)
+        schema_name: Schema to restore. If None, restores all schemas.
         get_oxigraph_store: Function to get/init Oxigraph store
 
     Returns:
@@ -53,71 +55,78 @@ async def _restore_workspace_core(
     if not schemas:
         return None
 
-    # Resolve schema name
     all_schemas = list(schemas.keys())
-    if not schema_name:
-        schema_name = all_schemas[0]
-        if len(all_schemas) > 1:
-            await ctx.info(
-                f"Multiple schemas available: {', '.join(all_schemas)}. "
-                f"Auto-restoring '{schema_name}'."
-            )
 
-    schema_data = schemas.get(schema_name)
-    if not schema_data:
+    # Determine which schemas to restore
+    if schema_name:
+        schemas_to_restore = [schema_name] if schema_name in schemas else []
+    else:
+        schemas_to_restore = all_schemas
+
+    if not schemas_to_restore:
         return None
 
     restored: List[str] = []
     failed: List[str] = []
+    any_ontology_enriched = False
 
-    # 1. Restore schema cache
-    schema_section = schema_data.get("schema", {})
-    schema_file = schema_section.get("schema_file")
-    if schema_file:
-        schema_path = conn_dir / schema_file
-        if schema_path.exists():
-            try:
-                with open(schema_path, "r", encoding="utf-8") as f:
-                    schema_json = json.load(f)
+    # --- Per-schema restore: schema cache + ontology ---
+    for sname in schemas_to_restore:
+        schema_data = schemas[sname]
+        session.set_current_schema(sname)
 
-                tables_raw = schema_json.get("tables", [])
-                tables_info = [TableInfo.from_dict(t) for t in tables_raw]
+        # 1. Restore schema cache
+        schema_section = schema_data.get("schema", {})
+        schema_file = schema_section.get("schema_file")
+        if schema_file:
+            schema_path = conn_dir / schema_file
+            if schema_path.exists():
+                try:
+                    with open(schema_path, "r", encoding="utf-8") as f:
+                        schema_json = json.load(f)
 
-                session.cache_schema_analysis(schema_name, tables_info)
-                session.schema_file = schema_file
-                restored.append(f"Schema analysis: {len(tables_info)} tables")
-            except Exception as e:
-                logger.error(f"Failed to restore schema cache: {e}")
-                failed.append(f"Schema cache: {e}")
-        else:
-            failed.append(f"Schema file missing: {schema_file}")
+                    tables_raw = schema_json.get("tables", [])
+                    tables_info = [TableInfo.from_dict(t) for t in tables_raw]
 
-    # 2. Restore ontology
-    ontology_section = schema_data.get("ontology", {})
-    ontology_file = ontology_section.get("ontology_file")
-    if ontology_file:
-        ontology_path = conn_dir / ontology_file
-        if ontology_path.exists():
-            try:
-                session.ontology_file = ontology_file
-                is_enriched = ontology_section.get("enriched", False)
-                session.ontology_enriched = is_enriched
-                enriched_tag = " (enriched)" if is_enriched else ""
-                restored.append(f"Ontology file{enriched_tag}")
+                    session.cache_schema_analysis(sname, tables_info)
+                    session.schema_file = schema_file
+                    restored.append(f"Schema '{sname}': {len(tables_info)} tables")
+                except Exception as e:
+                    logger.error(f"Failed to restore schema cache for '{sname}': {e}")
+                    failed.append(f"Schema cache '{sname}': {e}")
+            else:
+                failed.append(f"Schema file missing for '{sname}': {schema_file}")
 
-                ontology_content = ontology_path.read_text(encoding="utf-8")
-                session.loaded_ontology = ontology_content
-                session.loaded_ontology_path = str(ontology_path)
-            except Exception as e:
-                logger.error(f"Failed to restore ontology: {e}")
-                failed.append(f"Ontology: {e}")
-        else:
-            failed.append(f"Ontology file missing: {ontology_file}")
+        # 2. Restore ontology (into this schema's state)
+        ontology_section = schema_data.get("ontology", {})
+        ontology_file = ontology_section.get("ontology_file")
+        if ontology_file:
+            ontology_path = conn_dir / ontology_file
+            if ontology_path.exists():
+                try:
+                    session.ontology_file = ontology_file
+                    is_enriched = ontology_section.get("enriched", False)
+                    session.ontology_enriched = is_enriched
+                    if is_enriched:
+                        any_ontology_enriched = True
+                    enriched_tag = " (enriched)" if is_enriched else ""
+                    restored.append(f"Ontology '{sname}'{enriched_tag}")
 
-    # Restore R2RML file reference
-    r2rml_file = schema_section.get("r2rml_file")
-    if r2rml_file and (conn_dir / r2rml_file).exists():
-        session.r2rml_file = r2rml_file
+                    ontology_content = ontology_path.read_text(encoding="utf-8")
+                    session.loaded_ontology = ontology_content
+                    session.loaded_ontology_path = str(ontology_path)
+                except Exception as e:
+                    logger.error(f"Failed to restore ontology for '{sname}': {e}")
+                    failed.append(f"Ontology '{sname}': {e}")
+            else:
+                failed.append(f"Ontology file missing for '{sname}': {ontology_file}")
+
+        # Restore R2RML file reference
+        r2rml_file = schema_section.get("r2rml_file")
+        if r2rml_file and (conn_dir / r2rml_file).exists():
+            session.r2rml_file = r2rml_file
+
+    # --- Connection-scoped restore (once, not per-schema) ---
 
     # 3. Restore Oxigraph RDF store
     rdf_store = workspace.get("rdf_store", {})
@@ -125,55 +134,52 @@ async def _restore_workspace_core(
         try:
             store = get_oxigraph_store(ctx)
             if store:
-                graph_uri = ontology_section.get("graph_uri")
-                if graph_uri:
-                    try:
-                        graph_data = store.export_graph(graph_uri, format="turtle")
-                        if graph_data and len(graph_data) > 100:
-                            restored.append(f"RDF store (graph: {graph_uri})")
-                        else:
-                            failed.append("RDF store: graph empty or not found")
-                    except Exception:
-                        failed.append("RDF store: graph verification failed")
-                else:
-                    restored.append("RDF store (initialized)")
+                restored.append("RDF store (initialized)")
         except Exception as e:
             logger.error(f"Failed to restore RDF store: {e}")
             failed.append(f"RDF store: {e}")
 
-    # 4. Restore GraphRAG
-    graphrag_section = schema_data.get("graphrag", {})
-    if graphrag_section.get("initialized"):
-        try:
-            manager = GraphRAGManager(
-                embedding_model="tfidf",
-                embedding_dimension=384,
-                connection_id=connection_id,
-                schema_name=schema_name,
-            )
-            if manager.load_state(ensure_output_dir()):
-                session.graphrag_manager = manager
-                session.graphrag_initialized = True
-                stats = manager.vector_store.get_statistics()
-                restored.append(
-                    f"GraphRAG: {stats.get('total_elements', 0)} embeddings, "
-                    f"{manager.graph_retriever.graph.number_of_nodes()} tables"
-                )
-            else:
-                failed.append("GraphRAG: load_state returned False")
-        except Exception as e:
-            logger.error(f"Failed to restore GraphRAG: {e}")
-            failed.append(f"GraphRAG: {e}")
+    # 4. Restore GraphRAG (connection-scoped, accumulative)
+    if not session.graphrag_initialized:
+        # Find first schema with graphrag initialized to trigger load
+        for sname in schemas_to_restore:
+            graphrag_section = schemas[sname].get("graphrag", {})
+            if graphrag_section.get("initialized"):
+                try:
+                    manager = GraphRAGManager(
+                        embedding_model="tfidf",
+                        embedding_dimension=384,
+                        connection_id=connection_id,
+                        schema_name=sname,
+                    )
+                    if manager.load_state(ensure_output_dir()):
+                        session.graphrag_manager = manager
+                        session.graphrag_initialized = True
+                        stats = manager.vector_store.get_statistics()
+                        restored.append(
+                            f"GraphRAG: {stats.get('total_elements', 0)} embeddings, "
+                            f"{manager.graph_retriever.graph.number_of_nodes()} tables"
+                        )
+                    else:
+                        failed.append("GraphRAG: load_state returned False")
+                except Exception as e:
+                    logger.error(f"Failed to restore GraphRAG: {e}")
+                    failed.append(f"GraphRAG: {e}")
+                break  # Connection-scoped — load once from combined state
 
     # Collect semantic models
     models = workspace.get("models", {})
 
+    # Set current schema to the first restored schema
+    session.set_current_schema(schemas_to_restore[0])
+
     return {
-        "schema_name": schema_name,
+        "schema_name": schemas_to_restore[0],
         "all_schemas": all_schemas,
+        "restored_schemas": schemas_to_restore,
         "restored": restored,
         "failed": failed,
-        "ontology_enriched": session.ontology_enriched,
+        "ontology_enriched": any_ontology_enriched,
         "models": models,
     }
 
@@ -187,20 +193,19 @@ def _format_restore_summary(result: Dict[str, Any]) -> str:
     Returns:
         Formatted markdown string
     """
-    schema_name = result["schema_name"]
     restored = result["restored"]
     failed = result["failed"]
     ontology_enriched = result.get("ontology_enriched", False)
     models = result.get("models", {})
-    all_schemas = result.get("all_schemas", [schema_name])
+    restored_schemas = result.get("restored_schemas", [result["schema_name"]])
+
+    restored_str = str(restored)
 
     lines = ["# Workspace Auto-Restored", ""]
-    lines.append(f"Schema: {schema_name}")
-
-    if len(all_schemas) > 1:
-        others = [s for s in all_schemas if s != schema_name]
-        lines.append(f"Other schemas available: {', '.join(others)}")
-        lines.append("Use analyze_schema(schema_name) to switch schemas.")
+    if len(restored_schemas) == 1:
+        lines.append(f"Schema: {restored_schemas[0]}")
+    else:
+        lines.append(f"Schemas: {', '.join(restored_schemas)}")
     lines.append("")
 
     if restored:
@@ -221,9 +226,9 @@ def _format_restore_summary(result: Dict[str, Any]) -> str:
 
     # Build "do not call" list
     skip_tools = []
-    if "Schema analysis" in str(restored):
+    if "Schema '" in restored_str:
         skip_tools.append("analyze_schema()")
-    if "Ontology" in str(restored):
+    if "Ontology '" in restored_str:
         skip_tools.append("generate_ontology()")
         if ontology_enriched:
             skip_tools.append("suggest_semantic_names()")
@@ -236,16 +241,16 @@ def _format_restore_summary(result: Dict[str, Any]) -> str:
 
     lines.append("")
     lines.append("## Ready to Use")
-    if "Schema analysis" in str(restored):
-        if not ontology_enriched and "Ontology" not in str(restored):
+    if "Schema '" in restored_str:
+        if not ontology_enriched and "Ontology '" not in restored_str:
             lines.append("- generate_ontology() to create ontology from cached schema")
-        if not ontology_enriched and "Ontology" in str(restored):
+        if not ontology_enriched and "Ontology '" in restored_str:
             lines.append("- suggest_semantic_names() to enrich the ontology")
-    if "Ontology" in str(restored):
+    if "Ontology '" in restored_str:
         lines.append("- query_sparql() for semantic queries")
         lines.append("- validate_sql_syntax() with ontology-aware validation")
         lines.append("- execute_sql_query() for data queries")
-    if "GraphRAG" in str(restored):
+    if "GraphRAG" in restored_str:
         lines.append("- graphrag_search() for semantic schema search")
 
     if models:
@@ -300,7 +305,7 @@ async def cleanup_workspace(
         except Exception as e:
             logger.debug(f"Oxigraph close during cleanup: {e}")
 
-    # Drop GraphRAG reference (releases ChromaDB handle)
+    # Drop GraphRAG reference (connection-scoped, releases ChromaDB handle)
     session.graphrag_manager = None
 
     # 2. Delete workspace directories
@@ -320,17 +325,11 @@ async def cleanup_workspace(
 
     # 3. Clear all in-memory session state (keep connection alive)
     session.clear_schema_cache()
-    session.schema_file = None
-    session.ontology_file = None
-    session.r2rml_file = None
-    session.loaded_ontology = None
-    session.loaded_ontology_path = None
-    session.ontology_enriched = False
-    session.obqc_validator = None
-    session.oxigraph_store = None
-    session.oxigraph_initialized = False
+    session.clear_all_schema_states()
     session.graphrag_manager = None
     session.graphrag_initialized = False
+    session.oxigraph_store = None
+    session.oxigraph_initialized = False
 
     await ctx.info(f"Workspace cleaned for connection {connection_id[:8]}...")
 

--- a/src/main.py
+++ b/src/main.py
@@ -232,20 +232,15 @@ def _clear_session_state(session: SessionData, reason: str = "connection change"
     logger.info(f"Clearing session state ({reason})")
 
     session.clear_schema_cache()
-    session.schema_file = None
-    session.ontology_file = None
-    session.r2rml_file = None
-    session.loaded_ontology = None
-    session.loaded_ontology_path = None
-    session.ontology_enriched = False
 
-    session.obqc_validator = None
+    # Clear all per-schema state (ontology for every schema)
+    session.clear_all_schema_states()
 
-    session.oxigraph_store = None
-    session.oxigraph_initialized = False
-
+    # Clear connection-scoped state
     session.graphrag_manager = None
     session.graphrag_initialized = False
+    session.oxigraph_store = None
+    session.oxigraph_initialized = False
 
     logger.info("Session state cleared")
 

--- a/src/main.py
+++ b/src/main.py
@@ -237,6 +237,7 @@ def _clear_session_state(session: SessionData, reason: str = "connection change"
     session.r2rml_file = None
     session.loaded_ontology = None
     session.loaded_ontology_path = None
+    session.ontology_enriched = False
 
     session.obqc_validator = None
 
@@ -539,16 +540,15 @@ from .handlers import info as _h_info
 async def connect_database(ctx: Context, db_type: str) -> str:
     """Connect to a database using credentials from environment variables.
 
-    IMPORTANT: The response may include a 'Previous workspace found' section.
-    If it does, call restore_workspace() as the next step instead of analyze_schema().
-    This avoids redundant re-analysis and restores schema cache, ontology, GraphRAG,
-    and RDF store from the previous session.
+    If a previous workspace exists for this connection, it is automatically
+    restored (schema cache, ontology, GraphRAG, RDF store). The response
+    indicates what was restored and which tools are ready to use.
 
     Args:
         db_type: Database type - 'postgresql', 'snowflake', 'dremio', 'clickhouse', 'bigquery', 'duckdb', 'databricks', or 'mysql'
 
     Returns:
-        Connection status message, optionally with workspace restoration guidance
+        Connection status with auto-restored workspace summary if available
     """
     return await _h_connection.connect_database(
         ctx, db_type,
@@ -557,6 +557,7 @@ async def connect_database(ctx: Context, db_type: str) -> str:
         create_error_response=create_error_response,
         _get_connection_fingerprint=_get_connection_fingerprint,
         _clear_session_state=_clear_session_state,
+        get_oxigraph_store=get_oxigraph_store,
     )
 
 
@@ -888,30 +889,21 @@ async def generate_chart(
 
 
 @mcp.tool()
-async def restore_workspace(
-    ctx: Context,
-    schema_name: Optional[str] = None,
-) -> str:
-    """Restore workspace from a previous session's artifacts.
+async def cleanup_workspace(ctx: Context) -> str:
+    """Delete all workspace files for the current database connection and clear session state.
 
-    When reconnecting to the same database, this tool restores schema cache,
-    ontology, GraphRAG, and RDF store from disk — avoiding re-analysis costs.
+    Removes schema JSON, ontology TTL, R2RML mappings, GraphRAG data, ChromaDB vectors,
+    Oxigraph RDF store, semantic models, and metadata for this connection.
+    The database connection itself remains active.
 
-    IMPORTANT: After a successful restore, do NOT call analyze_schema() or
-    generate_ontology() — the restored data replaces those steps entirely.
-    Proceed directly to the tools listed in the 'Ready to Use' section of
-    the response.
-
-    Args:
-        schema_name: Schema to restore (auto-selects if only one available)
+    Use this to start fresh or free disk space. Requires an active connection.
 
     Returns:
-        Summary of what was restored and what's ready to use
+        Summary of what was removed
     """
-    return await _h_workspace.restore_workspace(
-        ctx, schema_name,
+    return await _h_workspace.cleanup_workspace(
+        ctx,
         get_session_data=get_session_data,
-        get_oxigraph_store=get_oxigraph_store,
         create_error_response=create_error_response,
     )
 

--- a/src/session.py
+++ b/src/session.py
@@ -3,10 +3,9 @@
 Provides decomposed, focused state objects for per-session isolation.
 Each MCP session gets its own SessionData instance containing:
 - ConnectionState: database connection tracking
-- OntologyState: ontology generation and loading
-- SchemaCache: cached schema analysis results
-- GraphRAGState: GraphRAG integration with init tracking
-- RDFStoreState: Oxigraph RDF store with init tracking
+- SchemaCache: cached schema analysis results (multi-schema)
+- SchemaState: per-schema ontology + GraphRAG state (multi-schema)
+- RDFStoreState: Oxigraph RDF store (connection-scoped, multi-schema via named graphs)
 """
 
 import asyncio
@@ -39,12 +38,11 @@ class OntologyState:
 
 
 class SchemaCache:
-    """Cached schema analysis results."""
+    """Cached schema analysis results (multi-schema capable)."""
 
     def __init__(self):
         self._cached_schema: Optional[Dict[str, List[Any]]] = None  # schema_name -> List[TableInfo]
         self._last_analyzed_schema: Optional[str] = None
-        self.schema_file: Optional[str] = None
 
     def cache_schema_analysis(self, schema_name: str, tables_info: List[Any]) -> None:
         """Cache schema analysis results for reuse."""
@@ -65,12 +63,23 @@ class SchemaCache:
             logger.debug(f"Using cached schema for '{cache_key}': {len(cached)} tables")
         return cached
 
-    def clear(self) -> None:
-        """Clear cached schema analysis (e.g., on reconnect)."""
-        self._cached_schema = None
-        self._last_analyzed_schema = None
-        self.schema_file = None
-        logger.debug("Cleared schema cache")
+    def clear(self, schema_name: Optional[str] = None) -> None:
+        """Clear cached schema analysis.
+
+        Args:
+            schema_name: If provided, clear only that schema's cache.
+                         If None, clear all cached schemas.
+        """
+        if schema_name is not None and self._cached_schema is not None:
+            cache_key = schema_name or "_default_"
+            self._cached_schema.pop(cache_key, None)
+            if self._last_analyzed_schema == schema_name:
+                self._last_analyzed_schema = None
+            logger.debug(f"Cleared schema cache for '{cache_key}'")
+        else:
+            self._cached_schema = None
+            self._last_analyzed_schema = None
+            logger.debug("Cleared all schema caches")
 
     def get_last_analyzed_schema(self) -> Optional[str]:
         """Get the name of the last analyzed schema."""
@@ -87,7 +96,11 @@ class GraphRAGState:
 
 
 class RDFStoreState:
-    """Oxigraph RDF store state with Future-based init tracking."""
+    """Oxigraph RDF store state with Future-based init tracking.
+
+    Connection-scoped (not per-schema). Oxigraph supports multiple schemas
+    via named graphs within a single store.
+    """
 
     def __init__(self):
         self.oxigraph_store: Optional[Any] = None  # OxigraphStoreManager
@@ -95,18 +108,40 @@ class RDFStoreState:
         self._init_task: Optional[asyncio.Task] = None
 
 
-class SessionData:
-    """Per-session data storage with decomposed state objects.
+class SchemaState:
+    """Per-schema state for ontology data.
 
-    Composes focused state objects for clean separation of concerns.
+    Each analyzed schema gets its own SchemaState so that switching
+    schemas does not destroy the previous schema's ontology state.
+    GraphRAG is connection-scoped (accumulative across schemas).
+    """
+
+    def __init__(self, schema_name: str):
+        self.schema_name = schema_name
+        self.schema_file: Optional[str] = None
+        self.ontology = OntologyState()
+
+
+class SessionData:
+    """Per-session data storage with multi-schema support.
+
+    Connection-level state (ConnectionState, RDFStoreState) is shared
+    across all schemas. Per-schema state (ontology, GraphRAG) is isolated
+    in SchemaState instances keyed by schema name.
     """
 
     def __init__(self):
         self.connection = ConnectionState()
-        self.ontology = OntologyState()
         self.schema_cache = SchemaCache()
-        self.graphrag = GraphRAGState()
         self.rdf_store = RDFStoreState()
+
+        # Connection-scoped state (shared across schemas)
+        self.graphrag = GraphRAGState()
+
+        # Multi-schema state (ontology is per-schema)
+        self._schema_states: Dict[str, SchemaState] = {}
+        self._current_schema: Optional[str] = None
+
         # Activity tracking for idle eviction
         self.created_at: datetime = datetime.now()
         self.last_activity: datetime = datetime.now()
@@ -115,9 +150,83 @@ class SessionData:
         """Update last activity timestamp."""
         self.last_activity = datetime.now()
 
-    # --- Convenience accessors for backward compatibility ---
-    # These will be used during migration; handler code should use
-    # the decomposed state objects directly.
+    # --- Multi-schema management ---
+
+    @property
+    def current_schema(self) -> Optional[str]:
+        """Name of the currently active schema."""
+        return self._current_schema
+
+    def set_current_schema(self, schema_name: str) -> "SchemaState":
+        """Set the active schema, creating a SchemaState if needed.
+
+        Args:
+            schema_name: Schema name to activate
+
+        Returns:
+            The SchemaState for the activated schema
+        """
+        key = schema_name or "default"
+        if key not in self._schema_states:
+            self._schema_states[key] = SchemaState(key)
+            logger.debug(f"Created SchemaState for '{key}'")
+        self._current_schema = key
+        logger.debug(f"Current schema set to '{key}'")
+        return self._schema_states[key]
+
+    def get_schema_state(self, schema_name: Optional[str] = None) -> Optional["SchemaState"]:
+        """Get SchemaState for a specific or the current schema.
+
+        Args:
+            schema_name: Schema name to look up. If None, uses current schema.
+
+        Returns:
+            SchemaState if found, None otherwise.
+        """
+        key = schema_name or self._current_schema
+        if key is None:
+            return None
+        key = key or "default"
+        return self._schema_states.get(key)
+
+    def get_or_create_schema_state(self, schema_name: Optional[str] = None) -> "SchemaState":
+        """Get or create SchemaState for a specific or the current schema.
+
+        If schema_name is None and no current schema is set, uses "default".
+        """
+        key = schema_name or self._current_schema or "default"
+        if key not in self._schema_states:
+            self._schema_states[key] = SchemaState(key)
+        return self._schema_states[key]
+
+    @property
+    def schema_names(self) -> List[str]:
+        """List of all schema names with active state."""
+        return list(self._schema_states.keys())
+
+    def clear_all_schema_states(self) -> None:
+        """Clear all per-schema state (ontology, GraphRAG) for all schemas."""
+        self._schema_states.clear()
+        self._current_schema = None
+        logger.debug("Cleared all schema states")
+
+    # --- Convenience accessors ---
+    # Delegate to the current schema's state for backward compatibility.
+    # Handler code can also access schema state directly via
+    # get_schema_state() for explicit schema targeting.
+
+    @property
+    def _current_schema_state(self) -> Optional["SchemaState"]:
+        """Internal helper: get current SchemaState or None."""
+        if self._current_schema is None:
+            return None
+        return self._schema_states.get(self._current_schema)
+
+    def _ensure_schema_state(self) -> "SchemaState":
+        """Internal helper: get or create current SchemaState."""
+        return self.get_or_create_schema_state()
+
+    # Connection properties (session-scoped, unchanged)
 
     @property
     def db_manager(self):
@@ -143,61 +252,74 @@ class SessionData:
     def connected_at(self, value):
         self.connection.connected_at = value
 
+    # Ontology properties (per-schema via current schema)
+
     @property
     def ontology_file(self):
-        return self.ontology.ontology_file
+        ss = self._current_schema_state
+        return ss.ontology.ontology_file if ss else None
 
     @ontology_file.setter
     def ontology_file(self, value):
-        self.ontology.ontology_file = value
+        self._ensure_schema_state().ontology.ontology_file = value
 
     @property
     def r2rml_file(self):
-        return self.ontology.r2rml_file
+        ss = self._current_schema_state
+        return ss.ontology.r2rml_file if ss else None
 
     @r2rml_file.setter
     def r2rml_file(self, value):
-        self.ontology.r2rml_file = value
+        self._ensure_schema_state().ontology.r2rml_file = value
 
     @property
     def loaded_ontology(self):
-        return self.ontology.loaded_ontology
+        ss = self._current_schema_state
+        return ss.ontology.loaded_ontology if ss else None
 
     @loaded_ontology.setter
     def loaded_ontology(self, value):
-        self.ontology.loaded_ontology = value
+        self._ensure_schema_state().ontology.loaded_ontology = value
 
     @property
     def loaded_ontology_path(self):
-        return self.ontology.loaded_ontology_path
+        ss = self._current_schema_state
+        return ss.ontology.loaded_ontology_path if ss else None
 
     @loaded_ontology_path.setter
     def loaded_ontology_path(self, value):
-        self.ontology.loaded_ontology_path = value
+        self._ensure_schema_state().ontology.loaded_ontology_path = value
 
     @property
     def obqc_validator(self):
-        return self.ontology.obqc_validator
+        ss = self._current_schema_state
+        return ss.ontology.obqc_validator if ss else None
 
     @obqc_validator.setter
     def obqc_validator(self, value):
-        self.ontology.obqc_validator = value
+        self._ensure_schema_state().ontology.obqc_validator = value
 
     @property
     def ontology_enriched(self):
-        return self.ontology.ontology_enriched
+        ss = self._current_schema_state
+        return ss.ontology.ontology_enriched if ss else False
 
     @ontology_enriched.setter
     def ontology_enriched(self, value):
-        self.ontology.ontology_enriched = value
+        self._ensure_schema_state().ontology.ontology_enriched = value
+
+    # Schema file (per-schema via current schema)
 
     @property
     def schema_file(self):
-        return self.schema_cache.schema_file
+        ss = self._current_schema_state
+        return ss.schema_file if ss else None
 
     @schema_file.setter
     def schema_file(self, value):
-        self.schema_cache.schema_file = value
+        self._ensure_schema_state().schema_file = value
+
+    # GraphRAG properties (connection-scoped, accumulative across schemas)
 
     @property
     def graphrag_manager(self):
@@ -214,6 +336,8 @@ class SessionData:
     @graphrag_initialized.setter
     def graphrag_initialized(self, value):
         self.graphrag.graphrag_initialized = value
+
+    # RDF Store properties (connection-scoped, unchanged)
 
     @property
     def oxigraph_store(self):
@@ -241,9 +365,13 @@ class SessionData:
         """Get cached schema analysis results if available."""
         return self.schema_cache.get_cached_schema(schema_name)
 
-    def clear_schema_cache(self) -> None:
-        """Clear cached schema analysis (e.g., on reconnect)."""
-        self.schema_cache.clear()
+    def clear_schema_cache(self, schema_name: Optional[str] = None) -> None:
+        """Clear cached schema analysis.
+
+        Args:
+            schema_name: If provided, clear only that schema. If None, clear all.
+        """
+        self.schema_cache.clear(schema_name)
 
     def get_last_analyzed_schema(self) -> Optional[str]:
         """Get the name of the last analyzed schema."""

--- a/src/workspace.py
+++ b/src/workspace.py
@@ -162,8 +162,7 @@ def format_workspace_summary(workspace: Dict[str, Any]) -> str:
         lines.append(f"  RDF store: {graph_count} graph(s)")
 
     lines.append("")
-    lines.append("IMPORTANT: Call restore_workspace() as the NEXT STEP to reuse these artifacts.")
-    lines.append("Do NOT call analyze_schema() or generate_ontology() — they are already available.")
-    lines.append("Only use analyze_schema() if you need to start fresh with a different schema.")
+    lines.append("NOTE: Auto-restore was not available. Workspace artifacts exist on disk.")
+    lines.append("Call analyze_schema() to re-analyze, or reconnect to trigger auto-restore.")
 
     return "\n".join(lines)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+"""Global test fixtures for OrionBelt Analytics.
+
+Patches OUTPUT_DIR to use pytest's tmp_path for all tests, preventing
+test artifacts from polluting the real tmp/ directory.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolate_output_dir(tmp_path, monkeypatch):
+    """Redirect OUTPUT_DIR to a temp directory for every test.
+
+    This prevents tests from writing metadata.json, ontology files,
+    and other artifacts into the project's real tmp/ directory.
+    """
+    test_output = tmp_path / "output"
+    test_output.mkdir()
+
+    # Patch the canonical source
+    monkeypatch.setattr("src.paths.OUTPUT_DIR", test_output)
+
+    # Patch every module that imports OUTPUT_DIR at module level
+    targets = [
+        "src.handlers.connection",
+        "src.handlers.schema",
+        "src.handlers.ontology",
+        "src.handlers.workspace",
+        "src.handlers.rdf",
+        "src.handlers.graphrag",
+        "src.workspace",
+        "src.graphrag.vector_store_chromadb",
+    ]
+    for mod in targets:
+        try:
+            monkeypatch.setattr(f"{mod}.OUTPUT_DIR", test_output)
+        except AttributeError:
+            pass  # Module may not be imported yet
+
+    return test_output

--- a/tests/test_ontology_workflow_fix.py
+++ b/tests/test_ontology_workflow_fix.py
@@ -289,6 +289,11 @@ async def test_full_workflow_lightweight_to_ontology(mock_context, mock_db_manag
                 self.graphrag_manager = None
                 self.graphrag = Mock()
                 self._cache = cached_data
+                self._current_schema = None
+                self.ontology_enriched = False
+                self.loaded_ontology = None
+                self.loaded_ontology_path = None
+                self.r2rml_file = None
 
             def get_cached_schema(self, schema_name):
                 return self._cache.get(schema_name)
@@ -298,6 +303,14 @@ async def test_full_workflow_lightweight_to_ontology(mock_context, mock_db_manag
 
             def get_last_analyzed_schema(self):
                 return "public" if "public" in self._cache else None
+
+            def set_current_schema(self, schema_name):
+                self._current_schema = schema_name
+                return self
+
+            @property
+            def current_schema(self):
+                return self._current_schema
 
         session = FakeSession()
         mock_session_data.return_value = session

--- a/tests/test_phase2_hierarchical.py
+++ b/tests/test_phase2_hierarchical.py
@@ -144,7 +144,7 @@ class TestPhase2FunctionalityPreserved:
             "validate_sql_syntax",
             "execute_sql_query",
             "generate_chart",
-            "restore_workspace",
+            "cleanup_workspace",
             "get_server_info"
         ]
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -8,7 +8,7 @@ Covers:
 4. Workspace summary formatting
 5. GraphRAG load_state
 6. TableInfo.from_dict deserialization
-7. restore_workspace tool registration
+7. cleanup_workspace tool registration
 """
 
 import asyncio
@@ -244,7 +244,7 @@ class TestWorkspaceDetection:
         assert "enriched" in summary
         assert "RDF store" in summary
         assert "312 embeddings" in summary
-        assert "restore_workspace" in summary
+        assert "Auto-restore was not available" in summary
 
 
 class TestGraphRetrieverLoadGraph:
@@ -362,24 +362,21 @@ class TestTableInfoFromDict:
 
 
 class TestToolRegistration:
-    """Test restore_workspace is properly registered."""
+    """Test cleanup_workspace is properly registered."""
 
     @pytest.mark.asyncio
-    async def test_restore_workspace_registered(self):
-        """Verify restore_workspace tool exists in MCP."""
+    async def test_cleanup_workspace_registered(self):
+        """Verify cleanup_workspace tool exists in MCP."""
         tools = await mcp.list_tools()
         tool_names = [t.name for t in tools]
-        assert "restore_workspace" in tool_names
+        assert "cleanup_workspace" in tool_names
 
-    def test_restore_workspace_has_schema_param(self):
-        """Verify restore_workspace has optional schema_name parameter."""
-        import inspect
-        fn = _get_tool_fn("restore_workspace")
-        sig = inspect.signature(fn)
-        params = sig.parameters
-
-        assert "schema_name" in params
-        assert params["schema_name"].default is None
+    @pytest.mark.asyncio
+    async def test_restore_workspace_removed(self):
+        """Verify restore_workspace tool no longer exists (replaced by auto-restore)."""
+        tools = await mcp.list_tools()
+        tool_names = [t.name for t in tools]
+        assert "restore_workspace" not in tool_names
 
 
 class TestGraphRAGManagerLoadState:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -15,7 +15,7 @@ import asyncio
 import pytest
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from src.database_manager import TableInfo, ColumnInfo
 from src.lifecycle.metadata import (
@@ -432,6 +432,158 @@ class TestGraphRAGManagerLoadState:
         assert mgr2._initialized is True
         assert mgr2.graph_retriever.graph.number_of_nodes() == 2
         assert mgr2.graph_retriever.graph.number_of_edges() == 1
+
+
+class TestMultiSchemaSessionState:
+    """Test that SessionData isolates per-schema state (ontology, GraphRAG)."""
+
+    def test_set_current_schema_creates_state(self):
+        """set_current_schema creates a SchemaState and sets it as active."""
+        from src.session import SessionData
+
+        session = SessionData()
+        assert session.current_schema is None
+
+        ss = session.set_current_schema("public")
+        assert session.current_schema == "public"
+        assert ss.schema_name == "public"
+        assert ss.ontology.ontology_file is None
+
+    def test_schema_isolation_ontology(self):
+        """Ontology state is isolated per schema."""
+        from src.session import SessionData
+
+        session = SessionData()
+
+        # Set up "public" schema ontology
+        session.set_current_schema("public")
+        session.ontology_file = "ontology_public.ttl"
+        session.ontology_enriched = True
+
+        # Switch to "analytics"
+        session.set_current_schema("analytics")
+        session.ontology_file = "ontology_analytics.ttl"
+        session.ontology_enriched = False
+
+        # Verify isolation
+        session.set_current_schema("public")
+        assert session.ontology_file == "ontology_public.ttl"
+        assert session.ontology_enriched is True
+
+        session.set_current_schema("analytics")
+        assert session.ontology_file == "ontology_analytics.ttl"
+        assert session.ontology_enriched is False
+
+    def test_graphrag_is_connection_scoped(self):
+        """GraphRAG state is connection-scoped (shared across schemas)."""
+        from src.session import SessionData
+        from unittest.mock import Mock
+
+        session = SessionData()
+        manager = Mock(name="graphrag_manager")
+        session.graphrag_manager = manager
+        session.graphrag_initialized = True
+
+        # GraphRAG is the same regardless of current schema
+        session.set_current_schema("public")
+        assert session.graphrag_manager is manager
+        assert session.graphrag_initialized is True
+
+        session.set_current_schema("analytics")
+        assert session.graphrag_manager is manager
+        assert session.graphrag_initialized is True
+
+    def test_schema_isolation_schema_file(self):
+        """Schema file reference is isolated per schema."""
+        from src.session import SessionData
+
+        session = SessionData()
+
+        session.set_current_schema("public")
+        session.schema_file = "schema_public.json"
+
+        session.set_current_schema("analytics")
+        session.schema_file = "schema_analytics.json"
+
+        session.set_current_schema("public")
+        assert session.schema_file == "schema_public.json"
+
+        session.set_current_schema("analytics")
+        assert session.schema_file == "schema_analytics.json"
+
+    def test_rdf_store_is_connection_scoped(self):
+        """RDF store remains connection-scoped (shared across schemas)."""
+        from src.session import SessionData
+        from unittest.mock import Mock
+
+        session = SessionData()
+        store = Mock(name="oxigraph_store")
+        session.oxigraph_store = store
+
+        session.set_current_schema("public")
+        assert session.oxigraph_store is store
+
+        session.set_current_schema("analytics")
+        assert session.oxigraph_store is store
+
+    def test_schema_cache_is_multi_schema(self):
+        """SchemaCache can hold multiple schemas simultaneously."""
+        from src.session import SessionData
+
+        session = SessionData()
+        public_tables = [Mock(name="t1")]
+        analytics_tables = [Mock(name="t2"), Mock(name="t3")]
+
+        session.cache_schema_analysis("public", public_tables)
+        session.cache_schema_analysis("analytics", analytics_tables)
+
+        assert len(session.get_cached_schema("public")) == 1
+        assert len(session.get_cached_schema("analytics")) == 2
+
+    def test_clear_all_schema_states(self):
+        """clear_all_schema_states removes all per-schema state."""
+        from src.session import SessionData
+
+        session = SessionData()
+
+        session.set_current_schema("public")
+        session.ontology_file = "ontology_public.ttl"
+
+        session.set_current_schema("analytics")
+        session.ontology_file = "ontology_analytics.ttl"
+
+        session.clear_all_schema_states()
+        assert session.current_schema is None
+        assert session.schema_names == []
+        assert session.ontology_file is None
+        assert session.graphrag_manager is None
+
+    def test_get_schema_state_specific(self):
+        """get_schema_state can access non-current schema state."""
+        from src.session import SessionData
+
+        session = SessionData()
+
+        session.set_current_schema("public")
+        session.ontology_file = "pub.ttl"
+
+        session.set_current_schema("analytics")
+
+        # Access public's state while analytics is current
+        pub_state = session.get_schema_state("public")
+        assert pub_state is not None
+        assert pub_state.ontology.ontology_file == "pub.ttl"
+
+    def test_schema_names_lists_all(self):
+        """schema_names lists all schemas with active state."""
+        from src.session import SessionData
+
+        session = SessionData()
+        session.set_current_schema("public")
+        session.set_current_schema("analytics")
+        session.set_current_schema("staging")
+
+        assert sorted(session.schema_names) == ["analytics", "public", "staging"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **Multi-schema session state**: `SessionData` is now schema-aware — ontology state is per-schema (switching schemas preserves each schema's ontology), while GraphRAG and Oxigraph RDF store are connection-scoped and accumulative (each `analyze_schema()` adds tables to the same graph for cross-schema join path discovery)
- **Auto-restore all schemas**: `connect_database` auto-restores the full workspace on reconnect — all schemas' caches and ontologies are loaded, not just the first
- **`cleanup_workspace` tool**: Deletes all workspace files for the current connection and clears session state while keeping the database connection alive
- **Startup cleanup improvements**: Retention cleanup logging and test output isolation fixes

## Test plan

- [x] `uv run pytest` — 288 passed, 3 warnings
- [x] Multi-schema ontology isolation verified (set schema A, switch to B, switch back — A's state preserved)
- [x] GraphRAG accumulation verified (analyze two schemas → single graph with both schemas' tables)
- [x] Workspace auto-restore loads all schemas on reconnect
- [x] `cleanup_workspace` clears state but keeps connection alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)