### PR TITLE
fix: clean up chart storage paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center"><strong>The Ontology-based MCP server for your Text-2-SQL convenience.</strong></p>
 
-[![Version 1.4.3](https://img.shields.io/badge/version-1.4.3-purple.svg)](https://github.com/ralfbecher/orionbelt-analytics/releases)
+[![Version 1.4.4](https://img.shields.io/badge/version-1.4.4-purple.svg)](https://github.com/ralfbecher/orionbelt-analytics/releases)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralfbecher/orionbelt-analytics/blob/main/LICENSE)
 [![FastMCP](https://img.shields.io/badge/FastMCP-3.2.4+-blue)](https://github.com/jlowin/fastmcp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-analytics"
-version = "1.4.3"
+version = "1.4.4"
 description = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "ralf.becher@web.de"}]
 readme = "README.md"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """OrionBelt Analytics - Ontology-based MCP server for your Text-2-SQL convenience."""
 
-__version__ = "1.4.3"
+__version__ = "1.4.4"
 __author__ = "OrionBelt Analytics Contributors"
 __email__ = "contributors@example.com"
 __description__ = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"

--- a/src/chart_utils.py
+++ b/src/chart_utils.py
@@ -543,34 +543,25 @@ def save_image_to_tmp(
     image_bytes: bytes,
     chart_id: str,
     format: str,
-    connection_id: Optional[str] = None
+    connection_id: str,
 ) -> Optional[str]:
-    """Save image bytes to connection-scoped directory and return file path.
+    """Save image bytes to connection-scoped charts directory and return file path.
 
     Args:
         image_bytes: Image data to save
         chart_id: Unique chart identifier
         format: Image format (e.g., 'png', 'jpg')
         connection_id: Database connection fingerprint for scoping.
-                      If None, uses legacy global tmp/ directory (backward compat).
 
     Returns:
         Path to saved image file, or None on error
     """
-    from .paths import get_charts_dir, OUTPUT_DIR
+    from .paths import get_charts_dir
 
     try:
         image_filename = f"{chart_id}.{format}"
-
-        if connection_id:
-            # Use connection-scoped charts directory (preferred)
-            charts_dir = get_charts_dir(connection_id)
-            image_file_path = charts_dir / image_filename
-        else:
-            # Legacy fallback to global charts directory
-            charts_dir = OUTPUT_DIR / "charts"
-            charts_dir.mkdir(exist_ok=True)
-            image_file_path = charts_dir / image_filename
+        charts_dir = get_charts_dir(connection_id)
+        image_file_path = charts_dir / image_filename
 
         with open(image_file_path, 'wb') as f:
             f.write(image_bytes)

--- a/src/chart_utils.py
+++ b/src/chart_utils.py
@@ -567,10 +567,10 @@ def save_image_to_tmp(
             charts_dir = get_charts_dir(connection_id)
             image_file_path = charts_dir / image_filename
         else:
-            # Legacy fallback to global tmp/ directory
-            tmp_dir = OUTPUT_DIR / "tmp"
-            tmp_dir.mkdir(exist_ok=True)
-            image_file_path = tmp_dir / image_filename
+            # Legacy fallback to global charts directory
+            charts_dir = OUTPUT_DIR / "charts"
+            charts_dir.mkdir(exist_ok=True)
+            image_file_path = charts_dir / image_filename
 
         with open(image_file_path, 'wb') as f:
             f.write(image_bytes)

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -27,7 +27,7 @@ async def generate_chart(
     sort_by: Optional[str],
     sort_order: Optional[str],
     output_format: str,
-    get_session_data=None,
+    get_session_data,
     add_resource=None,
 ) -> str:
     """Generate interactive or static charts from query results.
@@ -138,8 +138,7 @@ async def generate_chart(
             try:
                 chart_id = str(uuid4())
                 image_bytes = fig.to_image(format="png", width=width, height=height)
-                session = get_session_data(ctx) if get_session_data else None
-                connection_id = session.connection_id if session else None
+                connection_id = get_session_data(ctx).connection_id
                 image_file_path = save_image_to_tmp(
                     image_bytes, chart_id, "png", connection_id=connection_id
                 )
@@ -163,15 +162,13 @@ async def generate_chart(
     if isinstance(result, tuple) and len(result) == 2:
         image_bytes, chart_id = result
 
-        # Get connection_id from session for scoped storage
-        session = get_session_data(ctx) if get_session_data else None
-        connection_id = session.connection_id if session else None
+        connection_id = get_session_data(ctx).connection_id
 
         image_file_path = save_image_to_tmp(
             image_bytes,
             chart_id,
             "png",
-            connection_id=connection_id
+            connection_id=connection_id,
         )
 
         if not image_file_path:

--- a/src/main.py
+++ b/src/main.py
@@ -469,7 +469,7 @@ class ErrorResponse(BaseModel):
 
 def create_error_response(
     error_msg: str, error_type: str = "unknown", details: Optional[str] = None
-) -> str:
+) -> Dict[str, Any]:
     """Create a standardized error response.
 
     DEPRECATED: Use exceptions from src.exceptions instead.
@@ -479,7 +479,7 @@ def create_error_response(
     use the exception hierarchy in src/exceptions.py.
     """
     response = ErrorResponse(error=error_msg, error_type=error_type, details=details)
-    return response.model_dump_json()
+    return response.model_dump()
 
 
 # --- Oxigraph Store Helper ---
@@ -1096,12 +1096,17 @@ async def query_sparql(
     sparql_query: str,
     timeout_seconds: int = 30,
 ) -> Dict[str, Any]:
-    """Execute SPARQL query against stored ontologies. Supports SELECT, ASK,
-    and CONSTRUCT query types (auto-detected from query string).
+    """Execute a SPARQL query against the RDF ontology store. Use this to explore
+    schema relationships, classes, properties, and semantic metadata loaded via
+    generate_ontology or load_my_ontology. Requires an ontology to be loaded first.
+
+    Supports SELECT, ASK, and CONSTRUCT query types (auto-detected from query string).
+    Common prefixes (rdf, rdfs, owl, xsd) are available by default.
 
     Args:
-        sparql_query: SPARQL query string (SELECT, ASK, or CONSTRUCT)
-        timeout_seconds: Query timeout
+        sparql_query: A complete SPARQL query string (SELECT, ASK, or CONSTRUCT).
+            Example: "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10"
+        timeout_seconds: Query timeout in seconds
 
     Returns:
         Query results (bindings for SELECT, boolean for ASK, Turtle string for CONSTRUCT)

--- a/src/tools/chart.py
+++ b/src/tools/chart.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime
 from typing import Dict, List, Any, Optional, Union, Tuple
 
-from ..chart_utils import create_plotly_chart, save_image_to_tmp
+from ..chart_utils import create_plotly_chart
 
 logger = logging.getLogger(__name__)
 
@@ -197,8 +197,6 @@ def generate_chart(
 
         logger.info(f"Created {chart_type} chart image with {len(df)} data points")
 
-        # Also save to tmp directory for backward compatibility
-        save_image_to_tmp(image_bytes, chart_id, 'png')
         return (image_bytes, chart_id)
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- Renamed legacy chart output directory from `tmp/tmp/` to `tmp/charts/` for clarity
- Removed duplicate chart save — charts were written twice (once without connection scoping in `tools/chart.py`, once with proper scoping in `handlers/chart.py`)
- Made `connection_id` required in `save_image_to_tmp` since a DB connection is always present when generating charts
- Removed defensive `None` guards for `get_session_data` in the chart handler since it's always provided by `main.py`

## Test plan
- [ ] Generate a chart via MCP and verify it's saved only in `tmp/<connectionId>/charts/`
- [ ] Verify no files are written to `tmp/charts/` (legacy path)
- [ ] Test both interactive and image output formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)