### PR TITLE
refactor: rename analyze_schema to discover_schema, reduce tool friction

### DIFF
--- a/.claude/skills/analytical-workflow.md
+++ b/.claude/skills/analytical-workflow.md
@@ -79,7 +79,7 @@ list_schemas()
 
 #### 2.1 Analyze Schema
 
-**Tool:** `analyze_schema()`
+**Tool:** `discover_schema()`
 
 **Purpose:** Get complete schema structure with automatic GraphRAG initialization
 
@@ -88,7 +88,7 @@ list_schemas()
 User: "Analyze the public schema"
 
 Claude calls:
-analyze_schema(
+discover_schema(
   schema_name="public",
   lightweight=false
 )
@@ -489,7 +489,7 @@ generate_chart(
 ### Auto-Features (Enabled by Default)
 
 **1. GraphRAG Auto-Init**
-- Automatically triggers on `analyze_schema()`
+- Automatically triggers on `discover_schema()`
 - No manual initialization needed
 - Configure: `AUTO_GRAPHRAG=true` in `.env`
 
@@ -516,7 +516,7 @@ generate_chart(
 
 ```
 1. connect_database()
-2. analyze_schema()
+2. discover_schema()
 3. Ask: "What tables are related to X?"
 4. sample_table_data()
 5. execute_sql_query()
@@ -532,7 +532,7 @@ generate_chart(
 ```
 1. connect_database()
 2. list_schemas()
-3. analyze_schema()
+3. discover_schema()
 4. generate_ontology()  // auto-persist enabled
 5. Ask: "Find join path between X and Y"
 6. validate_sql_syntax()
@@ -549,7 +549,7 @@ generate_chart(
 
 ```
 1. connect_database()
-2. analyze_schema()
+2. discover_schema()
 3. generate_ontology()
 4. download_ontology()  // for external tools
 5. query_sparql()  // semantic queries
@@ -667,11 +667,11 @@ SELECT c.id, c.name FROM customers c JOIN orders o ON c.id = o.customer_id
 
 ### Multi-Schema Support
 
-**Ontology state is per-schema; GraphRAG is connection-scoped and accumulative.** Each `analyze_schema()` adds tables to the same graph, enabling cross-schema join path discovery:
+**Ontology state is per-schema; GraphRAG is connection-scoped and accumulative.** Each `discover_schema()` adds tables to the same graph, enabling cross-schema join path discovery:
 
 ```
-analyze_schema(schema_name="public")     # → ontology for public, GraphRAG adds public tables
-analyze_schema(schema_name="analytics")  # → ontology for analytics, GraphRAG adds analytics tables
+discover_schema(schema_name="public")     # → ontology for public, GraphRAG adds public tables
+discover_schema(schema_name="analytics")  # → ontology for analytics, GraphRAG adds analytics tables
 graphrag_search("customers")             # → searches across ALL analyzed schemas
 graphrag_find_join_path("public.orders", "analytics.events")  # → cross-schema path
 ```
@@ -687,7 +687,7 @@ Ontology state is isolated per schema — switching schemas does not destroy the
 | Tool | Purpose | Phase |
 |------|---------|-------|
 | `connect_database()` | Establish connection | 1 |
-| `analyze_schema()` | Get schema + auto-init GraphRAG | 2 |
+| `discover_schema()` | Get schema + auto-init GraphRAG | 2 |
 | `generate_ontology()` | Create RDF ontology (auto-persist) | 4 |
 | `execute_sql_query()` | Safe SQL execution | 6 |
 | `generate_chart()` | Data visualization | 7 |
@@ -781,7 +781,7 @@ When creating OBML models, users and LLMs leverage GraphRAG to:
 
 ```
 1. Schema Discovery with GraphRAG (Analytics)
-   → analyze_schema(schema_name="sales")
+   → discover_schema(schema_name="sales")
    → GraphRAG auto-initializes with graph + vector embeddings
 
 2. Intelligent Schema Exploration (Analytics + GraphRAG)
@@ -805,7 +805,7 @@ When creating OBML models, users and LLMs leverage GraphRAG to:
 
 ```
 1. Schema Analysis (Analytics)
-   → analyze_schema()  # Optional - for validation/updates
+   → discover_schema()  # Optional - for validation/updates
 
 2. Business Queries (Semantic Layer - Primary)
    → semantic_layer.query("revenue by customer segment")
@@ -847,7 +847,7 @@ When creating OBML models, users and LLMs leverage GraphRAG to:
 User: "Create a semantic model for our sales database"
 
 Step 1: Schema Discovery (Analytics + GraphRAG)
-analyze_schema(schema_name="sales")
+discover_schema(schema_name="sales")
 → GraphRAG auto-initializes: graph structure + vector embeddings
 
 Step 2: Explore Relationships (GraphRAG)
@@ -898,7 +898,7 @@ generate_chart(data=..., chart_type="bar")
 - ❌ Extensive user guidance needed for modeling
 
 **With GraphRAG:**
-- ✅ **Zero-setup schema intelligence** - Automatic on `analyze_schema()`
+- ✅ **Zero-setup schema intelligence** - Automatic on `discover_schema()`
 - ✅ **Intelligent relationship discovery** - Graph algorithms (12 hop traversal)
 - ✅ **Semantic similarity search** - Vector embeddings find related concepts
 - ✅ **OBML model creation** - LLM can create accurate models automatically
@@ -971,14 +971,14 @@ When available, prefer Semantic Layer MCP for business-friendly queries and metr
 **Minimal Workflow (3 steps):**
 ```
 1. connect_database()
-2. analyze_schema()  // auto-inits GraphRAG
+2. discover_schema()  // auto-inits GraphRAG
 3. execute_sql_query()
 ```
 
 **Optimal Workflow (5 steps):**
 ```
 1. connect_database()
-2. analyze_schema()  // auto-inits GraphRAG
+2. discover_schema()  // auto-inits GraphRAG
 3. generate_ontology()  // auto-persist
 4. execute_sql_query()
 5. generate_chart()
@@ -993,7 +993,7 @@ When available, prefer Semantic Layer MCP for business-friendly queries and metr
 ```
 1. connect_database()
 2. list_schemas()
-3. analyze_schema()
+3. discover_schema()
 4. generate_ontology()
 5. query_sparql()  // semantic discovery
 6. validate_sql_syntax()

--- a/.claude/skills/fan-trap-prevention.md
+++ b/.claude/skills/fan-trap-prevention.md
@@ -30,7 +30,7 @@ JOIN public.shipments ON public.orders.id = public.shipments.order_id;
 
 Before writing multi-table queries with aggregation:
 
-1. **Review foreign_keys** from `analyze_schema()` FIRST
+1. **Review foreign_keys** from `discover_schema()` FIRST
 2. **Identify relationship patterns:**
    - Safe: 1:1 relationships (customers → customer_profiles)
    - Requires care: 1:many (customers → orders)
@@ -207,7 +207,7 @@ If you suspect fan-trap in existing query:
 
 For queries with 2+ tables and aggregation:
 
-- [ ] Schema analyzed with `analyze_schema()`
+- [ ] Schema analyzed with `discover_schema()`
 - [ ] Relationships reviewed (check foreign_keys)
 - [ ] Fan-trap patterns identified
 - [ ] Syntax validated with `validate_sql_syntax()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ server.py → src/main.py (@mcp.tool decorators)
 
 Each handler maps to a group of MCP tools:
 - `connection.py` - `connect_database`, `list_schemas`
-- `schema.py` - `analyze_schema`, `get_table_details`, `reset_cache`
+- `schema.py` - `discover_schema`, `get_table_details`, `reset_cache`
 - `ontology.py` - `generate_ontology`, `suggest_semantic_names`, `apply_semantic_names`, `load_my_ontology`, `download_artifact`
 - `query.py` - `execute_sql_query` (includes built-in validation), `sample_table_data`
 - `chart.py` - `generate_chart`
@@ -97,7 +97,7 @@ BaseDriver (src/drivers/base.py)
 ### GraphRAG Subsystem (`src/graphrag/`)
 
 Graph-based Retrieval Augmented Generation for schema intelligence:
-- `manager.py` - Orchestrator, auto-initialized by `analyze_schema()`
+- `manager.py` - Orchestrator, auto-initialized by `discover_schema()`
 - `embedder.py` - Vector embeddings for schema elements
 - `retriever.py` - Graph traversal and relationship discovery (up to 12 hops)
 - `vector_store_chromadb.py` - ChromaDB vector storage implementation
@@ -110,10 +110,10 @@ Graph-based Retrieval Augmented Generation for schema intelligence:
 
 ### Key Patterns
 
-**Per-Session State Isolation**: Each MCP session maintains isolated `SessionData` (in `src/session.py`) with its own `DatabaseManager`, GraphRAG manager, and file paths, preventing cross-session interference. Ontology state is per-schema via `SchemaState` — switching schemas does not destroy the previous schema's ontology. GraphRAG and Oxigraph RDF store are connection-scoped and accumulative: each `analyze_schema()` adds tables to the same graph, enabling cross-schema join path discovery and unified semantic search.
+**Per-Session State Isolation**: Each MCP session maintains isolated `SessionData` (in `src/session.py`) with its own `DatabaseManager`, GraphRAG manager, and file paths, preventing cross-session interference. Ontology state is per-schema via `SchemaState` — switching schemas does not destroy the previous schema's ontology. GraphRAG and Oxigraph RDF store are connection-scoped and accumulative: each `discover_schema()` adds tables to the same graph, enabling cross-schema join path discovery and unified semantic search.
 
 **Fan-Trap Prevention**: Multi-step validation prevents data multiplication errors:
-1. `analyze_schema()` extracts FK relationships
+1. `discover_schema()` extracts FK relationships
 2. Pattern detection in `execute_sql_query()`
 3. Suggests UNION ALL patterns for multi-fact aggregation
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center"><strong>The Ontology-based MCP server for your Text-2-SQL convenience.</strong></p>
 
-[![Version 1.4.0](https://img.shields.io/badge/version-1.4.0-purple.svg)](https://github.com/ralfbecher/orionbelt-analytics/releases)
+[![Version 1.4.1](https://img.shields.io/badge/version-1.4.1-purple.svg)](https://github.com/ralfbecher/orionbelt-analytics/releases)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralfbecher/orionbelt-analytics/blob/main/LICENSE)
 [![FastMCP](https://img.shields.io/badge/FastMCP-3.2.4+-blue)](https://github.com/jlowin/fastmcp)

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ OrionBelt exposes 32 MCP tools. Here is a summary by category:
 | `connect_database` | Connect to any supported database using `.env` credentials |
 | `list_schemas` | List available schemas in the connected database |
 | `reset_cache` | Clear cached schema and ontology data for the current session |
-| `analyze_schema` | Analyze schema structure with automatic GraphRAG + ontology generation |
+| `discover_schema` | Analyze schema structure with automatic GraphRAG + ontology generation |
 | `get_table_details` | Get detailed column, key, and constraint info for a specific table |
 | `cleanup_workspace` | Delete all workspace files for the current connection and start fresh |
 
@@ -161,7 +161,7 @@ OrionBelt exposes 32 MCP tools. Here is a summary by category:
 
 | Tool | Description |
 |------|-------------|
-| `graphrag_search` | Semantic search + schema overview (auto-initialized by `analyze_schema`) |
+| `graphrag_search` | Semantic search + schema overview (auto-initialized by `discover_schema`) |
 | `graphrag_query_context` | Get optimized context for SQL generation (85-95% token reduction) |
 | `graphrag_find_join_path` | Discover join paths between tables via graph traversal |
 
@@ -193,7 +193,7 @@ For full parameter details, return values, and examples, see [docs/tools-referen
 
 **Full analysis session:**
 ```
-connect_database("postgresql") -> analyze_schema("public") -> generate_ontology() -> execute_sql_query(...)
+connect_database("postgresql") -> discover_schema("public") -> generate_ontology() -> execute_sql_query(...)
 ```
 
 **Quick data exploration:**

--- a/docs/development.md
+++ b/docs/development.md
@@ -184,7 +184,7 @@ orionbelt-analytics/
 |   |
 |   |-- handlers/                    # MCP tool implementations (handler layer)
 |   |   |-- connection.py            #   connect_database, list_schemas
-|   |   |-- schema.py                #   analyze_schema, get_table_details, reset_cache
+|   |   |-- schema.py                #   discover_schema, get_table_details, reset_cache
 |   |   |-- ontology.py              #   generate_ontology, suggest/apply semantic names,
 |   |   |                            #     load_my_ontology
 |   |   |-- query.py                 #   validate_sql_syntax, execute_sql_query,
@@ -207,7 +207,7 @@ orionbelt-analytics/
 |   |   +-- databricks.py            #   Databricks SQL driver
 |   |
 |   |-- graphrag/                    # Graph-based RAG for schema intelligence
-|   |   |-- manager.py               #   Orchestrator (auto-init by analyze_schema)
+|   |   |-- manager.py               #   Orchestrator (auto-init by discover_schema)
 |   |   |-- embedder.py              #   Vector embeddings for schema elements
 |   |   |-- retriever.py             #   Graph traversal, relationship discovery (12 hops)
 |   |   |-- community_detector.py    #   Schema clustering via community detection
@@ -291,7 +291,7 @@ Each MCP session maintains its own `SessionData` instance (`src/session.py`), wh
 - **GraphRAGState** -- GraphRAG manager instance, initialization status (connection-scoped, accumulative)
 - **RDFStoreState** -- Oxigraph store instance (connection-scoped, multi-schema via named graphs)
 
-Ontology state is isolated per schema via `SchemaState`. GraphRAG and the Oxigraph RDF store are connection-scoped: each `analyze_schema()` call accumulates tables into the same graph and vector store, enabling cross-schema join path discovery and unified semantic search. Switching schemas (e.g., `analyze_schema("analytics")` after `analyze_schema("public")`) does not destroy the previous schema's ontology state, and both schemas' tables are searchable in GraphRAG simultaneously.
+Ontology state is isolated per schema via `SchemaState`. GraphRAG and the Oxigraph RDF store are connection-scoped: each `discover_schema()` call accumulates tables into the same graph and vector store, enabling cross-schema join path discovery and unified semantic search. Switching schemas (e.g., `discover_schema("analytics")` after `discover_schema("public")`) does not destroy the previous schema's ontology state, and both schemas' tables are searchable in GraphRAG simultaneously.
 
 This isolation prevents cross-session interference when multiple clients connect to the server simultaneously. Idle sessions are automatically evicted based on `SESSION_IDLE_TIMEOUT_SECONDS`.
 
@@ -301,7 +301,7 @@ This isolation prevents cross-session interference when multiple clients connect
 
 **Ontology triple storage**: RDF graphs embed SQL metadata using the `oba:` (OrionBelt Analytics) namespace. Tables become OWL classes with `oba:tableName` and `oba:primaryKey` annotations; relationships become OWL object properties with `oba:sqlJoinCondition`. The Oxigraph store provides persistent SPARQL 1.1 query access.
 
-**GraphRAG auto-initialization**: When `analyze_schema()` runs, GraphRAG is automatically initialized in the background (controlled by `AUTO_GRAPHRAG`). The graph structure supports up to 12-hop traversal for relationship discovery, and ChromaDB stores vector embeddings for semantic similarity search.
+**GraphRAG auto-initialization**: When `discover_schema()` runs, GraphRAG is automatically initialized in the background (controlled by `AUTO_GRAPHRAG`). The graph structure supports up to 12-hop traversal for relationship discovery, and ChromaDB stores vector embeddings for semantic similarity search.
 
 **MCP resources**: Skills stored in `.claude/skills/` (fan-trap prevention, SQL best practices, chart examples, analytical workflow) are exposed as MCP resources via `@mcp.resource()` decorators.
 

--- a/docs/fan-trap-prevention.md
+++ b/docs/fan-trap-prevention.md
@@ -50,9 +50,9 @@ Result: **200** (each item row is duplicated per shipment). The query executes w
 
 OrionBelt Analytics applies fan-trap detection at three layers, each catching different scenarios.
 
-### Layer 1: Schema Analysis (`analyze_schema`)
+### Layer 1: Schema Analysis (`discover_schema`)
 
-When `analyze_schema()` inspects foreign keys, it flags any table that references multiple other tables as a potential fan-trap bridge:
+When `discover_schema()` inspects foreign keys, it flags any table that references multiple other tables as a potential fan-trap bridge:
 
 ```python
 # From src/handlers/schema.py
@@ -67,7 +67,7 @@ if len(table_info.foreign_keys) > 1:
     })
 ```
 
-These warnings appear in the `analyze_schema()` output so the LLM (or user) is aware of risky join paths before writing any SQL.
+These warnings appear in the `discover_schema()` output so the LLM (or user) is aware of risky join paths before writing any SQL.
 
 ### Layer 2: OBQC Query Validation (`validate_sql_syntax`)
 
@@ -324,7 +324,7 @@ Even with automatic detection, verify your results:
 
 3. **Use `validate_sql_syntax()` before execution.** It runs OBQC checks and will flag fan-trap risks in the response.
 
-4. **Review the `fan_trap_warnings` from `analyze_schema()`.** They list which tables have multiple foreign keys and are therefore fan-trap candidates.
+4. **Review the `fan_trap_warnings` from `discover_schema()`.** They list which tables have multiple foreign keys and are therefore fan-trap candidates.
 
 5. **Look at business expectations.** If a customer's total suddenly jumps by an order of magnitude after adding a second join, investigate.
 
@@ -348,7 +348,7 @@ Even with automatic detection, verify your results:
 
 ```
 1. connect_database()
-2. analyze_schema()        --> fan_trap_warnings in output
+2. discover_schema()        --> fan_trap_warnings in output
 3. generate_ontology()     --> oba:relationshipType annotations stored
 4. validate_sql_syntax()   --> OBQC checks for fan-trap patterns
 5. execute_sql_query()     --> runs with fan-trap protection active

--- a/docs/graphrag.md
+++ b/docs/graphrag.md
@@ -25,10 +25,10 @@ The subsystem lives under `src/graphrag/` and is composed of four core modules:
 
 ### Schema Discovery Workflow
 
-GraphRAG initialization follows a four-step pipeline, triggered automatically when `analyze_schema()` completes:
+GraphRAG initialization follows a four-step pipeline, triggered automatically when `discover_schema()` completes:
 
 ```
-analyze_schema()
+discover_schema()
     |
     v
 1. Create Embeddings
@@ -92,7 +92,7 @@ GraphRAG serves as the schema intelligence layer that bridges raw database struc
 
 ### 1. Schema Discovery (Analytics + GraphRAG)
 
-The starting point. Connect to a database, run `analyze_schema()`, and GraphRAG auto-initializes. At this stage you have:
+The starting point. Connect to a database, run `discover_schema()`, and GraphRAG auto-initializes. At this stage you have:
 
 - A complete graph of table relationships
 - Vector embeddings for semantic search
@@ -126,7 +126,7 @@ GraphRAG is what makes OBML model creation scalable. Without it, an LLM would ne
 
 ## Key Benefits
 
-**Zero-setup intelligence.** GraphRAG initializes automatically as part of `analyze_schema()`. No separate configuration, no manual graph definition, no embedding model training. Connect to a database, analyze the schema, and GraphRAG is ready.
+**Zero-setup intelligence.** GraphRAG initializes automatically as part of `discover_schema()`. No separate configuration, no manual graph definition, no embedding model training. Connect to a database, analyze the schema, and GraphRAG is ready.
 
 **Automatic relationship discovery.** Foreign key relationships are extracted from the database catalog and built into a traversable graph. Join paths between any two tables are found algorithmically (shortest path with up to 12 hops), including mixed-direction paths where FK arrows point in different directions.
 
@@ -152,7 +152,7 @@ tmp/
     communities_{schema}.json     # Community assignments and summaries
 ```
 
-GraphRAG is connection-scoped and accumulative. Each `analyze_schema()` call adds tables to the same graph and vector store, enabling cross-schema join path discovery and unified semantic search. The combined state file (`graph_combined.json`) stores all accumulated schemas in a single graph; per-schema files are saved alongside for backward compatibility.
+GraphRAG is connection-scoped and accumulative. Each `discover_schema()` call adds tables to the same graph and vector store, enabling cross-schema join path discovery and unified semantic search. The combined state file (`graph_combined.json`) stores all accumulated schemas in a single graph; per-schema files are saved alongside for backward compatibility.
 
 ChromaDB uses its own persistent storage that reconnects automatically when a new `GraphRAGManager` is created with the same `connection_id`. The JSON files serve as backup and contain the `tables_info` needed to rebuild the NetworkX graph and community assignments.
 
@@ -167,7 +167,7 @@ connect_database("postgresql")
 
 This restores:
 
-1. **Schema cache** -- The analyzed table metadata, so `analyze_schema()` does not need to re-query the database catalog.
+1. **Schema cache** -- The analyzed table metadata, so `discover_schema()` does not need to re-query the database catalog.
 2. **Ontology** -- The generated RDF/OWL file and its loaded state.
 3. **RDF store** -- The Oxigraph triple store with SPARQL query support.
 4. **GraphRAG** -- Vector embeddings (via ChromaDB reconnection), relationship graph (rebuilt from saved `tables_info`), and community assignments.

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -12,7 +12,7 @@ Complete reference for all OrionBelt Analytics MCP tools. These tools are invoke
 
 1. **connect_database** -- establish a secure database connection
 2. **list_schemas** -- discover available schemas
-3. **analyze_schema** -- extract schema structure with relationships (auto-generates R2RML)
+3. **discover_schema** -- extract schema structure with relationships (auto-generates R2RML)
 4. **generate_ontology** -- create semantic ontology with `oba:` annotations
 5. **suggest_semantic_names** -- identify cryptic/abbreviated names for review
 6. **apply_semantic_names** -- apply LLM-suggested improvements
@@ -27,7 +27,7 @@ Complete reference for all OrionBelt Analytics MCP tools. These tools are invoke
 ### Quick Data Exploration
 
 1. **connect_database** -- connect
-2. **analyze_schema** -- lightweight mode (default) for fast overview
+2. **discover_schema** -- lightweight mode (default) for fast overview
 3. **sample_table_data** -- preview actual data
 4. **execute_sql_query** -- run queries
 
@@ -101,7 +101,7 @@ Clear cached schema and/or ontology data to force re-analysis.
 
 ---
 
-### 4. analyze_schema
+### 4. discover_schema
 
 Analyze database schema and return table metadata with relationships. Automatically generates W3C R2RML mappings and triggers GraphRAG initialization in the background.
 
@@ -152,7 +152,7 @@ Get detailed metadata for a single table, including all columns, data types, key
 
 **Key Features:**
 - Requires `connect_database` first
-- Ideal companion to lightweight `analyze_schema` -- get full details for specific tables only
+- Ideal companion to lightweight `discover_schema` -- get full details for specific tables only
 - Returns foreign key targets with referenced table and column names
 
 ---
@@ -174,7 +174,7 @@ Generate an RDF/OWL ontology from the database schema with `oba:` (OrionBelt Ana
 **Returns:** Status message with ontology file path, table count, and (if auto-persisted) triple count and graph URI.
 
 **Key Features:**
-- Automatically uses cached schema from `analyze_schema` -- no need to pass schema data
+- Automatically uses cached schema from `discover_schema` -- no need to pass schema data
 - Returns cached result if ontology was already generated this session
 - Generates OWL classes for tables with `oba:tableName`, `oba:primaryKey` annotations
 - Generates OWL ObjectProperties for relationships with `oba:sqlJoinCondition`
@@ -413,7 +413,7 @@ Delete all workspace files for the current database connection and clear session
 **Key Features:**
 - Removes the workspace directory (`tmp/{connection_id}/`), Oxigraph RDF store, and ChromaDB vector store
 - Clears all in-memory session state (schema cache, ontology, GraphRAG, RDF store)
-- Database connection stays active -- call `analyze_schema()` to start fresh
+- Database connection stays active -- call `discover_schema()` to start fresh
 - Safe: only affects the current connection's workspace, not other sessions
 
 ---

--- a/integrations/chatgpt-custom-gpt/README.md
+++ b/integrations/chatgpt-custom-gpt/README.md
@@ -80,7 +80,7 @@ If using Option 1 (bridge):
 |------|-------------|
 | `connect_database` | Connect to PostgreSQL, Snowflake, Dremio, ClickHouse, or MySQL |
 | `list_schemas` | Discover available database schemas |
-| `analyze_schema` | Analyze schema structure with relationships |
+| `discover_schema` | Analyze schema structure with relationships |
 | `get_table_details` | Deep-dive into a specific table |
 | `generate_ontology` | Generate RDF/OWL ontology with SQL mappings |
 | `validate_sql_syntax` | Validate SQL syntax, security, and fan-trap risks |

--- a/integrations/chatgpt-custom-gpt/instructions.md
+++ b/integrations/chatgpt-custom-gpt/instructions.md
@@ -12,7 +12,7 @@ Users describe what they want in natural language, and you use the available too
 
 1. **Connect first.** Call `connect_database` with the database type (postgresql, snowflake, dremio, clickhouse, or mysql). Credentials are configured server-side via environment variables.
 
-2. **Discover schemas.** Call `list_schemas` to see available schemas, then `analyze_schema` to get the full structure with table relationships.
+2. **Discover schemas.** Call `list_schemas` to see available schemas, then `discover_schema` to get the full structure with table relationships.
 
 3. **Deep-dive tables.** Use `get_table_details` for detailed column info, constraints, and foreign keys for specific tables.
 

--- a/integrations/crewai/README.md
+++ b/integrations/crewai/README.md
@@ -56,7 +56,7 @@ All MCP tools are automatically available. Key tools include:
 |------|-------------|
 | `connect_database` | Connect to PostgreSQL, Snowflake, Dremio, ClickHouse, or MySQL |
 | `list_schemas` | Discover available database schemas |
-| `analyze_schema` | Analyze schema structure with relationships |
+| `discover_schema` | Analyze schema structure with relationships |
 | `get_table_details` | Deep-dive into a specific table |
 | `generate_ontology` | Generate RDF/OWL ontology with SQL mappings |
 | `validate_sql_syntax` | Validate SQL syntax, security, and fan-trap risks |

--- a/integrations/crewai/crew_example.py
+++ b/integrations/crewai/crew_example.py
@@ -65,7 +65,7 @@ analyze_task = Task(
     description=(
         "1. Connect to PostgreSQL using connect_database.\n"
         "2. List available schemas using list_schemas.\n"
-        "3. Analyze the 'public' schema using analyze_schema.\n"
+        "3. Analyze the 'public' schema using discover_schema.\n"
         "4. Get details for the most important tables.\n"
         "5. Generate an ontology for the schema."
     ),

--- a/integrations/google-adk/README.md
+++ b/integrations/google-adk/README.md
@@ -82,7 +82,7 @@ All MCP tools are automatically available. Key tools include:
 |------|-------------|
 | `connect_database` | Connect to PostgreSQL, Snowflake, Dremio, ClickHouse, or MySQL |
 | `list_schemas` | Discover available database schemas |
-| `analyze_schema` | Analyze schema structure with relationships |
+| `discover_schema` | Analyze schema structure with relationships |
 | `get_table_details` | Deep-dive into a specific table |
 | `generate_ontology` | Generate RDF/OWL ontology with SQL mappings |
 | `validate_sql_syntax` | Validate SQL syntax, security, and fan-trap risks |

--- a/integrations/google-adk/agent_example.py
+++ b/integrations/google-adk/agent_example.py
@@ -30,7 +30,7 @@ Workflow:
 1. Call connect_database to establish a connection (postgresql, snowflake,
    dremio, clickhouse, or mysql).
 2. Call list_schemas to discover available schemas.
-3. Call analyze_schema to get the schema structure with relationships.
+3. Call discover_schema to get the schema structure with relationships.
 4. Use get_table_details for deep-dive into specific tables.
 5. Call generate_ontology to create RDF/OWL ontology with SQL mappings.
 6. Use execute_sql_query to run SQL (set checklist_completed=true) — validation is built-in.

--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -57,7 +57,7 @@ All MCP tools are automatically available. Key tools include:
 |------|-------------|
 | `connect_database` | Connect to PostgreSQL, Snowflake, Dremio, ClickHouse, or MySQL |
 | `list_schemas` | Discover available database schemas |
-| `analyze_schema` | Analyze schema structure with relationships |
+| `discover_schema` | Analyze schema structure with relationships |
 | `get_table_details` | Deep-dive into a specific table |
 | `generate_ontology` | Generate RDF/OWL ontology with SQL mappings |
 | `validate_sql_syntax` | Validate SQL syntax, security, and fan-trap risks |

--- a/integrations/langchain/agent_example.py
+++ b/integrations/langchain/agent_example.py
@@ -28,7 +28,7 @@ safe SQL queries with fan-trap prevention.
 1. Call connect_database to establish a connection (postgresql, snowflake,
    dremio, clickhouse, or mysql).
 2. Call list_schemas to discover available schemas.
-3. Call analyze_schema to get the schema structure with relationships.
+3. Call discover_schema to get the schema structure with relationships.
 4. Use get_table_details for deep-dive into specific tables.
 5. Call generate_ontology to create RDF/OWL ontology with SQL mappings.
 6. Use execute_sql_query to run SQL (set checklist_completed=true) — validation is built-in.

--- a/integrations/n8n/README.md
+++ b/integrations/n8n/README.md
@@ -56,7 +56,7 @@ The MCP Client Tool auto-discovers all tools. Key tools include:
 |------|-------------|
 | `connect_database` | Connect to PostgreSQL, Snowflake, Dremio, ClickHouse, or MySQL |
 | `list_schemas` | Discover available database schemas |
-| `analyze_schema` | Analyze schema structure with relationships |
+| `discover_schema` | Analyze schema structure with relationships |
 | `get_table_details` | Deep-dive into a specific table |
 | `generate_ontology` | Generate RDF/OWL ontology with SQL mappings |
 | `validate_sql_syntax` | Validate SQL syntax, security, and fan-trap risks |

--- a/integrations/n8n/workflow_ai_agent.json
+++ b/integrations/n8n/workflow_ai_agent.json
@@ -4,7 +4,7 @@
     {
       "parameters": {
         "options": {
-          "systemMessage": "You are a database intelligence assistant powered by OrionBelt Analytics. You help users analyze database schemas, generate ontologies, and write safe SQL queries.\n\nWorkflow:\n1. Call connect_database to establish a connection (postgresql, snowflake, dremio, clickhouse, or mysql).\n2. Call list_schemas to discover available schemas.\n3. Call analyze_schema to get the schema structure.\n4. Use generate_ontology to create RDF/OWL ontology.\n5. Use validate_sql_syntax before running queries.\n6. Use execute_sql_query to run validated SQL (set checklist_completed=true).\n7. Use generate_chart to visualize results.\n\nAlways validate SQL before execution. Set checklist_completed=true after validation."
+          "systemMessage": "You are a database intelligence assistant powered by OrionBelt Analytics. You help users analyze database schemas, generate ontologies, and write safe SQL queries.\n\nWorkflow:\n1. Call connect_database to establish a connection (postgresql, snowflake, dremio, clickhouse, or mysql).\n2. Call list_schemas to discover available schemas.\n3. Call discover_schema to get the schema structure.\n4. Use generate_ontology to create RDF/OWL ontology.\n5. Use validate_sql_syntax before running queries.\n6. Use execute_sql_query to run validated SQL (set checklist_completed=true).\n7. Use generate_chart to visualize results.\n\nAlways validate SQL before execution. Set checklist_completed=true after validation."
         }
       },
       "id": "ai-agent",

--- a/integrations/openai-agents-sdk/README.md
+++ b/integrations/openai-agents-sdk/README.md
@@ -51,7 +51,7 @@ All MCP tools are automatically available. Key tools include:
 |------|-------------|
 | `connect_database` | Connect to PostgreSQL, Snowflake, Dremio, ClickHouse, or MySQL |
 | `list_schemas` | Discover available database schemas |
-| `analyze_schema` | Analyze schema structure with relationships |
+| `discover_schema` | Analyze schema structure with relationships |
 | `get_table_details` | Deep-dive into a specific table |
 | `generate_ontology` | Generate RDF/OWL ontology with SQL mappings |
 | `validate_sql_syntax` | Validate SQL syntax, security, and fan-trap risks |

--- a/integrations/openai-agents-sdk/agent_example.py
+++ b/integrations/openai-agents-sdk/agent_example.py
@@ -28,7 +28,7 @@ safe SQL queries with fan-trap prevention.
 1. Call connect_database to establish a connection (postgresql, snowflake,
    dremio, clickhouse, or mysql).
 2. Call list_schemas to discover available schemas.
-3. Call analyze_schema to get the schema structure with relationships.
+3. Call discover_schema to get the schema structure with relationships.
 4. Use get_table_details for deep-dive into specific tables.
 5. Call generate_ontology to create RDF/OWL ontology with SQL mappings.
 6. Use execute_sql_query to run SQL (set checklist_completed=true) — validation is built-in.

--- a/integrations/vercel-ai-sdk/README.md
+++ b/integrations/vercel-ai-sdk/README.md
@@ -78,7 +78,7 @@ All MCP tools are automatically available. Key tools include:
 |------|-------------|
 | `connect_database` | Connect to PostgreSQL, Snowflake, Dremio, ClickHouse, or MySQL |
 | `list_schemas` | Discover available database schemas |
-| `analyze_schema` | Analyze schema structure with relationships |
+| `discover_schema` | Analyze schema structure with relationships |
 | `get_table_details` | Deep-dive into a specific table |
 | `generate_ontology` | Generate RDF/OWL ontology with SQL mappings |
 | `validate_sql_syntax` | Validate SQL syntax, security, and fan-trap risks |

--- a/integrations/vercel-ai-sdk/route-example.ts
+++ b/integrations/vercel-ai-sdk/route-example.ts
@@ -21,7 +21,7 @@ You help users analyze database schemas, generate ontologies, and write safe SQL
 Workflow:
 1. Call connect_database to establish a connection (postgresql, snowflake, dremio, clickhouse, or mysql).
 2. Call list_schemas to discover available schemas.
-3. Call analyze_schema to get the schema structure with relationships.
+3. Call discover_schema to get the schema structure with relationships.
 4. Use get_table_details for deep-dive into specific tables.
 5. Call generate_ontology to create RDF/OWL ontology with SQL mappings.
 6. Use validate_sql_syntax before running queries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-analytics"
-version = "1.4.0"
+version = "1.4.1"
 description = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "ralf.becher@web.de"}]
 readme = "README.md"

--- a/server.py
+++ b/server.py
@@ -55,7 +55,7 @@ def print_startup_info():
         "Connection & Schema": [
             "connect_database - Connect to any supported database",
             "list_schemas - List available database schemas",
-            "analyze_schema - Analyze schema with auto GraphRAG + ontology",
+            "discover_schema - Analyze schema with auto GraphRAG + ontology",
             "get_table_details - Detailed table metadata and columns",
             "reset_cache - Clear cached schema and ontology data",
             "cleanup_workspace - Delete workspace files and start fresh",
@@ -73,7 +73,7 @@ def print_startup_info():
             "generate_chart - Generate Plotly charts with MCP-UI rendering",
         ],
         "GraphRAG": [
-            "graphrag_search - Semantic search + overview (auto-initialized by analyze_schema)",
+            "graphrag_search - Semantic search + overview (auto-initialized by discover_schema)",
             "graphrag_query_context - Optimized context for SQL generation",
             "graphrag_find_join_path - Discover join paths via graph traversal",
         ],

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """OrionBelt Analytics - Ontology-based MCP server for your Text-2-SQL convenience."""
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 __author__ = "OrionBelt Analytics Contributors"
 __email__ = "contributors@example.com"
 __description__ = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"

--- a/src/handlers/connection.py
+++ b/src/handlers/connection.py
@@ -336,7 +336,7 @@ async def list_schemas(ctx: Context, get_session_db_manager):
     db_manager = get_session_db_manager(ctx)
     schemas = db_manager.get_schemas()
     if schemas:
-        await ctx.info(f"Found {len(schemas)} schemas; next call should be analyze_schema")
+        await ctx.info(f"Found {len(schemas)} schemas; next call should be discover_schema")
     else:
         await ctx.info("No schemas found")
     return schemas if schemas else []

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -335,7 +335,7 @@ async def graphrag_search(
 
     if not session.graphrag_initialized or session.graphrag_manager is None:
         return create_error_response(
-            "GraphRAG not initialized. Please call analyze_schema() first.",
+            "GraphRAG not initialized. Please call discover_schema() first.",
             "graphrag_not_initialized",
         )
 
@@ -366,7 +366,7 @@ async def graphrag_query_context(
 
     if not session.graphrag_initialized or session.graphrag_manager is None:
         return create_error_response(
-            "GraphRAG not initialized. Please call analyze_schema() first.",
+            "GraphRAG not initialized. Please call discover_schema() first.",
             "graphrag_not_initialized",
         )
 
@@ -411,7 +411,7 @@ async def graphrag_find_join_path(
 
     if not session.graphrag_initialized or session.graphrag_manager is None:
         return create_error_response(
-            "GraphRAG not initialized. Please call analyze_schema() first.",
+            "GraphRAG not initialized. Please call discover_schema() first.",
             "graphrag_not_initialized",
         )
 
@@ -461,7 +461,7 @@ async def graphrag_overview(
 
     if not session.graphrag_initialized or session.graphrag_manager is None:
         return create_error_response(
-            "GraphRAG not initialized. Please call analyze_schema() first.",
+            "GraphRAG not initialized. Please call discover_schema() first.",
             "graphrag_not_initialized",
         )
 

--- a/src/handlers/info.py
+++ b/src/handlers/info.py
@@ -37,7 +37,7 @@ async def get_server_info(ctx: Context) -> Dict[str, Any]:
         "tools": [
             "connect_database",
             "list_schemas",
-            "analyze_schema",
+            "discover_schema",
             "get_table_details",
             "generate_ontology",
             "suggest_semantic_names",

--- a/src/handlers/ontology.py
+++ b/src/handlers/ontology.py
@@ -123,7 +123,7 @@ async def generate_ontology(
                 f"# ONTOLOGY ALREADY CACHED AND ENRICHED\n\n"
                 f"Ontology file: {session.ontology_file}\n\n"
                 f"Semantic names have already been applied. The ontology is ready to use.\n\n"
-                f"Do NOT call generate_ontology, analyze_schema, or suggest_semantic_names again.\n\n"
+                f"Do NOT call generate_ontology, discover_schema, or suggest_semantic_names again.\n\n"
                 f"## READY TO USE:\n"
                 f"- query_sparql() for semantic queries\n"
                 f"- execute_sql_query() for data queries (includes built-in validation)"
@@ -132,7 +132,7 @@ async def generate_ontology(
         return (
             f"# ONTOLOGY ALREADY CACHED\n\n"
             f"Ontology file: {session.ontology_file}\n\n"
-            f"Do NOT call generate_ontology or analyze_schema again!\n\n"
+            f"Do NOT call generate_ontology or discover_schema again!\n\n"
             f"## FOR ENRICHMENT:\n"
             f"Call suggest_semantic_names() NOW - it will use the cached ontology automatically.\n\n"
             f"That's the ONLY tool you need to call for enrichment!"
@@ -198,7 +198,7 @@ async def generate_ontology(
             schema_name = effective_schema
             tables_info = cached_tables
             logger.info(
-                f"Using CACHED schema from analyze_schema: {len(tables_info)} tables (no re-query needed)"
+                f"Using CACHED schema from discover_schema: {len(tables_info)} tables (no re-query needed)"
             )
             await ctx.info(f"Using cached schema: {len(tables_info)} tables - no database queries needed")
         else:
@@ -930,7 +930,7 @@ async def download_r2rml(
                     "success": False,
                     "error": "No schema_name provided and no schema in session",
                     "error_type": "parameter_error",
-                    "hint": "Provide schema_name parameter or run analyze_schema() first",
+                    "hint": "Provide schema_name parameter or run discover_schema() first",
                 }
 
         schema_safe = schema_name.replace(" ", "_").replace(".", "_")
@@ -948,7 +948,7 @@ async def download_r2rml(
                     "success": False,
                     "error": f"No R2RML file found for schema '{schema_name}' in connection folder",
                     "error_type": "file_not_found",
-                    "hint": "Run analyze_schema() first to generate R2RML mapping",
+                    "hint": "Run discover_schema() first to generate R2RML mapping",
                 }
         else:
             r2rml_file_path = conn_dir / r2rml_filename
@@ -958,7 +958,7 @@ async def download_r2rml(
                 "success": False,
                 "error": f"R2RML file not found: {r2rml_file_path}",
                 "error_type": "file_not_found",
-                "hint": "Run analyze_schema() to generate R2RML mapping",
+                "hint": "Run discover_schema() to generate R2RML mapping",
             }
 
         with open(r2rml_file_path, "r", encoding="utf-8") as f:

--- a/src/handlers/schema.py
+++ b/src/handlers/schema.py
@@ -516,6 +516,7 @@ async def sample_table_data(
     table_name: str,
     schema_name: Optional[str],
     limit: int,
+    get_session_data,
     get_session_db_manager,
 ) -> List[Dict[str, Any]]:
     """Sample data from a specific table for analysis.
@@ -525,6 +526,7 @@ async def sample_table_data(
         table_name: Name of the table to sample
         schema_name: Schema containing the table
         limit: Maximum number of rows to return
+        get_session_data: Function to get session data
         get_session_db_manager: Function to get session db manager
     """
     if not table_name:
@@ -532,6 +534,10 @@ async def sample_table_data(
 
     if limit <= 0 or limit > 100:
         limit = 10
+
+    if not schema_name:
+        session = get_session_data(ctx)
+        schema_name = session.get_last_analyzed_schema()
 
     db_manager = get_session_db_manager(ctx)
     sample_data = db_manager.sample_table_data(table_name, schema_name, limit)

--- a/src/handlers/schema.py
+++ b/src/handlers/schema.py
@@ -450,6 +450,7 @@ async def get_table_details(
     ctx: Context,
     table_name: str,
     schema_name: Optional[str],
+    get_session_data,
     get_session_db_manager,
 ) -> Dict[str, Any]:
     """Get detailed metadata for a single table.
@@ -458,8 +459,46 @@ async def get_table_details(
         ctx: FastMCP context
         table_name: Name of the table to analyze
         schema_name: Schema containing the table
+        get_session_data: Function to get session data
         get_session_db_manager: Function to get session db manager
     """
+    session = get_session_data(ctx)
+
+    if not schema_name:
+        schema_name = session.get_last_analyzed_schema()
+
+    # Return from cache if schema was already discovered
+    cached_tables = session.get_cached_schema(schema_name or "")
+    if cached_tables:
+        for t in cached_tables:
+            if t.name.lower() == table_name.lower():
+                await ctx.info(
+                    f"Table '{table_name}' found in cache — no database call needed"
+                )
+                return {
+                    "success": True,
+                    "name": t.name,
+                    "schema": t.schema,
+                    "columns": [
+                        {
+                            "name": col.name,
+                            "data_type": col.data_type,
+                            "is_nullable": col.is_nullable,
+                            "is_primary_key": col.is_primary_key,
+                            "is_foreign_key": col.is_foreign_key,
+                            "foreign_key_table": col.foreign_key_table,
+                            "foreign_key_column": col.foreign_key_column,
+                            "comment": col.comment,
+                        }
+                        for col in t.columns
+                    ],
+                    "primary_keys": t.primary_keys,
+                    "foreign_keys": t.foreign_keys,
+                    "comment": t.comment,
+                    "row_count": t.row_count,
+                    "cache_hit": True,
+                }
+
     db_manager = get_session_db_manager(ctx)
 
     try:

--- a/src/handlers/schema.py
+++ b/src/handlers/schema.py
@@ -82,12 +82,25 @@ async def discover_schema(
     # Log function entry to verify code is being called
     logger.debug(f"discover_schema() called - schema: '{schema_name}', lightweight: {lightweight}")
 
-    # Check cache
     session = get_session_data(ctx)
     effective_schema = schema_name or ""
 
     # Set current schema so per-schema state (ontology, GraphRAG) is isolated
     session.set_current_schema(effective_schema or "default")
+
+    # Early exit: workspace already fully restored — nothing to do
+    if session.ontology_enriched and session.get_cached_schema(effective_schema):
+        await ctx.info("Schema already discovered and ontology enriched — skipping.")
+        return {
+            "schema": effective_schema or "default",
+            "status": "already_complete",
+            "message": (
+                "Schema is already discovered and the ontology is enriched. "
+                "Nothing to do. Use execute_sql_query() to query data, "
+                "query_sparql() for semantic queries, or graphrag_search() "
+                "for schema navigation."
+            ),
+        }
 
     cached_tables = session.get_cached_schema(effective_schema)
 

--- a/src/handlers/schema.py
+++ b/src/handlers/schema.py
@@ -51,15 +51,15 @@ async def reset_cache(
     return {
         "status": "success",
         "cleared_caches": cleared,
-        "message": f"Cleared {', '.join(cleared)} cache(s). You can now re-run analyze_schema and/or generate_ontology.",
+        "message": f"Cleared {', '.join(cleared)} cache(s). You can now re-run discover_schema and/or generate_ontology.",
         "next_steps": {
-            "schema": "Call analyze_schema() to re-analyze database schema",
+            "schema": "Call discover_schema() to re-analyze database schema",
             "ontology": "Call generate_ontology() to regenerate ontology",
         },
     }
 
 
-async def analyze_schema(
+async def discover_schema(
     ctx: Context,
     schema_name: Optional[str],
     lightweight: bool,
@@ -80,7 +80,7 @@ async def analyze_schema(
         _auto_initialize_graphrag_background: Background init function
     """
     # Log function entry to verify code is being called
-    logger.debug(f"analyze_schema() called - schema: '{schema_name}', lightweight: {lightweight}")
+    logger.debug(f"discover_schema() called - schema: '{schema_name}', lightweight: {lightweight}")
 
     # Check cache
     session = get_session_data(ctx)
@@ -148,7 +148,7 @@ async def analyze_schema(
                 "message": f"Schema already CACHED ({len(cached_tables)} tables). Call generate_ontology() next.",
                 "schema_file": session.schema_file,
                 "next_step": "generate_ontology",
-                "instruction": "Call generate_ontology() NOW - do NOT call analyze_schema again!",
+                "instruction": "Call generate_ontology() NOW - do NOT call discover_schema again!",
             }
             if auto_graphrag == "true":
                 result["graphrag_auto_init"] = "started in background (from cache)"
@@ -358,7 +358,7 @@ async def analyze_schema(
             "recommended": "generate_ontology",
             "reason": "Generate ontology with database schema linking for accurate SQL generation and fan-trap prevention",
             "workflow": [
-                "1. analyze_schema (completed - schema is now CACHED)",
+                "1. discover_schema (completed - schema is now CACHED)",
                 "2. generate_ontology (recommended next - will use cached schema automatically)",
                 "3. execute_sql_query (with ontology context)",
             ],
@@ -366,13 +366,13 @@ async def analyze_schema(
         schema_result["schema_cached"] = True
         schema_result["cache_hint"] = (
             "IMPORTANT: Schema analysis is now CACHED for this session. "
-            "Do NOT call analyze_schema again - just call generate_ontology() directly. "
+            "Do NOT call discover_schema again - just call generate_ontology() directly. "
             "It will automatically use the cached schema data."
         )
         schema_result["analytical_guidance"] = (
             "Recommended next step: Run generate_ontology() - NO parameters needed!\n\n"
             "The schema is CACHED - generate_ontology will use it automatically.\n"
-            "Do NOT call analyze_schema again.\n\n"
+            "Do NOT call discover_schema again.\n\n"
             "This will create an ontology with:\n"
             "- Database schema linking (oba: namespace)\n"
             "- SQL column references for queries\n"

--- a/src/handlers/workspace.py
+++ b/src/handlers/workspace.py
@@ -227,7 +227,7 @@ def _format_restore_summary(result: Dict[str, Any]) -> str:
     # Build "do not call" list
     skip_tools = []
     if "Schema '" in restored_str or "Ontology '" in restored_str:
-        skip_tools.append("analyze_schema()")
+        skip_tools.append("discover_schema()")
     if "Ontology '" in restored_str:
         skip_tools.append("generate_ontology()")
         if ontology_enriched:
@@ -345,7 +345,7 @@ async def cleanup_workspace(
 
     result += "\n## Session State Cleared\n"
     result += "- Schema cache, ontology, GraphRAG, RDF store\n\n"
-    result += "Call analyze_schema() to start building a new workspace.\n"
+    result += "Call discover_schema() to start building a new workspace.\n"
 
     return result
 

--- a/src/main.py
+++ b/src/main.py
@@ -812,6 +812,11 @@ async def execute_sql_query(
     """Execute SQL query with built-in syntax validation, security checks, OBQC
     validation, and fan-trap protection.
 
+    PREFER SEMANTIC LAYER: If the OrionBelt Semantic Layer MCP server is available,
+    create an OBML model and use execute_query/compile_query instead of raw SQL.
+    Only use this tool when no semantic model is loaded or the user explicitly asks
+    for raw SQL.
+
     Automatically validates SQL syntax and security before execution. If an ontology
     is loaded, OBQC checks (fan-trap detection, semantic validation) run too — errors
     block execution, warnings are included in the result.

--- a/src/main.py
+++ b/src/main.py
@@ -608,16 +608,21 @@ async def get_table_details(
     table_name: str,
     schema_name: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Get detailed metadata for a single table.
+    """Get detailed metadata for a single table. Only use when you need to
+    inspect a specific table that the user asked about — do NOT call this for
+    every table. discover_schema() and the ontology already contain full
+    schema structure including columns, keys, and relationships.
 
     REQUIRES: connect_database must be called first.
 
     Args:
         table_name: Name of the table to analyze
-        schema_name: Schema containing the table (optional)
+        schema_name: Schema containing the table (optional, auto-detected)
     """
     return await _h_schema.get_table_details(
-        ctx, table_name, schema_name, get_session_db_manager=get_session_db_manager
+        ctx, table_name, schema_name,
+        get_session_data=get_session_data,
+        get_session_db_manager=get_session_db_manager,
     )
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -790,7 +790,9 @@ async def sample_table_data(
         limit: Maximum number of rows to return (default: 10, max: 100)
     """
     return await _h_schema.sample_table_data(
-        ctx, table_name, schema_name, limit, get_session_db_manager=get_session_db_manager
+        ctx, table_name, schema_name, limit,
+        get_session_data=get_session_data,
+        get_session_db_manager=get_session_db_manager,
     )
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -77,7 +77,7 @@ Semantic database analysis with ontology-enhanced Text-to-SQL generation.
 
 1. `connect_database()` -> Establish secure connection
 2. `list_schemas()` -> Discover available schemas
-3. `analyze_schema()` -> Get schema structure with relationships
+3. `discover_schema()` -> Get schema structure with relationships
 4. `generate_ontology()` -> Create semantic ontology with oba: annotations
 5. `execute_sql_query()` -> Run validated SQL with fan-trap protection
 6. `generate_chart()` -> Visualize results
@@ -109,7 +109,7 @@ Semantic database analysis with ontology-enhanced Text-to-SQL generation.
 ## Important Notes
 
 - Always fully qualify identifiers: `schema.table.column`
-- Review foreign_keys from analyze_schema() before complex JOINs
+- Review foreign_keys from discover_schema() before complex JOINs
 - execute_sql_query() includes built-in syntax, security, and OBQC validation
 - For multi-fact aggregation, use UNION ALL pattern (see /fan-trap-prevention)
 
@@ -579,7 +579,7 @@ async def reset_cache(ctx: Context, cache_type: Optional[str] = None) -> Dict[st
 
 
 @mcp.tool()
-async def analyze_schema(
+async def discover_schema(
     ctx: Context,
     schema_name: Optional[str] = None,
     lightweight: bool = True,
@@ -593,7 +593,7 @@ async def analyze_schema(
         lightweight: If True (default), return minimal data (table names, FK relationships, fan-trap warnings).
                      If False, return full schema with all column details.
     """
-    return await _h_schema.analyze_schema(
+    return await _h_schema.discover_schema(
         ctx, schema_name, lightweight,
         get_session_data=get_session_data,
         get_session_db_manager=get_session_db_manager,
@@ -967,7 +967,7 @@ async def graphrag_search(
 ) -> Dict[str, Any]:
     """Search schema using natural language via GraphRAG, or get a schema overview.
 
-    GraphRAG is auto-initialized by analyze_schema. Pass overview=True to get
+    GraphRAG is auto-initialized by discover_schema. Pass overview=True to get
     schema statistics and community clustering instead of search results.
 
     Args:

--- a/src/workspace.py
+++ b/src/workspace.py
@@ -163,6 +163,6 @@ def format_workspace_summary(workspace: Dict[str, Any]) -> str:
 
     lines.append("")
     lines.append("NOTE: Auto-restore was not available. Workspace artifacts exist on disk.")
-    lines.append("Call analyze_schema() to re-analyze, or reconnect to trigger auto-restore.")
+    lines.append("Call discover_schema() to re-analyze, or reconnect to trigger auto-restore.")
 
     return "\n".join(lines)

--- a/tests/test_ontology_workflow_fix.py
+++ b/tests/test_ontology_workflow_fix.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Test that ontology generation works correctly after analyze_schema(lightweight=True).
+Test that ontology generation works correctly after discover_schema(lightweight=True).
 
 This test verifies the bug fix for Phase 2 where lightweight mode wasn't caching
 TableInfo objects, causing generate_ontology() to fail or re-query the database.
@@ -158,9 +158,9 @@ async def test_lightweight_caches_for_ontology(mock_context, mock_db_manager, tm
         session.cache_schema_analysis = Mock(side_effect=cache_schema)
         mock_session_data.return_value = session
 
-        # Step 1: Call analyze_schema in lightweight mode
+        # Step 1: Call discover_schema in lightweight mode
         # Use .fn accessor to handle both FunctionTool (under coverage) and plain function
-        analyze_fn = getattr(main_module.analyze_schema, 'fn', main_module.analyze_schema)
+        analyze_fn = getattr(main_module.discover_schema, 'fn', main_module.discover_schema)
         result = await analyze_fn(mock_context, schema_name="public", lightweight=True)
 
         # Verify lightweight result structure
@@ -330,10 +330,10 @@ async def test_full_workflow_lightweight_to_ontology(mock_context, mock_db_manag
         mock_server_state.get_ontology_generator.return_value = mock_generator
 
         # Use .fn accessor to handle both FunctionTool (under coverage) and plain function
-        analyze_fn = getattr(main_module.analyze_schema, 'fn', main_module.analyze_schema)
+        analyze_fn = getattr(main_module.discover_schema, 'fn', main_module.discover_schema)
         generate_fn = getattr(main_module.generate_ontology, 'fn', main_module.generate_ontology)
 
-        # Step 1: analyze_schema(lightweight=True)
+        # Step 1: discover_schema(lightweight=True)
         schema_result = await analyze_fn(mock_context, schema_name="public", lightweight=True)
 
         assert schema_result["mode"] == "lightweight"

--- a/tests/test_phase1_token_reduction.py
+++ b/tests/test_phase1_token_reduction.py
@@ -141,13 +141,13 @@ class TestPhase1TokenReduction:
         # Should mention chart-related content
         assert "chart" in docstring.lower()
 
-    def test_analyze_schema_docstring_condensed(self):
-        """Verify analyze_schema docstring is condensed."""
-        docstring = _get_tool_docstring('analyze_schema')
-        assert docstring is not None, "analyze_schema has no docstring"
+    def test_discover_schema_docstring_condensed(self):
+        """Verify discover_schema docstring is condensed."""
+        docstring = _get_tool_docstring('discover_schema')
+        assert docstring is not None, "discover_schema has no docstring"
 
         # Original was ~3,775 chars, should be much smaller now
-        assert len(docstring) < 3000, f"analyze_schema docstring not condensed: {len(docstring)} chars"
+        assert len(docstring) < 3000, f"discover_schema docstring not condensed: {len(docstring)} chars"
 
     @pytest.mark.asyncio
     async def test_all_tools_still_registered(self):
@@ -160,7 +160,7 @@ class TestPhase1TokenReduction:
             "connect_database",
             "list_schemas",
             "reset_cache",
-            "analyze_schema",
+            "discover_schema",
             "get_table_details",
             "generate_ontology",
             "suggest_semantic_names",
@@ -223,7 +223,7 @@ class TestFunctionalityPreserved:
         tool_names = [
             "connect_database",
             "list_schemas",
-            "analyze_schema",
+            "discover_schema",
             "generate_ontology",
             "execute_sql_query",
             "generate_chart"

--- a/tests/test_phase2_hierarchical.py
+++ b/tests/test_phase2_hierarchical.py
@@ -2,8 +2,8 @@
 Test suite for Phase 2 hierarchical schema retrieval changes.
 
 Verifies that:
-1. analyze_schema(lightweight=True) returns minimal data
-2. analyze_schema(lightweight=False) returns full schema
+1. discover_schema(lightweight=True) returns minimal data
+2. discover_schema(lightweight=False) returns full schema
 3. get_table_details() works correctly
 4. Token savings are achieved
 5. No functionality regression
@@ -38,11 +38,11 @@ def _get_tool_docstring(name):
 
 
 class TestPhase2LightweightMode:
-    """Test lightweight mode for analyze_schema()."""
+    """Test lightweight mode for discover_schema()."""
 
-    def test_analyze_schema_has_lightweight_parameter(self):
-        """Verify analyze_schema has lightweight parameter."""
-        fn = _get_tool_fn('analyze_schema')
+    def test_discover_schema_has_lightweight_parameter(self):
+        """Verify discover_schema has lightweight parameter."""
+        fn = _get_tool_fn('discover_schema')
         sig = inspect.signature(fn)
         params = sig.parameters
 
@@ -69,9 +69,9 @@ class TestPhase2LightweightMode:
         assert "table_name" in params
         assert "schema_name" in params
 
-    def test_analyze_schema_docstring_mentions_lightweight(self):
-        """Verify analyze_schema docstring explains lightweight mode."""
-        docstring = _get_tool_docstring('analyze_schema')
+    def test_discover_schema_docstring_mentions_lightweight(self):
+        """Verify discover_schema docstring explains lightweight mode."""
+        docstring = _get_tool_docstring('discover_schema')
         assert docstring is not None
 
         # Should explain lightweight mode
@@ -114,9 +114,9 @@ class TestPhase2TokenSavings:
 class TestPhase2FunctionalityPreserved:
     """Test that existing functionality still works."""
 
-    def test_analyze_schema_backward_compatible(self):
-        """Verify analyze_schema defaults to lightweight=True."""
-        fn = _get_tool_fn('analyze_schema')
+    def test_discover_schema_backward_compatible(self):
+        """Verify discover_schema defaults to lightweight=True."""
+        fn = _get_tool_fn('discover_schema')
         sig = inspect.signature(fn)
         lightweight_param = sig.parameters["lightweight"]
 
@@ -134,7 +134,7 @@ class TestPhase2FunctionalityPreserved:
             "connect_database",
             "list_schemas",
             "reset_cache",
-            "analyze_schema",
+            "discover_schema",
             "get_table_details",
             "generate_ontology",
             "suggest_semantic_names",
@@ -152,25 +152,25 @@ class TestPhase2FunctionalityPreserved:
 
     @pytest.mark.asyncio
     async def test_tool_order_preserved(self):
-        """Verify get_table_details is positioned after analyze_schema."""
+        """Verify get_table_details is positioned after discover_schema."""
         # list_tools() is async in FastMCP and returns list[FunctionTool]
         tools = await mcp.list_tools()
         tool_names = [t.name for t in tools]
 
-        analyze_idx = tool_names.index("analyze_schema")
+        analyze_idx = tool_names.index("discover_schema")
         get_details_idx = tool_names.index("get_table_details")
         generate_ont_idx = tool_names.index("generate_ontology")
 
-        # get_table_details should be between analyze_schema and generate_ontology
+        # get_table_details should be between discover_schema and generate_ontology
         assert analyze_idx < get_details_idx < generate_ont_idx
 
     def test_imports_still_work(self):
         """Verify all imports still work after changes."""
         try:
-            from src.main import mcp, analyze_schema, get_table_details
+            from src.main import mcp, discover_schema, get_table_details
             from src.database_manager import DatabaseManager, TableInfo, ColumnInfo
 
-            assert all([mcp, analyze_schema, get_table_details,
+            assert all([mcp, discover_schema, get_table_details,
                        DatabaseManager, TableInfo, ColumnInfo])
         except ImportError as e:
             pytest.fail(f"Import failed: {e}")
@@ -181,10 +181,10 @@ class TestPhase2HierarchicalWorkflow:
 
     def test_workflow_documentation_in_docstrings(self):
         """Verify hierarchical workflow is documented."""
-        analyze_doc = _get_tool_docstring('analyze_schema')
+        analyze_doc = _get_tool_docstring('discover_schema')
         details_doc = _get_tool_docstring('get_table_details')
 
-        # analyze_schema should mention lightweight mode
+        # discover_schema should mention lightweight mode
         assert "lightweight" in analyze_doc.lower()
 
         # get_table_details should mention table analysis
@@ -228,7 +228,7 @@ class TestPhase2HierarchicalWorkflow:
 class TestPhase2EdgeCases:
     """Test edge cases and error handling."""
 
-    def test_analyze_schema_with_no_tables(self):
+    def test_discover_schema_with_no_tables(self):
         """Test behavior when schema has no tables."""
         # This should be handled gracefully
         # Lightweight mode should return empty lists

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -395,7 +395,7 @@ class TestMCPToolsAsync:
             with pytest.raises(RuntimeError, match="No database connection"):
                 await main_module.list_schemas(mock_ctx)
 
-    async def test_analyze_schema_success(self, mock_ctx, mock_session_data, sample_users_table, sample_orders_table):
+    async def test_discover_schema_success(self, mock_ctx, mock_session_data, sample_users_table, sample_orders_table):
         """Test successful schema analysis with session isolation."""
         mock_db_manager = Mock()
         mock_db_manager.get_tables.return_value = ["users", "orders"]
@@ -412,7 +412,7 @@ class TestMCPToolsAsync:
              patch('builtins.open', MagicMock()), \
              patch('json.dump'):
 
-            result = await main_module.analyze_schema(mock_ctx, "public", lightweight=False)
+            result = await main_module.discover_schema(mock_ctx, "public", lightweight=False)
 
         assert isinstance(result, dict)
         assert result["schema"] == "public"
@@ -429,7 +429,7 @@ class TestMCPToolsAsync:
         orders_table = next(t for t in result["tables"] if t["name"] == "orders")
         assert len(orders_table["foreign_keys"]) == 1
 
-    async def test_analyze_schema_no_connection(self, mock_ctx, mock_session_data):
+    async def test_discover_schema_no_connection(self, mock_ctx, mock_session_data):
         """Test schema analysis without connection raises exception."""
         mock_db_manager = Mock()
         mock_db_manager.get_tables.side_effect = RuntimeError("No database connection")
@@ -440,7 +440,7 @@ class TestMCPToolsAsync:
 
             # The function raises exception (no internal error handling)
             with pytest.raises(RuntimeError, match="No database connection"):
-                await main_module.analyze_schema(mock_ctx, "public")
+                await main_module.discover_schema(mock_ctx, "public")
 
     async def test_generate_ontology_success(self, mock_ctx, mock_session_data, sample_users_table):
         """Test successful ontology generation with session isolation."""


### PR DESCRIPTION
## Summary
- Renamed `analyze_schema` → `discover_schema` across 35 files (128 occurrences) to avoid LLM confusion when users say "analyze my data"
- `discover_schema` returns early with `status: "already_complete"` when workspace is fully restored
- `get_table_details` returns cached data from session and discourages bulk usage in tool description
- `sample_table_data` auto-fills `schema_name` from session when omitted
- `execute_sql_query` tool description recommends semantic layer (OBML) when available
- Updated all integration examples, docs, skills, and tests

## Test plan
- [ ] `uv run pytest` passes
- [ ] Connect to a database, verify `discover_schema` returns early on second call
- [ ] Verify `get_table_details` uses cached schema data
- [ ] Verify `sample_table_data` auto-fills schema_name
- [ ] Verify `execute_sql_query` includes OBQC validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)