### PR TITLE
feat: chart improvements — JSON resource, multi-y bar, return_binary config

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -98,6 +98,13 @@ ONTOLOGY_BASE_URI=http://example.com/ontology/
 # Base IRI for R2RML subject templates (schema name will be appended)
 R2RML_BASE_IRI=http://mycompany.com/
 
+# Chart Output Configuration
+# --------------------------
+# Return inline binary image (ImageContent) from generate_chart responses.
+# When false (default), only text URIs (ui://, file://) are returned.
+# Set to true to include the PNG image bytes directly in the MCP response.
+CHART_RETURN_BINARY=false
+
 # Output directory for generated files (schema JSON, ontology TTL, R2RML, etc.)
 # Relative to project root. Default: tmp
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-analytics"
-version = "1.4.1"
+version = "1.4.2"
 description = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "ralf.becher@web.de"}]
 readme = "README.md"

--- a/src/chart_utils.py
+++ b/src/chart_utils.py
@@ -511,12 +511,12 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
     if show_legend:
         legend_config = dict(
             orientation="v",
-            yanchor="top",
-            y=0.65,
+            yanchor="middle",
+            y=0.5,
             xanchor="left",
             x=1.02
         )
-        margin_config = dict(b=100, t=80, l=60, r=200)
+        margin_config = dict(b=100, t=60, l=60, r=200)
     else:
         legend_config = dict()
         margin_config = dict(b=100, t=60, l=60, r=60)

--- a/src/chart_utils.py
+++ b/src/chart_utils.py
@@ -508,25 +508,18 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
     # Determine if we should show legend
     show_legend = bool(color_column or (isinstance(y_column, list) and chart_type in ["bar", "line"]))
 
-    # For line charts with multiple measures, use horizontal legend between title and plot
-    if chart_type == "line" and isinstance(y_column, list):
+    if show_legend:
         legend_config = dict(
             orientation="h",
             yanchor="bottom",
-            y=1.0,  # Position at top of plot area (below title)
+            y=1.0,
             xanchor="center",
             x=0.5
         )
-        margin_config = dict(b=100, t=120, l=60, r=60)  # Extra top margin for title and legend space
+        margin_config = dict(b=100, t=120, l=60, r=60)
     else:
-        legend_config = dict(
-            orientation="v",
-            yanchor="middle",
-            y=0.5,
-            xanchor="left",
-            x=1.02
-        )
-        margin_config = dict(b=100, t=60, l=60, r=200)  # Extra right margin for legend
+        legend_config = dict()
+        margin_config = dict(b=100, t=60, l=60, r=60)
 
     fig.update_layout(
         font=dict(size=12),

--- a/src/chart_utils.py
+++ b/src/chart_utils.py
@@ -535,6 +535,7 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
         margin=margin_config,
         showlegend=show_legend,
         legend=legend_config,
+        modebar=dict(bgcolor='white', color='gray', activecolor='black'),
         width=width,
         height=height
     )

--- a/src/chart_utils.py
+++ b/src/chart_utils.py
@@ -531,7 +531,6 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
         modebar=dict(
             bgcolor='white', color='gray', activecolor='black',
             orientation='h',
-            remove=['select2d', 'lasso2d', 'zoomIn2d', 'zoomOut2d', 'autoScale2d'],
         ),
         width=width,
         height=height

--- a/src/chart_utils.py
+++ b/src/chart_utils.py
@@ -508,8 +508,8 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
     # Determine if we should show legend
     show_legend = bool(color_column or (isinstance(y_column, list) and chart_type in ["bar", "line"]))
 
-    # For charts with multiple measures, use horizontal legend between title and plot
-    if isinstance(y_column, list) and chart_type in ["bar", "line"]:
+    # For line charts with multiple measures, use horizontal legend between title and plot
+    if chart_type == "line" and isinstance(y_column, list):
         legend_config = dict(
             orientation="h",
             yanchor="bottom",

--- a/src/chart_utils.py
+++ b/src/chart_utils.py
@@ -510,13 +510,13 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
 
     if show_legend:
         legend_config = dict(
-            orientation="h",
-            yanchor="bottom",
-            y=1.0,
-            xanchor="center",
-            x=0.5
+            orientation="v",
+            yanchor="top",
+            y=0.75,
+            xanchor="left",
+            x=1.02
         )
-        margin_config = dict(b=100, t=120, l=60, r=60)
+        margin_config = dict(b=100, t=60, l=60, r=200)
     else:
         legend_config = dict()
         margin_config = dict(b=100, t=60, l=60, r=60)

--- a/src/chart_utils.py
+++ b/src/chart_utils.py
@@ -528,7 +528,11 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
         margin=margin_config,
         showlegend=show_legend,
         legend=legend_config,
-        modebar=dict(bgcolor='white', color='gray', activecolor='black'),
+        modebar=dict(
+            bgcolor='white', color='gray', activecolor='black',
+            orientation='h',
+            remove=['select2d', 'lasso2d', 'zoomIn2d', 'zoomOut2d', 'autoScale2d'],
+        ),
         width=width,
         height=height
     )

--- a/src/chart_utils.py
+++ b/src/chart_utils.py
@@ -512,11 +512,11 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
         legend_config = dict(
             orientation="v",
             yanchor="top",
-            y=0.75,
+            y=0.65,
             xanchor="left",
             x=1.02
         )
-        margin_config = dict(b=100, t=60, l=60, r=200)
+        margin_config = dict(b=100, t=80, l=60, r=200)
     else:
         legend_config = dict()
         margin_config = dict(b=100, t=60, l=60, r=60)

--- a/src/chart_utils.py
+++ b/src/chart_utils.py
@@ -506,10 +506,10 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
     
     # Apply consistent styling
     # Determine if we should show legend
-    show_legend = bool(color_column or (chart_type == "line" and isinstance(y_column, list)))
+    show_legend = bool(color_column or (isinstance(y_column, list) and chart_type in ["bar", "line"]))
 
-    # For line charts with multiple measures, use horizontal legend between title and plot
-    if chart_type == "line" and isinstance(y_column, list):
+    # For charts with multiple measures, use horizontal legend between title and plot
+    if isinstance(y_column, list) and chart_type in ["bar", "line"]:
         legend_config = dict(
             orientation="h",
             yanchor="bottom",

--- a/src/chart_utils.py
+++ b/src/chart_utils.py
@@ -154,7 +154,7 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
     """Create Plotly chart based on type.
 
     Args:
-        y_column: Can be a string (single measure) or list of strings (multiple measures for line charts)
+        y_column: Can be a string (single measure) or list of strings (multiple measures for bar/line charts)
         sort_by: Column to sort by. If None, uses automatic sorting based on chart type:
             - Bar/grouped/stacked: sorts by measure (y_column) descending
             - Line: sorts by dimension (x_column) ascending
@@ -200,13 +200,32 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
         if is_chronological:
             effective_sort_by = sort_by if sort_by is not None else x_column
             effective_sort_order = sort_order if sort_order is not None else 'ascending'
+        elif isinstance(y_column, list):
+            effective_sort_by = sort_by if sort_by else x_column
+            effective_sort_order = sort_order if sort_order else 'ascending'
         else:
             effective_sort_by = sort_by if sort_by else y_column
             effective_sort_order = sort_order if sort_order else 'descending'
 
         sort_ascending = (effective_sort_order == 'ascending')
 
-        if chart_style == "stacked" and color_column:
+        if isinstance(y_column, list):
+            agg_df = df.groupby(x_column, as_index=False)[y_column].sum()
+            agg_df = _clean_dataframe_for_plotly(agg_df)
+            quarter_order = get_quarter_sort_order(agg_df[x_column].unique(), ascending=sort_ascending)
+            if quarter_order:
+                category_order = quarter_order
+            else:
+                sorted_df = agg_df.sort_values(by=effective_sort_by, ascending=sort_ascending)
+                category_order = sorted_df[x_column].tolist()
+            barmode = 'stack' if chart_style == 'stacked' else 'group'
+            labels = {x_column: format_measure_name(x_column)}
+            labels.update({col: format_measure_name(col) for col in y_column})
+            fig = px.bar(agg_df, x=x_column, y=y_column, title=title,
+                        barmode=barmode, category_orders={x_column: category_order},
+                        labels=labels)
+            fig.update_layout(bargap=0.15, bargroupgap=0.05)
+        elif chart_style == "stacked" and color_column:
             # Stacked bar chart with two dimensions: x_column (categories) and color_column (stack groups)
             # Aggregate data first to handle duplicates
             agg_df = df.groupby([x_column, color_column], as_index=False)[y_column].sum()

--- a/src/config.py
+++ b/src/config.py
@@ -29,6 +29,7 @@ class ServerConfig:
     mcp_server_port: int = 9000
     session_idle_timeout: int = DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS
     session_scan_interval: int = DEFAULT_SESSION_SCAN_INTERVAL_SECONDS
+    chart_return_binary: bool = False
 
     def __post_init__(self):
         """Validate configuration after initialization."""
@@ -107,7 +108,8 @@ class ConfigManager:
                 session_scan_interval=int(os.getenv(
                     "SESSION_SCAN_INTERVAL_SECONDS",
                     str(DEFAULT_SESSION_SCAN_INTERVAL_SECONDS),
-                ))
+                )),
+                chart_return_binary=os.getenv("CHART_RETURN_BINARY", "false").lower() == "true",
             )
             logger.info("Server configuration loaded")
         return self._server_config

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -109,6 +109,19 @@ async def generate_chart(
             # Remove fixed dimensions so the chart is fully responsive in its container
             fig.update_layout(width=None, height=None, autosize=True)
             html = fig.to_html(include_plotlyjs="cdn", full_html=True)
+            toolbar_css = (
+                "<style>"
+                ".modebar-container { position: absolute !important; top: 0 !important; "
+                "left: 0 !important; right: 0 !important; width: 100% !important; "
+                "background: #f8f8f8 !important; border-bottom: 1px solid #eee !important; "
+                "padding: 4px 8px !important; z-index: 100 !important; "
+                "display: flex !important; justify-content: flex-end !important; }"
+                ".modebar { display: flex !important; flex-direction: row !important; "
+                "flex-wrap: nowrap !important; }"
+                ".modebar-group { display: flex !important; flex-direction: row !important; }"
+                "</style>"
+            )
+            html = html.replace("</head>", toolbar_css + "</head>")
 
             # Register as a FastMCP Apps resource
             chart_uri = f"ui://orionbelt/chart/{uuid4()}"

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -106,6 +106,8 @@ async def generate_chart(
             chart_type_display = metadata.get("chart_type", chart_type)
 
             # Generate self-contained HTML with Plotly.js from CDN
+            # Remove fixed dimensions so the chart is fully responsive in its container
+            fig.update_layout(width=None, height=None, autosize=True)
             html = fig.to_html(include_plotlyjs="cdn", full_html=True)
             modebar_css = (
                 "<style>"

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -113,9 +113,10 @@ async def generate_chart(
                 full_html=True,
                 config={
                     "displaylogo": False,
-                    "modeBarButtonsToRemove": [
-                        "select2d", "lasso2d", "zoomIn2d", "zoomOut2d",
-                    ],
+                    "modeBarButtons": [[
+                        "toImage", "zoom2d", "pan2d",
+                        "autoScale2d", "resetScale2d",
+                    ]],
                 },
             )
 

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -107,16 +107,6 @@ async def generate_chart(
 
             # Generate self-contained HTML with Plotly.js from CDN
             html = fig.to_html(include_plotlyjs="cdn", full_html=True)
-            modebar_css = (
-                "<style>"
-                ".modebar-container { background: #ffffff !important; "
-                "border-radius: 4px; padding: 2px 4px; "
-                "box-shadow: 0 1px 3px rgba(0,0,0,0.15); z-index: 10; }"
-                ".modebar-btn { opacity: 0.8 !important; }"
-                ".modebar-btn:hover { opacity: 1 !important; }"
-                "</style>"
-            )
-            html = html.replace("</head>", modebar_css + "</head>")
 
             # Register as a FastMCP Apps resource
             chart_uri = f"ui://orionbelt/chart/{uuid4()}"

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -108,21 +108,16 @@ async def generate_chart(
             # Generate self-contained HTML with Plotly.js from CDN
             # Remove fixed dimensions so the chart is fully responsive in its container
             fig.update_layout(width=None, height=None, autosize=True)
-            html = fig.to_html(include_plotlyjs="cdn", full_html=True)
-            toolbar_css = (
-                "<style>"
-                ".modebar-container { position: absolute !important; top: 0 !important; "
-                "left: 0 !important; right: 0 !important; width: 100% !important; "
-                "background: #f8f8f8 !important; border-bottom: 1px solid #eee !important; "
-                "padding: 4px 8px !important; z-index: 100 !important; "
-                "display: flex !important; justify-content: flex-end !important; }"
-                ".modebar { display: flex !important; flex-direction: row !important; "
-                "flex-wrap: nowrap !important; }"
-                ".modebar-group { display: flex !important; flex-direction: row !important; }"
-                "</style>"
+            html = fig.to_html(
+                include_plotlyjs="cdn",
+                full_html=True,
+                config={
+                    "displaylogo": False,
+                    "modeBarButtonsToRemove": [
+                        "select2d", "lasso2d", "zoomIn2d", "zoomOut2d",
+                    ],
+                },
             )
-            html = html.replace("</body>", toolbar_css + "</body>")
-            logger.debug(f"Toolbar CSS injected: {'modebar-container' in html}")
 
             # Register as a FastMCP Apps resource
             chart_uri = f"ui://orionbelt/chart/{uuid4()}"

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -107,6 +107,13 @@ async def generate_chart(
 
             # Generate self-contained HTML with Plotly.js from CDN
             html = fig.to_html(include_plotlyjs="cdn", full_html=True)
+            modebar_css = (
+                "<style>"
+                ".modebar { background: #fff !important; padding: 2px 4px !important; }"
+                ".modebar-group { background: #fff !important; }"
+                "</style>"
+            )
+            html = html.replace("</body>", modebar_css + "</body>")
 
             # Register as a FastMCP Apps resource
             chart_uri = f"ui://orionbelt/chart/{uuid4()}"

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -107,6 +107,15 @@ async def generate_chart(
 
             # Generate self-contained HTML with Plotly.js from CDN
             html = fig.to_html(include_plotlyjs="cdn", full_html=True)
+            modebar_css = (
+                "<style>"
+                ".modebar { background: #fff !important; "
+                "border-radius: 4px !important; padding: 4px !important; "
+                "box-shadow: 0 1px 4px rgba(0,0,0,0.2) !important; }"
+                ".modebar-group { background: #fff !important; }"
+                "</style>"
+            )
+            html = html.replace("</body>", modebar_css + "</body>")
 
             # Register as a FastMCP Apps resource
             chart_uri = f"ui://orionbelt/chart/{uuid4()}"

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -108,17 +108,6 @@ async def generate_chart(
             # Generate self-contained HTML with Plotly.js from CDN
             # Remove fixed dimensions so the chart is fully responsive in its container
             fig.update_layout(width=None, height=None, autosize=True)
-            html = fig.to_html(
-                include_plotlyjs="cdn",
-                full_html=True,
-                config={
-                    "displaylogo": False,
-                    "modeBarButtons": [[
-                        "toImage", "zoom2d", "pan2d",
-                        "autoScale2d", "resetScale2d",
-                    ]],
-                },
-            )
             toolbar_css = (
                 "<style>"
                 ".js-plotly-plot .plotly .modebar { "
@@ -127,7 +116,18 @@ async def generate_chart(
                 "padding: 4px !important; }"
                 "</style>"
             )
-            html = html.replace("</body>", toolbar_css + "</body>")
+            chart_div = fig.to_html(
+                include_plotlyjs="cdn",
+                full_html=False,
+                config={
+                    "displaylogo": False,
+                    "modeBarButtons": [[
+                        "toImage", "zoom2d", "pan2d",
+                        "autoScale2d", "resetScale2d",
+                    ]],
+                },
+            )
+            html = toolbar_css + chart_div
 
             # Register as a FastMCP Apps resource
             chart_uri = f"ui://orionbelt/chart/{uuid4()}"

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -110,8 +110,12 @@ async def generate_chart(
             fig.update_layout(width=None, height=None, autosize=True)
             html = fig.to_html(include_plotlyjs="cdn", full_html=True)
 
-            # Register as a FastMCP Apps resource
-            chart_uri = f"ui://orionbelt/chart/{uuid4()}"
+            # Register as FastMCP Apps resources:
+            # - HTML for Claude Desktop / MCP Apps clients
+            # - JSON for direct consumption by OB Chat (avoids HTML parsing)
+            chart_id = uuid4()
+            chart_uri = f"ui://orionbelt/chart/{chart_id}"
+            chart_json_uri = f"ui://orionbelt/chart-json/{chart_id}"
             if add_resource:
                 from fastmcp.resources import TextResource
                 add_resource(TextResource(
@@ -120,7 +124,13 @@ async def generate_chart(
                     text=html,
                     mime_type="text/html",
                 ))
-                logger.info(f"Registered chart resource: {chart_uri}")
+                add_resource(TextResource(
+                    uri=chart_json_uri,
+                    name=f"Chart JSON: {title or chart_type_display}",
+                    text=fig.to_json(),
+                    mime_type="application/json",
+                ))
+                logger.info(f"Registered chart resources: {chart_uri}, {chart_json_uri}")
 
             # Export a static PNG: saved to disk and returned inline as ImageContent
             image_inline = None
@@ -140,7 +150,7 @@ async def generate_chart(
                 logger.debug(f"PNG export failed: {e}")
 
             await ctx.info(f"Interactive {chart_type_display} chart with {data_points} data points")
-            text_result = f"Chart generated: {chart_uri}{file_uri}"
+            text_result = f"Chart generated: {chart_uri}{file_uri}\nChart JSON: {chart_json_uri}"
             return_binary = config_manager.get_server_config().chart_return_binary
             if image_inline and return_binary:
                 return [text_result, image_inline]

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -109,9 +109,10 @@ async def generate_chart(
             html = fig.to_html(include_plotlyjs="cdn", full_html=True)
             modebar_css = (
                 "<style>"
-                ".modebar-container { background: rgba(255,255,255,0.9) !important; "
-                "border-radius: 4px; padding: 2px; }"
-                ".modebar-btn { opacity: 0.7 !important; }"
+                ".modebar-container { background: #ffffff !important; "
+                "border-radius: 4px; padding: 2px 4px; "
+                "box-shadow: 0 1px 3px rgba(0,0,0,0.15); }"
+                ".modebar-btn { opacity: 0.8 !important; }"
                 ".modebar-btn:hover { opacity: 1 !important; }"
                 "</style>"
             )

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -109,10 +109,9 @@ async def generate_chart(
             html = fig.to_html(include_plotlyjs="cdn", full_html=True)
             modebar_css = (
                 "<style>"
-                ".modebar-container { background: #ffffff !important; "
-                "border-radius: 4px; padding: 2px 4px; "
-                "box-shadow: 0 1px 3px rgba(0,0,0,0.15); }"
-                ".modebar-btn { opacity: 0.8 !important; }"
+                ".modebar-container { background: rgba(255,255,255,0.9) !important; "
+                "border-radius: 4px; padding: 2px; }"
+                ".modebar-btn { opacity: 0.7 !important; }"
                 ".modebar-btn:hover { opacity: 1 !important; }"
                 "</style>"
             )

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -107,6 +107,15 @@ async def generate_chart(
 
             # Generate self-contained HTML with Plotly.js from CDN
             html = fig.to_html(include_plotlyjs="cdn", full_html=True)
+            modebar_css = (
+                "<style>"
+                ".modebar-container { background: rgba(255,255,255,0.9) !important; "
+                "border-radius: 4px; padding: 2px; }"
+                ".modebar-btn { opacity: 0.7 !important; }"
+                ".modebar-btn:hover { opacity: 1 !important; }"
+                "</style>"
+            )
+            html = html.replace("</head>", modebar_css + "</head>")
 
             # Register as a FastMCP Apps resource
             chart_uri = f"ui://orionbelt/chart/{uuid4()}"

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -8,6 +8,7 @@ from fastmcp import Context
 from fastmcp.utilities.types import Image
 
 from ..chart_utils import save_image_to_tmp
+from ..config import config_manager
 
 logger = logging.getLogger(__name__)
 
@@ -138,7 +139,8 @@ async def generate_chart(
 
             await ctx.info(f"Interactive {chart_type_display} chart with {data_points} data points")
             text_result = f"Chart generated: {chart_uri}{file_uri}"
-            if image_inline:
+            return_binary = config_manager.get_server_config().chart_return_binary
+            if image_inline and return_binary:
                 return [text_result, image_inline]
             return text_result
         else:
@@ -165,10 +167,13 @@ async def generate_chart(
             raise RuntimeError("Failed to save chart image to file")
 
         await ctx.info(f"Chart image saved: {image_file_path}")
-        return [
-            f"Chart saved to: {image_file_path}",
-            Image(data=image_bytes, format="png"),
-        ]
+        return_binary = config_manager.get_server_config().chart_return_binary
+        if return_binary:
+            return [
+                f"Chart saved to: {image_file_path}",
+                Image(data=image_bytes, format="png"),
+            ]
+        return f"Chart saved to: {image_file_path}"
     else:
         await ctx.info("Chart generation failed")
         raise RuntimeError("Chart generation failed: unexpected result format")

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -109,15 +109,6 @@ async def generate_chart(
             # Remove fixed dimensions so the chart is fully responsive in its container
             fig.update_layout(width=None, height=None, autosize=True)
             html = fig.to_html(include_plotlyjs="cdn", full_html=True)
-            modebar_css = (
-                "<style>"
-                ".modebar { background: #fff !important; "
-                "border-radius: 4px !important; padding: 4px !important; "
-                "box-shadow: 0 1px 4px rgba(0,0,0,0.2) !important; }"
-                ".modebar-group { background: #fff !important; }"
-                "</style>"
-            )
-            html = html.replace("</body>", modebar_css + "</body>")
 
             # Register as a FastMCP Apps resource
             chart_uri = f"ui://orionbelt/chart/{uuid4()}"

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -109,9 +109,10 @@ async def generate_chart(
             html = fig.to_html(include_plotlyjs="cdn", full_html=True)
             modebar_css = (
                 "<style>"
-                ".modebar-container { background: rgba(255,255,255,0.9) !important; "
-                "border-radius: 4px; padding: 2px; }"
-                ".modebar-btn { opacity: 0.7 !important; }"
+                ".modebar-container { background: #ffffff !important; "
+                "border-radius: 4px; padding: 2px 4px; "
+                "box-shadow: 0 1px 3px rgba(0,0,0,0.15); z-index: 10; }"
+                ".modebar-btn { opacity: 0.8 !important; }"
                 ".modebar-btn:hover { opacity: 1 !important; }"
                 "</style>"
             )

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -108,26 +108,7 @@ async def generate_chart(
             # Generate self-contained HTML with Plotly.js from CDN
             # Remove fixed dimensions so the chart is fully responsive in its container
             fig.update_layout(width=None, height=None, autosize=True)
-            toolbar_css = (
-                "<style>"
-                ".js-plotly-plot .plotly .modebar { "
-                "background: #fff !important; "
-                "border-radius: 4px !important; "
-                "padding: 4px !important; }"
-                "</style>"
-            )
-            chart_div = fig.to_html(
-                include_plotlyjs="cdn",
-                full_html=False,
-                config={
-                    "displaylogo": False,
-                    "modeBarButtons": [[
-                        "toImage", "zoom2d", "pan2d",
-                        "autoScale2d", "resetScale2d",
-                    ]],
-                },
-            )
-            html = toolbar_css + chart_div
+            html = fig.to_html(include_plotlyjs="cdn", full_html=True)
 
             # Register as a FastMCP Apps resource
             chart_uri = f"ui://orionbelt/chart/{uuid4()}"

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -107,15 +107,6 @@ async def generate_chart(
 
             # Generate self-contained HTML with Plotly.js from CDN
             html = fig.to_html(include_plotlyjs="cdn", full_html=True)
-            modebar_css = (
-                "<style>"
-                ".modebar { background: #fff !important; "
-                "border-radius: 4px !important; padding: 4px !important; "
-                "box-shadow: 0 1px 4px rgba(0,0,0,0.2) !important; }"
-                ".modebar-group { background: #fff !important; }"
-                "</style>"
-            )
-            html = html.replace("</body>", modebar_css + "</body>")
 
             # Register as a FastMCP Apps resource
             chart_uri = f"ui://orionbelt/chart/{uuid4()}"

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -109,7 +109,9 @@ async def generate_chart(
             html = fig.to_html(include_plotlyjs="cdn", full_html=True)
             modebar_css = (
                 "<style>"
-                ".modebar { background: #fff !important; padding: 2px 4px !important; }"
+                ".modebar { background: #fff !important; "
+                "border-radius: 4px !important; padding: 4px !important; "
+                "box-shadow: 0 1px 4px rgba(0,0,0,0.2) !important; }"
                 ".modebar-group { background: #fff !important; }"
                 "</style>"
             )

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -119,6 +119,15 @@ async def generate_chart(
                     ]],
                 },
             )
+            toolbar_css = (
+                "<style>"
+                ".js-plotly-plot .plotly .modebar { "
+                "background: #fff !important; "
+                "border-radius: 4px !important; "
+                "padding: 4px !important; }"
+                "</style>"
+            )
+            html = html.replace("</body>", toolbar_css + "</body>")
 
             # Register as a FastMCP Apps resource
             chart_uri = f"ui://orionbelt/chart/{uuid4()}"

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -121,7 +121,8 @@ async def generate_chart(
                 ".modebar-group { display: flex !important; flex-direction: row !important; }"
                 "</style>"
             )
-            html = html.replace("</head>", toolbar_css + "</head>")
+            html = html.replace("</body>", toolbar_css + "</body>")
+            logger.debug(f"Toolbar CSS injected: {'modebar-container' in html}")
 
             # Register as a FastMCP Apps resource
             chart_uri = f"ui://orionbelt/chart/{uuid4()}"

--- a/src/main.py
+++ b/src/main.py
@@ -854,17 +854,16 @@ async def generate_chart(
     sort_order: Optional[str] = None,
     output_format: str = "interactive",
 ):
-    """Generate a chart from query results. Returns an inline image (ImageContent)
-    that renders in all MCP clients, plus a ui:// MCP Apps widget for interactive use.
+    """Generate a chart from query results. Returns a ui:// MCP Apps widget for interactive use.
 
     Args:
         data_source: JSON array of objects, e.g. [{"name": "A", "value": 10}, ...] — pass as array, not string
         chart_type: 'bar', 'line', 'scatter', or 'heatmap'
         x_column: Column name for X-axis
-        y_column: Column name(s) for Y-axis
+        y_column: Column name(s) for Y-axis. Pass a single string or a list of strings. Multiple y_columns are supported for bar charts (grouped/stacked) and line charts.
         color_column: Optional column for grouping/coloring (heatmap: numeric value column for color intensity)
         title: Chart title
-        chart_style: 'default', 'stacked', or 'grouped'
+        chart_style: 'default', 'stacked', or 'grouped' — applies to bar charts including multi-y
         width: Chart width in pixels
         height: Chart height in pixels
         sort_by: Column to sort by

--- a/src/tools/chart.py
+++ b/src/tools/chart.py
@@ -129,9 +129,8 @@ def generate_chart(
         # Validate y_column(s)
         if chart_type in ["bar", "line", "scatter"] and y_column:
             if isinstance(y_column, list):
-                # Multiple measures (only supported for line charts)
-                if chart_type != "line":
-                    return {"error": f"❌ Multiple y_columns only supported for line charts, not {chart_type}"}
+                if chart_type not in ["bar", "line"]:
+                    return {"error": f"❌ Multiple y_columns only supported for bar and line charts, not {chart_type}"}
                 missing_cols = [col for col in y_column if col not in df.columns]
                 if missing_cols:
                     return {"error": f"❌ Y-axis columns {missing_cols} not found in data. Available columns: {list(df.columns)}"}
@@ -143,8 +142,12 @@ def generate_chart(
         # Generate title if not provided
         if not title:
             if chart_type == "bar":
-                y_label = y_column if isinstance(y_column, str) else 'Count'
-                title = f"{y_label} by {x_column}"
+                if isinstance(y_column, list):
+                    y_label = ', '.join(y_column)
+                    title = f"{y_label} by {x_column}"
+                else:
+                    y_label = y_column if isinstance(y_column, str) else 'Count'
+                    title = f"{y_label} by {x_column}"
                 if chart_style == "stacked" and color_column:
                     title += f" (stacked by {color_column})"
             elif chart_type == "line":

--- a/uv.lock
+++ b/uv.lock
@@ -2421,7 +2421,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-analytics"
-version = "1.4.1"
+version = "1.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -2421,7 +2421,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-analytics"
-version = "1.3.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Add `CHART_RETURN_BINARY` env setting (default=false) to control inline binary image return from `generate_chart`
- Support multiple y_columns for bar charts (grouped/stacked), not just line charts
- Register a JSON chart resource (`ui://orionbelt/chart-json/{id}`) alongside the HTML resource, so OB Chat can render directly without HTML parsing
- Responsive chart layout with vertical right-side legend and horizontal modebar toolbar
- Version bump to 1.4.2

## Test plan
- [x] Verified interactive charts render correctly in OB Chat with JSON fast path
- [x] Verified multi-y bar charts (grouped and stacked) work
- [x] Verified all modebar toolbar buttons visible and horizontal
- [x] Verified `ui://` HTML resource still works for Claude Desktop
- [x] Verified `CHART_RETURN_BINARY=false` (default) suppresses inline image

🤖 Generated with [Claude Code](https://claude.com/claude-code)