### PR TITLE
feat: generate_chart returns both ui:// and file:// URIs

### DIFF
--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -118,8 +118,23 @@ async def generate_chart(
                 ))
                 logger.info(f"Registered chart resource: {chart_uri}")
 
+            # Also export a static PNG for clients that don't render MCP Apps
+            file_uri = ""
+            try:
+                chart_id = str(uuid4())
+                image_bytes = fig.to_image(format="png", width=width, height=height)
+                session = get_session_data(ctx) if get_session_data else None
+                connection_id = session.connection_id if session else None
+                image_file_path = save_image_to_tmp(
+                    image_bytes, chart_id, "png", connection_id=connection_id
+                )
+                if image_file_path:
+                    file_uri = f"\nStatic image: file://{image_file_path}"
+            except Exception as e:
+                logger.debug(f"PNG fallback export failed (kaleido may not be installed): {e}")
+
             await ctx.info(f"Interactive {chart_type_display} chart with {data_points} data points")
-            return f"Chart generated: {chart_uri}"
+            return f"Chart generated: {chart_uri}{file_uri}"
         else:
             await ctx.info("Chart generation failed")
             raise RuntimeError("Chart generation failed: unexpected result format for interactive mode")


### PR DESCRIPTION
## Summary
- In interactive mode, `generate_chart` now also exports a static PNG and returns a `file://` URI alongside the `ui://` MCP App URI
- Clients that render MCP Apps (e.g. claude.ai) use the `ui://` widget; clients that don't (e.g. Claude Desktop) can display the `file://` PNG fallback
- PNG export is best-effort — if kaleido is not installed, only the `ui://` URI is returned

## Test plan
- [ ] Generate an interactive chart — verify both `ui://` and `file://` URIs in response
- [ ] Verify PNG file exists at the returned path
- [ ] Test without kaleido installed — verify graceful fallback (ui:// only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)