### PR TITLE
docs: add GraphRAG and SPARQL/RDF flows to Recommended Workflows

### DIFF
--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -31,6 +31,23 @@ Complete reference for all OrionBelt Analytics MCP tools. These tools are invoke
 3. **sample_table_data** -- preview actual data
 4. **execute_sql_query** -- run queries
 
+### GraphRAG-Assisted Analysis (large schemas)
+
+1. **connect_database** -- connect
+2. **discover_schema** -- auto-initializes GraphRAG in the background
+3. **graphrag_query_context** -- narrow the schema to just the tables/columns relevant to the question (85-95% fewer tokens than the full schema)
+4. *(optional)* **graphrag_find_join_path** -- resolve how two specific tables join, or **graphrag_search** to explore the schema by keyword
+5. **execute_sql_query** -- run SQL informed by the focused context
+6. **generate_chart** -- visualize results
+
+### Semantic Exploration & Export (SPARQL / RDF)
+
+1. **connect_database** -- connect
+2. **discover_schema** -> **generate_ontology** -- generating the ontology auto-persists it to the Oxigraph RDF store (use **store_ontology_in_rdf** only if `auto_persist` was disabled)
+3. **query_sparql** -- explore classes, properties, and relationships semantically
+4. *(optional)* **add_rdf_knowledge** -- layer custom metadata triples onto the ontology
+5. **download_artifact** -- export the ontology or R2RML mapping as a Turtle file for external tools (Protégé, Ontop, D2RQ)
+
 ---
 
 ## Tool Reference


### PR DESCRIPTION
## Summary

The Recommended Workflows in `docs/tools-reference.md` only covered the connect → discover → ontology → SQL → chart path. The GraphRAG (#18–20), RDF/SPARQL (#21–23), and `download_artifact` (#10) tools were documented as standalone sections but never appeared in a workflow, so a reader had no guidance on *when* to use them.

Adds two workflows:

- **GraphRAG-Assisted Analysis (large schemas)** — `graphrag_query_context` to focus the schema, `graphrag_find_join_path` / `graphrag_search` to explore, then `execute_sql_query` → `generate_chart`.
- **Semantic Exploration & Export (SPARQL / RDF)** — ontology auto-persists to the RDF store (or `store_ontology_in_rdf`), then `query_sparql` to explore, `add_rdf_knowledge` to enrich, and `download_artifact` to export ontology/R2RML.

Docs-only; no code changes. Follow-up to #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)