### PR TITLE
feat: MCP sampling for suggest_semantic_names (v1.5.0)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -105,6 +105,15 @@ R2RML_BASE_IRI=http://mycompany.com/
 # Set to true to include the PNG image bytes directly in the MCP response.
 CHART_RETURN_BINARY=false
 
+# MCP Sampling
+# ------------
+# Allow the server to call back through the client's LLM (MCP sampling) for
+# tasks like generating semantic-rename suggestions inside suggest_semantic_names.
+# Requires a sampling-capable client (e.g. OrionBelt Chat). Clients without
+# sampling support (e.g. Claude Desktop) silently fall back to the legacy
+# manual-review path. Set to false to force the legacy path everywhere.
+ENABLE_SAMPLING=true
+
 # Output directory for generated files (schema JSON, ontology TTL, R2RML, etc.)
 # Relative to project root. Default: tmp
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to OrionBelt Analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.5.0] - 2026-05-03
 
 ### Added
 - **MCP sampling for `suggest_semantic_names`** -- when the connected client advertises the sampling capability, the server now calls back through the host LLM via `ctx.sample()` to pre-fill rename suggestions for cryptic identifiers, returning a `suggestions` dict alongside the cryptic-name lists in a single tool call.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to OrionBelt Analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **MCP sampling for `suggest_semantic_names`** -- when the connected client advertises the sampling capability, the server now calls back through the host LLM via `ctx.sample()` to pre-fill rename suggestions for cryptic identifiers, returning a `suggestions` dict alongside the cryptic-name lists in a single tool call.
+  - Gated on a new `ENABLE_SAMPLING` env flag (default `true`). Set to `false` to force the legacy manual-review path everywhere.
+  - Clients without sampling support (e.g. Claude Desktop) silently fall back to the legacy response shape — no breaking change.
+  - Sampling requests, results, and failures are logged with elapsed time and item counts for observability.
+
+### Fixed
+- **MCP session crash on client disconnect during `suggest_semantic_names`** -- a notification (`ctx.info`) write that hit `anyio.ClosedResourceError` because the client had already closed the streamable-HTTP session was caught by the handler's outer `except` and triggered a second doomed write, bringing down the entire FastMCP TaskGroup. Notifications are now sent through `safe_ctx_info` (failures swallowed at debug level), and `ClosedResourceError`-class disconnects re-raise cleanly so the framework tears the session down instead of writing into a dead transport.
+- **Sampling response parsing** -- replaced pydantic-ai's `result_type=Dict[str, str]` (which forces the model to call an injected `final_response` tool, fragile on large responses) with explicit JSON parsing that accepts bare JSON, ```json fences, and prose-embedded JSON.
+
 ## [1.2.0] - 2026-04-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Run Analytics and Semantic Layer side-by-side in Claude Desktop for schema-aware
 - **Interactive charting** -- Plotly charts with MCP-UI rendering in Claude Desktop
 - **Multi-schema support** -- analyze multiple schemas simultaneously; ontology and GraphRAG state are isolated per schema
 - **Workspace persistence** -- reconnect to the same database and restore your previous session
+- **MCP sampling** -- when the connected client supports sampling (e.g. [OrionBelt Chat](https://github.com/ralfbecher/orionbelt-chat)), `suggest_semantic_names` asks the host LLM to pre-fill rename suggestions for cryptic identifiers via `sampling/createMessage`, collapsing the previous review-then-apply flow into a single tool call. Clients without sampling support (e.g. Claude Desktop) silently fall back to the manual review path
 
 ## OBQC -- Ontology-Based Query Check
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,15 @@ ONTOLOGY_MAX_AGE_DAYS=60          # Delete versions older than 60 days
 # Options: false (default), true (retention-based), all (remove everything)
 AUTO_CLEANUP_ON_STARTUP=false
 
+# MCP Sampling
+# ------------
+# Allow the server to call back through the client's LLM (MCP sampling) for
+# tasks like generating semantic-rename suggestions inside suggest_semantic_names.
+# Requires a sampling-capable client (e.g. OrionBelt Chat). Clients without
+# sampling support (e.g. Claude Desktop) silently fall back to the legacy
+# manual-review path. Set to false to force the legacy path everywhere.
+ENABLE_SAMPLING=true
+
 # MCP Transport Configuration
 # Options: http, sse (Server-Sent Events)
 # - http: Standard HTTP transport (streamable, default)
@@ -217,6 +226,29 @@ DATABRICKS_SCHEMA=default
 - **Version control**: Never commit `.env` -- add it to `.gitignore`.
 - **Production**: Consider using environment variables directly, or a secrets management service (AWS Secrets Manager, Azure Key Vault, HashiCorp Vault).
 - **Credential rotation**: Implement rotation policies for database passwords and API tokens.
+
+---
+
+## MCP Sampling
+
+`ENABLE_SAMPLING` (default `true`) controls whether the server is allowed to call back through the client's LLM via the MCP `sampling/createMessage` capability.
+
+**Where it is used:** `suggest_semantic_names`. When sampling is available, the server asks the host LLM to produce rename suggestions for cryptic identifiers and returns them as a `suggestions: {old_name: new_name}` map alongside the existing cryptic-name lists. Without sampling, the response shape is unchanged: the host LLM is expected to inspect the cryptic lists and call `apply_semantic_names` with its own suggestions.
+
+**Capability detection is implicit.** The server attempts `ctx.sample(...)` and falls back to the legacy path on any failure — including the case where the client never advertised the capability. There is no separate handshake to configure.
+
+**Client compatibility:**
+
+| Client | Sampling support | Behaviour |
+|---|---|---|
+| OrionBelt Chat | Yes (with `sampling.tools`) | `suggestions` field is populated; one tool call instead of two |
+| Claude Desktop | No | Falls back silently to manual review path |
+| Claude Code | No | Falls back silently to manual review path |
+| Generic pydantic-ai clients | Depends on agent wiring | Works when `agent.set_mcp_sampling_model()` (or equivalent) is called |
+
+**Disabling:** set `ENABLE_SAMPLING=false` to force the legacy path even when the client supports sampling. Useful for cost control, deterministic regression testing, or when a particular host LLM produces poor rename suggestions.
+
+**Logging:** sampling activity is logged at INFO/WARNING with elapsed time and item counts -- look for lines starting with `MCP sampling:` in the server log to verify the path the request took.
 
 ---
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -22,6 +22,20 @@ resource, and prompt without manual registration.
 
 Complete, runnable examples with READMEs live in the [`integrations/`](../integrations/) folder.
 
+### MCP Sampling
+
+A subset of clients support [MCP sampling](https://modelcontextprotocol.io/specification/server/utilities/sampling) -- the server-initiated `sampling/createMessage` flow that lets a tool call back through the host LLM mid-execution. OrionBelt Analytics uses this in `suggest_semantic_names` to pre-fill rename suggestions for cryptic identifiers, collapsing the previous review-then-apply workflow into a single tool call.
+
+| Client | Sampling | Notes |
+|---|---|---|
+| **OrionBelt Chat** | Yes | Advertises `sampling.tools`; routes sampling requests to the env-configured default model |
+| Claude Desktop | No | Falls back silently to the manual-review response shape |
+| Claude Code | No | Same fallback |
+| Pydantic-AI agents | If wired | Call `agent.set_mcp_sampling_model()` (or pass `sampling_model=` to each MCP server) to expose the agent's LLM to sampling callbacks |
+| Other frameworks | Depends | Sampling is opt-in per host; check the framework's MCP client docs |
+
+Set `ENABLE_SAMPLING=false` in OrionBelt Analytics' `.env` to disable the sampling path globally regardless of client support. See [Configuration](./configuration.md#mcp-sampling) for details.
+
 ## Quick Start Examples
 
 ### LangChain / LangGraph

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-analytics"
-version = "1.4.4"
+version = "1.5.0"
 description = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "ralf.becher@web.de"}]
 readme = "README.md"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """OrionBelt Analytics - Ontology-based MCP server for your Text-2-SQL convenience."""
 
-__version__ = "1.4.4"
+__version__ = "1.5.0"
 __author__ = "OrionBelt Analytics Contributors"
 __email__ = "contributors@example.com"
 __description__ = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"

--- a/src/config.py
+++ b/src/config.py
@@ -30,6 +30,7 @@ class ServerConfig:
     session_idle_timeout: int = DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS
     session_scan_interval: int = DEFAULT_SESSION_SCAN_INTERVAL_SECONDS
     chart_return_binary: bool = False
+    enable_sampling: bool = True
 
     def __post_init__(self):
         """Validate configuration after initialization."""
@@ -110,6 +111,7 @@ class ConfigManager:
                     str(DEFAULT_SESSION_SCAN_INTERVAL_SECONDS),
                 )),
                 chart_return_binary=os.getenv("CHART_RETURN_BINARY", "false").lower() == "true",
+                enable_sampling=os.getenv("ENABLE_SAMPLING", "true").lower() == "true",
             )
             logger.info("Server configuration loaded")
         return self._server_config

--- a/src/handlers/ontology.py
+++ b/src/handlers/ontology.py
@@ -498,32 +498,39 @@ async def _maybe_sample_rename_suggestions(
 def _build_rename_prompt(items: list[str]) -> str:
     """Compose the sampling prompt with concrete naming rules and a worked example."""
     return (
-        "You are renaming cryptic identifiers in a SQL-derived OWL ontology so "
-        "the resulting labels read like domain language, not table columns.\n\n"
+        "You are producing human-readable rdfs:label values for an OWL ontology "
+        "derived from a SQL schema. The URI of each resource is unchanged — "
+        "you are only writing the *display label* a domain user will see in "
+        "Protégé, GraphDB, and OBQC error messages. Labels should read like "
+        "natural language, NOT like code identifiers.\n\n"
         "Each PROP item is qualified as `table.column`. The table is the OWL "
         "class the property belongs to — its name is implicit context, so "
         "REMOVE redundant prefixes from the property name.\n\n"
-        "Naming rules (apply strictly):\n"
-        "1. CLASSES → singular PascalCase. Example: `clientcomplaints` → "
-        "`ClientComplaint`.\n"
-        "2. PROPERTIES → camelCase, no underscores, no table prefix. "
+        "Naming rules (apply strictly and consistently):\n"
+        "1. CLASS labels → Title Case With Spaces, singular noun phrase. "
+        "Examples: `clientcomplaints` → `Client Complaint`; "
+        "`acctbal` → `Account Balance`; `customers` → `Customer`.\n"
+        "2. PROPERTY labels → lowercase with spaces between words. No "
+        "camelCase, no underscores, no table prefix. "
         "Examples: `purchases.purchaseamount` → `amount`; "
-        "`sales.salesdate` → `date` (or `placedOn`); "
-        "`clients.clientname` → `name`.\n"
-        "3. FOREIGN-KEY columns become object-property names that READ LIKE THE "
-        "RELATED ENTITY — drop the trailing `Id` and the source-table prefix. "
-        "Examples: `sales.salesclient` → `client`; "
+        "`products.unitsinstock` → `units in stock`; "
+        "`calendar.publicholiday` → `is public holiday`; "
+        "`sales.salespaymenttype` → `payment type`.\n"
+        "3. FOREIGN-KEY columns become object-property labels naming the "
+        "RELATED ENTITY in lowercase — drop the trailing `id` and any source-"
+        "table prefix. Examples: `sales.salesclient` → `client`; "
         "`purchases.purchaseproduct` → `product`; "
         "`purchases.purchasechanid` → `channel`.\n"
-        "4. PRIMARY-KEY identifiers stay short: `clients.clientid` → `id`.\n"
-        "5. Acronyms remain uppercase: `iban` → `IBAN`, `url` → `URL`, "
-        "`vat` → `VAT`. Trailing identifier suffix is `Id` (camelCase), not `ID`.\n"
-        "6. Date/time columns prefer verb-form participles when context suggests "
-        "an event: `purchasedate` → `placedOn`; `returndate` → `returnedOn`; "
-        "`shipmentdate` → `shippedOn`. Plain time fields stay as-is: "
-        "`createdat` → `createdAt`.\n"
-        "7. Add a one-sentence rdfs:comment-style `description` for every item — "
-        "what the concept means in business terms.\n"
+        "4. PRIMARY-KEY identifiers collapse to `id`: "
+        "`clients.clientid` → `id`.\n"
+        "5. Acronyms stay UPPERCASE inside the label: `iban` → `IBAN`, "
+        "`url` → `URL`, `vat` → `VAT`, `eu_id` → `EU id`.\n"
+        "6. Date/time columns prefer participle phrases when context suggests "
+        "an event: `purchasedate` → `placed on`; `returndate` → `returned on`; "
+        "`shipmentdate` → `shipped on`. Plain timestamps stay descriptive: "
+        "`createdat` → `created at`.\n"
+        "7. Add a one-sentence `description` (intended for `rdfs:comment`) for "
+        "every item — what the concept means in business terms.\n"
         "8. If you are not confident about an item, OMIT it (do not invent).\n\n"
         "Output format — a single JSON object, no prose, no code fences, no "
         "wrapping. Keys are exactly `classes`, `properties`, `relationships`.\n"
@@ -537,14 +544,21 @@ def _build_rename_prompt(items: list[str]) -> str:
         "columns that share a name across tables.\n\n"
         "Worked example. Input:\n"
         "  CLASS  clientcomplaints\n"
+        "  CLASS  acctbal\n"
         "  PROP   purchases.purchaseamount\n"
         "  PROP   purchases.purchasechanid\n"
+        "  PROP   purchases.purchasedate\n"
         "  PROP   sales.salesclient\n"
+        "  PROP   sales.salespaymenttype\n"
+        "  PROP   products.unitsinstock\n"
+        "  PROP   calendar.publicholiday\n"
         "  PROP   acctbal.iban\n"
         "Output:\n"
-        '{"classes":[{"original_name":"clientcomplaints",'
-        '"suggested_name":"ClientComplaint",'
-        '"description":"A complaint filed by a client."}],'
+        '{"classes":['
+        '{"original_name":"clientcomplaints","suggested_name":"Client Complaint",'
+        '"description":"A complaint filed by a client."},'
+        '{"original_name":"acctbal","suggested_name":"Account Balance",'
+        '"description":"A record of the financial balance for an account."}],'
         '"properties":['
         '{"original_name":"purchaseamount","suggested_name":"amount",'
         '"description":"Total monetary amount of the purchase.",'
@@ -552,9 +566,21 @@ def _build_rename_prompt(items: list[str]) -> str:
         '{"original_name":"purchasechanid","suggested_name":"channel",'
         '"description":"Sales channel through which the purchase was placed.",'
         '"table_name":"purchases"},'
+        '{"original_name":"purchasedate","suggested_name":"placed on",'
+        '"description":"Date the purchase was placed.",'
+        '"table_name":"purchases"},'
         '{"original_name":"salesclient","suggested_name":"client",'
         '"description":"The client who placed the sale.",'
         '"table_name":"sales"},'
+        '{"original_name":"salespaymenttype","suggested_name":"payment type",'
+        '"description":"Method of payment used for the sale.",'
+        '"table_name":"sales"},'
+        '{"original_name":"unitsinstock","suggested_name":"units in stock",'
+        '"description":"Number of units currently held in inventory.",'
+        '"table_name":"products"},'
+        '{"original_name":"publicholiday","suggested_name":"is public holiday",'
+        '"description":"Whether the calendar date falls on a public holiday.",'
+        '"table_name":"calendar"},'
         '{"original_name":"iban","suggested_name":"IBAN",'
         '"description":"International Bank Account Number for the account.",'
         '"table_name":"acctbal"}],'

--- a/src/handlers/ontology.py
+++ b/src/handlers/ontology.py
@@ -16,6 +16,7 @@ from ..lifecycle.metadata import update_workspace_section, update_workspace_rdf
 from ..paths import ensure_output_dir, get_connection_dir, OUTPUT_DIR, PROJECT_ROOT
 from ..constants import OBA_NAMESPACE
 from ..oxigraph_store import OXIGRAPH_AVAILABLE
+from ..config import config_manager
 
 logger = logging.getLogger(__name__)
 
@@ -392,6 +393,90 @@ To improve ontology for business users:
         return _build_minimal_graph_summary(ontology_ttl)
 
 
+async def _maybe_sample_rename_suggestions(
+    ctx: Context,
+    cryptic_classes: list,
+    cryptic_props_by_table: Dict[str, list],
+    cryptic_relationships: list,
+) -> Optional[Dict[str, str]]:
+    """Ask the host LLM (via MCP sampling) to suggest human-readable names.
+
+    Returns a flat ``{old_local_name: suggested_name}`` mapping, or ``None`` if
+    sampling is disabled, the client doesn't support it, or the call fails —
+    in which case the caller should return the legacy review-then-apply payload.
+    """
+    if not config_manager.get_server_config().enable_sampling:
+        logger.info("MCP sampling disabled (ENABLE_SAMPLING=false) — using legacy review path")
+        return None
+
+    if not (cryptic_classes or cryptic_props_by_table or cryptic_relationships):
+        return {}
+
+    items: list[str] = []
+    for c in cryptic_classes:
+        items.append(f"CLASS  {c}")
+    for table, cols in cryptic_props_by_table.items():
+        for col in cols:
+            items.append(f"PROP   {table}.{col}")
+    for r in cryptic_relationships:
+        items.append(f"REL    {r}")
+
+    logger.info(
+        "MCP sampling: requesting rename suggestions for %d items "
+        "(%d classes, %d properties, %d relationships)",
+        len(items),
+        len(cryptic_classes),
+        sum(len(v) for v in cryptic_props_by_table.values()),
+        len(cryptic_relationships),
+    )
+    started = datetime.now()
+
+    prompt = (
+        "You are normalizing cryptic database identifiers into clear, "
+        "business-friendly names suitable for an ontology.\n\n"
+        "For each item below, return the suggested name as the value, "
+        "keyed by the bare identifier (the part after the type prefix and "
+        "any table qualifier — e.g. for `PROP customer.cust_id` the key is "
+        "`cust_id`). Preserve meaning; expand abbreviations; use "
+        "PascalCase for classes and camelCase for properties/relationships. "
+        "Only include items you are confident about.\n\n"
+        "Items:\n" + "\n".join(items)
+    )
+
+    try:
+        result = await ctx.sample(
+            messages=prompt,
+            system_prompt="Expert in data modeling and ontology design.",
+            temperature=0.2,
+            max_tokens=2000,
+            result_type=Dict[str, str],
+        )
+    except Exception as e:
+        logger.warning(
+            "MCP sampling unavailable or failed after %.2fs (%s: %s) — "
+            "falling back to manual review path",
+            (datetime.now() - started).total_seconds(),
+            type(e).__name__,
+            str(e)[:200],
+        )
+        return None
+
+    elapsed = (datetime.now() - started).total_seconds()
+    suggestions = result.result if hasattr(result, "result") else None
+    if not isinstance(suggestions, dict) or not suggestions:
+        logger.info("MCP sampling returned no usable suggestions (%.2fs)", elapsed)
+        return None
+
+    cleaned = {str(k): str(v) for k, v in suggestions.items() if k and v and str(k) != str(v)}
+    logger.info(
+        "MCP sampling: received %d suggestions in %.2fs (model=%s)",
+        len(cleaned),
+        elapsed,
+        getattr(result, "model", "unknown"),
+    )
+    return cleaned
+
+
 async def suggest_semantic_names(
     ctx: Context,
     ontology_file: Optional[str],
@@ -454,6 +539,34 @@ async def suggest_semantic_names(
             + len(cryptic_relationships)
         )
         summary = extraction_result["summary"]
+
+        sampled_suggestions = await _maybe_sample_rename_suggestions(
+            ctx,
+            cryptic_classes=cryptic_classes,
+            cryptic_props_by_table=cryptic_props_by_table,
+            cryptic_relationships=cryptic_relationships,
+        )
+
+        if sampled_suggestions:
+            await ctx.info(
+                f"Found {total_cryptic} cryptic names; "
+                f"server pre-filled {len(sampled_suggestions)} suggestions via MCP sampling — "
+                f"review and call apply_semantic_names"
+            )
+            return {
+                "ontology_file": source_filename,
+                "summary": summary,
+                "cryptic_classes": cryptic_classes,
+                "cryptic_properties_by_table": cryptic_props_by_table,
+                "cryptic_relationships": cryptic_relationships,
+                "suggestions": sampled_suggestions,
+                "suggestions_source": "mcp_sampling",
+                "next_step": (
+                    "Suggestions were pre-generated via MCP sampling. "
+                    "Pass them to apply_semantic_names (edit any you want to change)."
+                ),
+                "next_tool": "apply_semantic_names",
+            }
 
         await ctx.info(
             f"Found {total_cryptic} cryptic names to review; "

--- a/src/handlers/ontology.py
+++ b/src/handlers/ontology.py
@@ -399,19 +399,29 @@ async def _maybe_sample_rename_suggestions(
     cryptic_classes: list,
     cryptic_props_by_table: Dict[str, list],
     cryptic_relationships: list,
-) -> Optional[Dict[str, str]]:
-    """Ask the host LLM (via MCP sampling) to suggest human-readable names.
+) -> Optional[Dict[str, Any]]:
+    """Ask the host LLM (via MCP sampling) for ontology-shaped rename suggestions.
 
-    Returns a flat ``{old_local_name: suggested_name}`` mapping, or ``None`` if
-    sampling is disabled, the client doesn't support it, or the call fails —
-    in which case the caller should return the legacy review-then-apply payload.
+    Returns the structured payload that ``apply_semantic_names`` consumes
+    natively::
+
+        {
+          "classes":       [{"original_name", "suggested_name", "description"}],
+          "properties":    [{"original_name", "suggested_name", "description",
+                             "table_name"}],
+          "relationships": [{"original_name", "suggested_name", "description"}],
+        }
+
+    Returns ``None`` if sampling is disabled, the client doesn't support it,
+    or the call fails — caller falls back to the legacy review-then-apply
+    payload.
     """
     if not config_manager.get_server_config().enable_sampling:
         logger.info("MCP sampling disabled (ENABLE_SAMPLING=false) — using legacy review path")
         return None
 
     if not (cryptic_classes or cryptic_props_by_table or cryptic_relationships):
-        return {}
+        return {"classes": [], "properties": [], "relationships": []}
 
     items: list[str] = []
     for c in cryptic_classes:
@@ -432,27 +442,18 @@ async def _maybe_sample_rename_suggestions(
     )
     started = datetime.now()
 
-    prompt = (
-        "You are normalizing cryptic database identifiers into clear, "
-        "business-friendly names suitable for an ontology.\n\n"
-        "For each item below, return the suggested name as the value, "
-        "keyed by the bare identifier (the part after the type prefix and "
-        "any table qualifier — e.g. for `PROP customer.cust_id` the key is "
-        "`cust_id`). Preserve meaning; expand abbreviations; use "
-        "PascalCase for classes and camelCase for properties/relationships. "
-        "Only include items you are confident about.\n\n"
-        "Respond with a single JSON object on its own (no prose, no code "
-        "fences) where each key is the original identifier and each value "
-        "is the suggested human-readable name. Do not wrap the JSON.\n\n"
-        "Items:\n" + "\n".join(items)
-    )
+    prompt = _build_rename_prompt(items)
 
     try:
         result = await ctx.sample(
             messages=prompt,
-            system_prompt="Expert in data modeling and ontology design. Respond with JSON only.",
+            system_prompt=(
+                "You are an expert ontology and information-architecture designer. "
+                "Produce concise, business-friendly OWL labels — not literal "
+                "column names. Respond with one JSON object only."
+            ),
             temperature=0.2,
-            max_tokens=4000,
+            max_tokens=8000,
         )
     except Exception as e:
         logger.warning(
@@ -466,8 +467,14 @@ async def _maybe_sample_rename_suggestions(
 
     elapsed = (datetime.now() - started).total_seconds()
     raw_text = getattr(result, "text", None) or ""
-    suggestions = _parse_rename_json(raw_text)
-    if not suggestions:
+    parsed = _parse_rename_json(raw_text)
+    suggestions = _normalize_structured_suggestions(parsed)
+    total = (
+        len(suggestions.get("classes") or [])
+        + len(suggestions.get("properties") or [])
+        + len(suggestions.get("relationships") or [])
+    )
+    if total == 0:
         logger.info(
             "MCP sampling returned no usable suggestions (%.2fs, %d chars text)",
             elapsed,
@@ -475,26 +482,141 @@ async def _maybe_sample_rename_suggestions(
         )
         return None
 
-    cleaned = {
-        str(k): str(v)
-        for k, v in suggestions.items()
-        if k and v and str(k).strip() != str(v).strip()
-    }
     logger.info(
-        "MCP sampling: received %d suggestions in %.2fs (model=%s)",
-        len(cleaned),
+        "MCP sampling: received %d suggestions (%d classes, %d properties, "
+        "%d relationships) in %.2fs (model=%s)",
+        total,
+        len(suggestions.get("classes") or []),
+        len(suggestions.get("properties") or []),
+        len(suggestions.get("relationships") or []),
         elapsed,
         getattr(result, "model", "unknown"),
     )
-    return cleaned
+    return suggestions
 
 
-def _parse_rename_json(text: str) -> Optional[Dict[str, str]]:
+def _build_rename_prompt(items: list[str]) -> str:
+    """Compose the sampling prompt with concrete naming rules and a worked example."""
+    return (
+        "You are renaming cryptic identifiers in a SQL-derived OWL ontology so "
+        "the resulting labels read like domain language, not table columns.\n\n"
+        "Each PROP item is qualified as `table.column`. The table is the OWL "
+        "class the property belongs to — its name is implicit context, so "
+        "REMOVE redundant prefixes from the property name.\n\n"
+        "Naming rules (apply strictly):\n"
+        "1. CLASSES → singular PascalCase. Example: `clientcomplaints` → "
+        "`ClientComplaint`.\n"
+        "2. PROPERTIES → camelCase, no underscores, no table prefix. "
+        "Examples: `purchases.purchaseamount` → `amount`; "
+        "`sales.salesdate` → `date` (or `placedOn`); "
+        "`clients.clientname` → `name`.\n"
+        "3. FOREIGN-KEY columns become object-property names that READ LIKE THE "
+        "RELATED ENTITY — drop the trailing `Id` and the source-table prefix. "
+        "Examples: `sales.salesclient` → `client`; "
+        "`purchases.purchaseproduct` → `product`; "
+        "`purchases.purchasechanid` → `channel`.\n"
+        "4. PRIMARY-KEY identifiers stay short: `clients.clientid` → `id`.\n"
+        "5. Acronyms remain uppercase: `iban` → `IBAN`, `url` → `URL`, "
+        "`vat` → `VAT`. Trailing identifier suffix is `Id` (camelCase), not `ID`.\n"
+        "6. Date/time columns prefer verb-form participles when context suggests "
+        "an event: `purchasedate` → `placedOn`; `returndate` → `returnedOn`; "
+        "`shipmentdate` → `shippedOn`. Plain time fields stay as-is: "
+        "`createdat` → `createdAt`.\n"
+        "7. Add a one-sentence rdfs:comment-style `description` for every item — "
+        "what the concept means in business terms.\n"
+        "8. If you are not confident about an item, OMIT it (do not invent).\n\n"
+        "Output format — a single JSON object, no prose, no code fences, no "
+        "wrapping. Keys are exactly `classes`, `properties`, `relationships`.\n"
+        "- `classes[i]`        : {original_name, suggested_name, description}\n"
+        "- `properties[i]`     : {original_name, suggested_name, description, "
+        "table_name}\n"
+        "- `relationships[i]`  : {original_name, suggested_name, description}\n"
+        "  `original_name` is the bare identifier (part after the table dot for "
+        "PROP items).\n"
+        "  `table_name` is the table for PROP items — REQUIRED to disambiguate "
+        "columns that share a name across tables.\n\n"
+        "Worked example. Input:\n"
+        "  CLASS  clientcomplaints\n"
+        "  PROP   purchases.purchaseamount\n"
+        "  PROP   purchases.purchasechanid\n"
+        "  PROP   sales.salesclient\n"
+        "  PROP   acctbal.iban\n"
+        "Output:\n"
+        '{"classes":[{"original_name":"clientcomplaints",'
+        '"suggested_name":"ClientComplaint",'
+        '"description":"A complaint filed by a client."}],'
+        '"properties":['
+        '{"original_name":"purchaseamount","suggested_name":"amount",'
+        '"description":"Total monetary amount of the purchase.",'
+        '"table_name":"purchases"},'
+        '{"original_name":"purchasechanid","suggested_name":"channel",'
+        '"description":"Sales channel through which the purchase was placed.",'
+        '"table_name":"purchases"},'
+        '{"original_name":"salesclient","suggested_name":"client",'
+        '"description":"The client who placed the sale.",'
+        '"table_name":"sales"},'
+        '{"original_name":"iban","suggested_name":"IBAN",'
+        '"description":"International Bank Account Number for the account.",'
+        '"table_name":"acctbal"}],'
+        '"relationships":[]}\n\n'
+        "Now produce suggestions for the items below. Items:\n"
+        + "\n".join(items)
+    )
+
+
+def _normalize_structured_suggestions(parsed: Optional[Dict[str, Any]]) -> Dict[str, list]:
+    """Validate and clean a structured suggestions payload.
+
+    Drops items missing required fields, strips suggestions that match the
+    original verbatim, and guarantees the three top-level keys exist.
+    """
+    out: Dict[str, list] = {"classes": [], "properties": [], "relationships": []}
+    if not isinstance(parsed, dict):
+        return out
+
+    def _clean_item(item: Any, *, require_table: bool) -> Optional[Dict[str, str]]:
+        if not isinstance(item, dict):
+            return None
+        original = str(item.get("original_name") or "").strip()
+        suggested = str(item.get("suggested_name") or "").strip()
+        if not original or not suggested or original == suggested:
+            return None
+        cleaned: Dict[str, str] = {
+            "original_name": original,
+            "suggested_name": suggested,
+        }
+        description = item.get("description")
+        if description:
+            cleaned["description"] = str(description).strip()
+        table_name = item.get("table_name")
+        if table_name:
+            cleaned["table_name"] = str(table_name).strip()
+        elif require_table:
+            return None
+        return cleaned
+
+    for item in parsed.get("classes") or []:
+        c = _clean_item(item, require_table=False)
+        if c:
+            out["classes"].append(c)
+    for item in parsed.get("properties") or []:
+        p = _clean_item(item, require_table=True)
+        if p:
+            out["properties"].append(p)
+    for item in parsed.get("relationships") or []:
+        r = _clean_item(item, require_table=False)
+        if r:
+            out["relationships"].append(r)
+
+    return out
+
+
+def _parse_rename_json(text: str) -> Optional[Dict[str, Any]]:
     """Best-effort JSON extraction from a sampling text response.
 
     Handles three common shapes: a bare JSON object, a JSON object inside
     ```json fences, and a JSON object embedded in surrounding prose. Returns
-    a flat str→str dict or None if nothing parses.
+    the parsed dict or None if nothing parses.
     """
     if not text:
         return None
@@ -595,11 +717,15 @@ async def suggest_semantic_names(
             cryptic_relationships=cryptic_relationships,
         )
 
-        if sampled_suggestions:
+        if sampled_suggestions and any(sampled_suggestions.get(k) for k in ("classes", "properties", "relationships")):
+            sampled_total = sum(
+                len(sampled_suggestions.get(k) or [])
+                for k in ("classes", "properties", "relationships")
+            )
             await safe_ctx_info(
                 ctx,
                 f"Found {total_cryptic} cryptic names; "
-                f"server pre-filled {len(sampled_suggestions)} suggestions via MCP sampling — "
+                f"server pre-filled {sampled_total} suggestions via MCP sampling — "
                 f"review and call apply_semantic_names",
             )
             return {
@@ -611,8 +737,10 @@ async def suggest_semantic_names(
                 "suggestions": sampled_suggestions,
                 "suggestions_source": "mcp_sampling",
                 "next_step": (
-                    "Suggestions were pre-generated via MCP sampling. "
-                    "Pass them to apply_semantic_names (edit any you want to change)."
+                    "Suggestions are in apply_semantic_names native format "
+                    "({classes, properties, relationships} arrays). Pass the "
+                    "`suggestions` value through to apply_semantic_names "
+                    "verbatim, or edit individual entries first."
                 ),
                 "next_tool": "apply_semantic_names",
             }

--- a/src/handlers/ontology.py
+++ b/src/handlers/ontology.py
@@ -17,6 +17,7 @@ from ..paths import ensure_output_dir, get_connection_dir, OUTPUT_DIR, PROJECT_R
 from ..constants import OBA_NAMESPACE
 from ..oxigraph_store import OXIGRAPH_AVAILABLE
 from ..config import config_manager
+from ..utils import safe_ctx_info, is_client_disconnect
 
 logger = logging.getLogger(__name__)
 
@@ -548,10 +549,11 @@ async def suggest_semantic_names(
         )
 
         if sampled_suggestions:
-            await ctx.info(
+            await safe_ctx_info(
+                ctx,
                 f"Found {total_cryptic} cryptic names; "
                 f"server pre-filled {len(sampled_suggestions)} suggestions via MCP sampling — "
-                f"review and call apply_semantic_names"
+                f"review and call apply_semantic_names",
             )
             return {
                 "ontology_file": source_filename,
@@ -568,9 +570,10 @@ async def suggest_semantic_names(
                 "next_tool": "apply_semantic_names",
             }
 
-        await ctx.info(
+        await safe_ctx_info(
+            ctx,
             f"Found {total_cryptic} cryptic names to review; "
-            f"next call should be apply_semantic_names with your suggestions"
+            f"next call should be apply_semantic_names with your suggestions",
         )
 
         return {
@@ -584,6 +587,12 @@ async def suggest_semantic_names(
         }
 
     except Exception as e:
+        if is_client_disconnect(e):
+            logger.warning(
+                "MCP client closed the session during suggest_semantic_names; "
+                "skipping error response (transport already closed)"
+            )
+            raise
         logger.error(f"Error extracting names for review: {e}")
         return {
             "error": f"Failed to extract names: {str(e)}",

--- a/src/handlers/ontology.py
+++ b/src/handlers/ontology.py
@@ -498,39 +498,32 @@ async def _maybe_sample_rename_suggestions(
 def _build_rename_prompt(items: list[str]) -> str:
     """Compose the sampling prompt with concrete naming rules and a worked example."""
     return (
-        "You are producing human-readable rdfs:label values for an OWL ontology "
-        "derived from a SQL schema. The URI of each resource is unchanged — "
-        "you are only writing the *display label* a domain user will see in "
-        "Protégé, GraphDB, and OBQC error messages. Labels should read like "
-        "natural language, NOT like code identifiers.\n\n"
+        "You are renaming cryptic identifiers in a SQL-derived OWL ontology so "
+        "the resulting labels read like domain language, not table columns.\n\n"
         "Each PROP item is qualified as `table.column`. The table is the OWL "
         "class the property belongs to — its name is implicit context, so "
         "REMOVE redundant prefixes from the property name.\n\n"
-        "Naming rules (apply strictly and consistently):\n"
-        "1. CLASS labels → Title Case With Spaces, singular noun phrase. "
-        "Examples: `clientcomplaints` → `Client Complaint`; "
-        "`acctbal` → `Account Balance`; `customers` → `Customer`.\n"
-        "2. PROPERTY labels → lowercase with spaces between words. No "
-        "camelCase, no underscores, no table prefix. "
+        "Naming rules (apply strictly):\n"
+        "1. CLASSES → singular PascalCase. Example: `clientcomplaints` → "
+        "`ClientComplaint`.\n"
+        "2. PROPERTIES → camelCase, no underscores, no table prefix. "
         "Examples: `purchases.purchaseamount` → `amount`; "
-        "`products.unitsinstock` → `units in stock`; "
-        "`calendar.publicholiday` → `is public holiday`; "
-        "`sales.salespaymenttype` → `payment type`.\n"
-        "3. FOREIGN-KEY columns become object-property labels naming the "
-        "RELATED ENTITY in lowercase — drop the trailing `id` and any source-"
-        "table prefix. Examples: `sales.salesclient` → `client`; "
+        "`sales.salesdate` → `date` (or `placedOn`); "
+        "`clients.clientname` → `name`.\n"
+        "3. FOREIGN-KEY columns become object-property names that READ LIKE THE "
+        "RELATED ENTITY — drop the trailing `Id` and the source-table prefix. "
+        "Examples: `sales.salesclient` → `client`; "
         "`purchases.purchaseproduct` → `product`; "
         "`purchases.purchasechanid` → `channel`.\n"
-        "4. PRIMARY-KEY identifiers collapse to `id`: "
-        "`clients.clientid` → `id`.\n"
-        "5. Acronyms stay UPPERCASE inside the label: `iban` → `IBAN`, "
-        "`url` → `URL`, `vat` → `VAT`, `eu_id` → `EU id`.\n"
-        "6. Date/time columns prefer participle phrases when context suggests "
-        "an event: `purchasedate` → `placed on`; `returndate` → `returned on`; "
-        "`shipmentdate` → `shipped on`. Plain timestamps stay descriptive: "
-        "`createdat` → `created at`.\n"
-        "7. Add a one-sentence `description` (intended for `rdfs:comment`) for "
-        "every item — what the concept means in business terms.\n"
+        "4. PRIMARY-KEY identifiers stay short: `clients.clientid` → `id`.\n"
+        "5. Acronyms remain uppercase: `iban` → `IBAN`, `url` → `URL`, "
+        "`vat` → `VAT`. Trailing identifier suffix is `Id` (camelCase), not `ID`.\n"
+        "6. Date/time columns prefer verb-form participles when context suggests "
+        "an event: `purchasedate` → `placedOn`; `returndate` → `returnedOn`; "
+        "`shipmentdate` → `shippedOn`. Plain time fields stay as-is: "
+        "`createdat` → `createdAt`.\n"
+        "7. Add a one-sentence rdfs:comment-style `description` for every item — "
+        "what the concept means in business terms.\n"
         "8. If you are not confident about an item, OMIT it (do not invent).\n\n"
         "Output format — a single JSON object, no prose, no code fences, no "
         "wrapping. Keys are exactly `classes`, `properties`, `relationships`.\n"
@@ -544,21 +537,14 @@ def _build_rename_prompt(items: list[str]) -> str:
         "columns that share a name across tables.\n\n"
         "Worked example. Input:\n"
         "  CLASS  clientcomplaints\n"
-        "  CLASS  acctbal\n"
         "  PROP   purchases.purchaseamount\n"
         "  PROP   purchases.purchasechanid\n"
-        "  PROP   purchases.purchasedate\n"
         "  PROP   sales.salesclient\n"
-        "  PROP   sales.salespaymenttype\n"
-        "  PROP   products.unitsinstock\n"
-        "  PROP   calendar.publicholiday\n"
         "  PROP   acctbal.iban\n"
         "Output:\n"
-        '{"classes":['
-        '{"original_name":"clientcomplaints","suggested_name":"Client Complaint",'
-        '"description":"A complaint filed by a client."},'
-        '{"original_name":"acctbal","suggested_name":"Account Balance",'
-        '"description":"A record of the financial balance for an account."}],'
+        '{"classes":[{"original_name":"clientcomplaints",'
+        '"suggested_name":"ClientComplaint",'
+        '"description":"A complaint filed by a client."}],'
         '"properties":['
         '{"original_name":"purchaseamount","suggested_name":"amount",'
         '"description":"Total monetary amount of the purchase.",'
@@ -566,21 +552,9 @@ def _build_rename_prompt(items: list[str]) -> str:
         '{"original_name":"purchasechanid","suggested_name":"channel",'
         '"description":"Sales channel through which the purchase was placed.",'
         '"table_name":"purchases"},'
-        '{"original_name":"purchasedate","suggested_name":"placed on",'
-        '"description":"Date the purchase was placed.",'
-        '"table_name":"purchases"},'
         '{"original_name":"salesclient","suggested_name":"client",'
         '"description":"The client who placed the sale.",'
         '"table_name":"sales"},'
-        '{"original_name":"salespaymenttype","suggested_name":"payment type",'
-        '"description":"Method of payment used for the sale.",'
-        '"table_name":"sales"},'
-        '{"original_name":"unitsinstock","suggested_name":"units in stock",'
-        '"description":"Number of units currently held in inventory.",'
-        '"table_name":"products"},'
-        '{"original_name":"publicholiday","suggested_name":"is public holiday",'
-        '"description":"Whether the calendar date falls on a public holiday.",'
-        '"table_name":"calendar"},'
         '{"original_name":"iban","suggested_name":"IBAN",'
         '"description":"International Bank Account Number for the account.",'
         '"table_name":"acctbal"}],'

--- a/src/handlers/ontology.py
+++ b/src/handlers/ontology.py
@@ -441,16 +441,18 @@ async def _maybe_sample_rename_suggestions(
         "`cust_id`). Preserve meaning; expand abbreviations; use "
         "PascalCase for classes and camelCase for properties/relationships. "
         "Only include items you are confident about.\n\n"
+        "Respond with a single JSON object on its own (no prose, no code "
+        "fences) where each key is the original identifier and each value "
+        "is the suggested human-readable name. Do not wrap the JSON.\n\n"
         "Items:\n" + "\n".join(items)
     )
 
     try:
         result = await ctx.sample(
             messages=prompt,
-            system_prompt="Expert in data modeling and ontology design.",
+            system_prompt="Expert in data modeling and ontology design. Respond with JSON only.",
             temperature=0.2,
-            max_tokens=2000,
-            result_type=Dict[str, str],
+            max_tokens=4000,
         )
     except Exception as e:
         logger.warning(
@@ -463,12 +465,21 @@ async def _maybe_sample_rename_suggestions(
         return None
 
     elapsed = (datetime.now() - started).total_seconds()
-    suggestions = result.result if hasattr(result, "result") else None
-    if not isinstance(suggestions, dict) or not suggestions:
-        logger.info("MCP sampling returned no usable suggestions (%.2fs)", elapsed)
+    raw_text = getattr(result, "text", None) or ""
+    suggestions = _parse_rename_json(raw_text)
+    if not suggestions:
+        logger.info(
+            "MCP sampling returned no usable suggestions (%.2fs, %d chars text)",
+            elapsed,
+            len(raw_text),
+        )
         return None
 
-    cleaned = {str(k): str(v) for k, v in suggestions.items() if k and v and str(k) != str(v)}
+    cleaned = {
+        str(k): str(v)
+        for k, v in suggestions.items()
+        if k and v and str(k).strip() != str(v).strip()
+    }
     logger.info(
         "MCP sampling: received %d suggestions in %.2fs (model=%s)",
         len(cleaned),
@@ -476,6 +487,42 @@ async def _maybe_sample_rename_suggestions(
         getattr(result, "model", "unknown"),
     )
     return cleaned
+
+
+def _parse_rename_json(text: str) -> Optional[Dict[str, str]]:
+    """Best-effort JSON extraction from a sampling text response.
+
+    Handles three common shapes: a bare JSON object, a JSON object inside
+    ```json fences, and a JSON object embedded in surrounding prose. Returns
+    a flat str→str dict or None if nothing parses.
+    """
+    if not text:
+        return None
+
+    candidates: list[str] = []
+
+    stripped = text.strip()
+    if stripped.startswith("{") and stripped.endswith("}"):
+        candidates.append(stripped)
+
+    fence_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL | re.IGNORECASE)
+    if fence_match:
+        candidates.append(fence_match.group(1))
+
+    first_brace = text.find("{")
+    last_brace = text.rfind("}")
+    if first_brace != -1 and last_brace > first_brace:
+        candidates.append(text[first_brace : last_brace + 1])
+
+    for candidate in candidates:
+        try:
+            parsed = json.loads(candidate)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(parsed, dict) and parsed:
+            return parsed
+
+    return None
 
 
 async def suggest_semantic_names(

--- a/src/main.py
+++ b/src/main.py
@@ -665,6 +665,11 @@ async def suggest_semantic_names(
 ) -> Dict[str, Any]:
     """Extract and analyze names from a generated ontology to identify abbreviations and cryptic names.
 
+    When the connected MCP client supports sampling (and ENABLE_SAMPLING=true),
+    the server pre-fills a ``suggestions`` dict via the host LLM so the next
+    call to ``apply_semantic_names`` can pass them through directly. Otherwise
+    the response contains only the cryptic-name lists for manual review.
+
     Args:
         ontology_file: The ontology filename from generate_ontology response
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -6,6 +6,37 @@ from typing import Any
 from urllib.parse import urlparse
 
 
+async def safe_ctx_info(ctx: Any, message: str) -> None:
+    """Send an MCP info notification without ever propagating transport errors.
+
+    A notification failing (e.g. ``anyio.ClosedResourceError`` because the
+    client already closed the session) must not abort the tool call — the
+    real result still has to flow back through the framework's response path.
+    Logs failures at debug level since they are usually benign client
+    disconnects.
+    """
+    try:
+        await ctx.info(message)
+    except Exception as exc:
+        logging.getLogger(__name__).debug(
+            "ctx.info send failed (%s); continuing", type(exc).__name__
+        )
+
+
+def is_client_disconnect(exc: BaseException) -> bool:
+    """Return True if *exc* indicates the MCP client closed the session.
+
+    Used to short-circuit error-response writes that would themselves fail
+    against a closed transport stream and turn a benign disconnect into a
+    crashed task group.
+    """
+    try:
+        from anyio import ClosedResourceError, BrokenResourceError, EndOfStream
+    except ImportError:
+        return False
+    return isinstance(exc, (ClosedResourceError, BrokenResourceError, EndOfStream))
+
+
 def setup_logging(log_level: str = "INFO", structured: bool = False) -> logging.Logger:
     """
     Setup logging configuration for the application.

--- a/uv.lock
+++ b/uv.lock
@@ -2421,7 +2421,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-analytics"
-version = "1.4.2"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Adds **MCP sampling** to `suggest_semantic_names`: when the connected client supports it, the server calls back through the host LLM via `ctx.sample()` and returns a pre-filled `suggestions` payload in `apply_semantic_names`'s native `{classes, properties, relationships}` shape. Clients without sampling support (Claude Desktop, Claude Code, etc.) silently fall back to today's manual review path. Gated on `ENABLE_SAMPLING` env flag (default `true`).
- **Hardens the handler against client disconnects** — `anyio.ClosedResourceError` from `ctx.info` no longer cascades into a second doomed write that crashed the entire FastMCP TaskGroup. Reusable `safe_ctx_info` / `is_client_disconnect` helpers added in `src/utils.py`.
- **Bumps version to 1.5.0** with full CHANGELOG, README, configuration, and integrations docs covering the new capability and per-client compatibility.

## Test plan
- [ ] Existing test suite passes (`uv run pytest`)
- [ ] On OrionBelt Chat (`feature/mcp-sampling` branch with sampling capability advertised): `suggest_semantic_names` returns `suggestions_source: "mcp_sampling"` with a populated `suggestions` object containing `classes`, `properties` (with `table_name`), and `relationships` arrays
- [ ] Pass that `suggestions` value verbatim to `apply_semantic_names` — produces a labelled ontology with `rdfs:label` and `rdfs:comment` populated for each entry
- [ ] On Claude Desktop (no sampling): same call returns the legacy response shape (cryptic-name lists, no `suggestions` field) — no crash, no breaking change
- [ ] `ENABLE_SAMPLING=false` in `.env` forces the legacy path even on a sampling-capable client
- [ ] Drop the OBC client mid-call during `suggest_semantic_names` — server logs a warning, no TaskGroup crash, session reconnects cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)