### PR TITLE
chore: add scripts/publish-docker.sh for Docker Hub releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 __pycache__/
 *.py[oc]
 design/
-scripts/
+scripts/*
+!scripts/publish-docker.sh
 build/
 dist/
 wheels/

--- a/scripts/publish-docker.sh
+++ b/scripts/publish-docker.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Build and push the OrionBelt Analytics Docker image to Docker Hub.
+#
+# Prerequisites:
+#   1. Log in once:           docker login -u ralforion
+#   2. A multi-arch builder:  docker buildx create --use --name oba-builder  (first time only)
+#
+# Usage:
+#   ./scripts/publish-docker.sh              # tags :<version> and :latest
+#   IMAGE=myorg/oba ./scripts/publish-docker.sh
+#   PLATFORMS=linux/amd64 ./scripts/publish-docker.sh
+#   SKIP_LATEST=1 ./scripts/publish-docker.sh
+
+set -euo pipefail
+
+IMAGE="${IMAGE:-ralforion/orionbelt-analytics}"
+PLATFORMS="${PLATFORMS:-linux/amd64,linux/arm64}"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+VERSION="$(grep -E '^__version__' src/__init__.py | sed -E 's/.*"([^"]+)".*/\1/')"
+if [[ -z "${VERSION}" ]]; then
+    echo "error: could not read __version__ from src/__init__.py" >&2
+    exit 1
+fi
+
+TAG_ARGS=( --tag "${IMAGE}:${VERSION}" )
+if [[ "${SKIP_LATEST:-0}" != "1" ]]; then
+    TAG_ARGS+=( --tag "${IMAGE}:latest" )
+fi
+
+if ! git diff --quiet HEAD -- . ':!scripts/publish-docker.sh' 2>/dev/null; then
+    echo "warning: working tree has uncommitted changes — published image will include them." >&2
+fi
+
+echo "Publishing ${IMAGE}:${VERSION}$( [[ "${SKIP_LATEST:-0}" != "1" ]] && echo ' (and :latest)') for ${PLATFORMS}"
+echo
+
+docker buildx build \
+    --platform "${PLATFORMS}" \
+    "${TAG_ARGS[@]}" \
+    --push \
+    "${REPO_ROOT}"
+
+echo
+echo "Pushed ${IMAGE}:${VERSION}$( [[ "${SKIP_LATEST:-0}" != "1" ]] && echo ' and :latest')"


### PR DESCRIPTION
## Summary
- Adds `scripts/publish-docker.sh`: reads `__version__` from `src/__init__.py` and pushes a multi-arch (`linux/amd64`, `linux/arm64`) image to `ralforion/orionbelt-analytics` tagged with the version and `:latest`
- Image name, platforms, and the `:latest` tag are overridable via `IMAGE`, `PLATFORMS`, `SKIP_LATEST` env vars
- Allowlists this single file in `.gitignore` so other local scripts under `scripts/` stay ignored

## Usage
```
docker login -u ralforion
docker buildx create --use --name oba-builder   # first time only
./scripts/publish-docker.sh
```

## Test plan
- [ ] `bash -n scripts/publish-docker.sh` passes (syntax check)
- [ ] Dry-run with `PLATFORMS=linux/amd64` builds and pushes a single-arch tag
- [ ] Full multi-arch run publishes `ralforion/orionbelt-analytics:1.5.0` and `:latest`
- [ ] `docker pull ralforion/orionbelt-analytics:1.5.0` works on both amd64 and arm64 hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)