### PR TITLE
feat: graph reasoning surface over generated ontology (v1.6.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,3 @@ Thumbs.db
 .mcpregistry_github_token
 .mcpregistry_registry_token
 .claude/settings.local.json
-
-# Claude Code project instructions (kept local)
-CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,6 @@ OrionBelt Analytics v1.0.0 now supports:
 - Ontology generation
 - Schema analysis tools
 
-[1.0.0]: https://github.com/ralfbecher/orionbelt-analytics/releases/tag/v1.0.0
-[0.7.0]: https://github.com/ralfbecher/orionbelt-analytics/releases/tag/v0.7.0
-[0.6.0]: https://github.com/ralfbecher/orionbelt-analytics/releases/tag/v0.6.0
+[1.0.0]: https://github.com/ralforion/orionbelt-analytics/releases/tag/v1.0.0
+[0.7.0]: https://github.com/ralforion/orionbelt-analytics/releases/tag/v0.7.0
+[0.6.0]: https://github.com/ralforion/orionbelt-analytics/releases/tag/v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to OrionBelt Analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-06-15
+
+### Added
+- **Graph reasoning surface over the generated ontology** (`design/PLAN_graph_reasoning.md`):
+  - **`oba:joinsTo` shared join predicate.** Every declared or inferred many-to-one foreign key now also emits a single directed `oba:joinsTo` edge between the table classes (finer grain → coarser grain). A single SPARQL property path `?from oba:joinsTo+ ?to` answers directed reachability across all FKs without enumerating each per-FK object property. Declared in `ontology/oba.ttl` (vocabulary bumped 0.1 → 0.2).
+  - **`reachable_from` MCP tool** — the dimension-capable tables for a query anchored on a table (many-to-one closure): coarser-grain tables joinable without row multiplication, safe to GROUP BY / filter on.
+  - **`measurable_from` MCP tool** — the measure-capable tables (one-to-many closure, the inverse): finer-grain tables that fan out the anchor and must only be aggregated, never used as dimensions at this grain. Both closures are cycle-safe.
+  - **`plan_composite_query` MCP tool** — advisory Composite Fact Layer (CFL) decomposition: detects whether the requested facts are independent grains (disjoint siblings) requiring a `UNION ALL` composite, and returns the leg roots, conformed (shared) GROUP BY dimensions, and per-leg NULL-pad sets. Advisory only — OBA does not compile SQL; defer compilation to OrionBelt Semantic Layer when connected.
+  - **Optional in-process SHACL validation.** When `pyshacl` is installed, `generate_ontology` validates the generated ontology against `ontology/oba-shacl.ttl` and surfaces violations as a non-blocking warning (gated by `OBA_SHACL_VALIDATE`, default on). Gracefully no-ops when the dependency or shapes file is absent.
+
+### Changed
+- **OBQC fan-trap detection is now grounded in the ontology's own `owl:disjointWith` axioms** (sibling facts sharing a dimension) instead of only re-deriving the risk from the relationship heuristic. When disjoint facts appear together in an aggregating query, OBQC cites the actual disjoint tables and recommends a Composite Fact Layer (UNION ALL). The relationship heuristic is retained as a fallback when no disjointness axioms are present.
+
 ## [1.5.3] - 2026-06-10
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+OrionBelt Analytics is an MCP server (FastMCP) that analyzes relational database schemas, generates RDF/OWL ontologies with embedded SQL mappings, and provides relationship-aware Text-to-SQL with fan-trap prevention, GraphRAG schema discovery, SPARQL access, and Plotly charting. Python 3.13+, managed with `uv`.
+
+## Commands
+
+```bash
+uv sync                                  # create venv + install all deps (prod + dev)
+uv run server.py                         # start the MCP server (http://localhost:9000)
+
+uv run pytest                            # full suite (coverage is on by default via addopts)
+uv run pytest tests/test_obqc_validator.py -v          # single file
+uv run pytest tests/test_obqc_validator.py::test_name -v   # single test
+uv run pytest -k "ontology and not server"             # keyword expression
+
+black src/ tests/ && isort src/ tests/   # format
+ruff check src/ tests/                   # lint
+mypy src/                                # strict type check (disallow_untyped_defs etc.)
+bandit -r src/                           # security scan (run for SQL/credential changes)
+pre-commit run --all-files               # all of the above as configured hooks
+```
+
+Config comes from `.env` (copy from `.env.template`). At minimum set credentials for one database. Key vars: `MCP_TRANSPORT` (http/sse), `MCP_SERVER_PORT` (9000), `AUTO_GRAPHRAG`, `SESSION_IDLE_TIMEOUT_SECONDS`, `AUTO_CLEANUP_ON_STARTUP`.
+
+## Architecture
+
+**Strict three-layer separation** — keep these boundaries when adding or changing tools:
+
+1. **Registration** (`src/main.py`): thin `@mcp.tool()` async wrappers. Extract session state, delegate to a handler. No business logic here.
+2. **Handlers** (`src/handlers/*.py`): tool implementation. Receive db manager / session data / config as parameters and orchestrate service modules. Grouped by domain (`connection`, `schema`, `ontology`, `query`, `chart`, `rdf`, `graphrag`, `workspace`).
+3. **Service** (`src/database_manager.py`, `src/ontology_generator.py`, `src/security.py`, `src/oxigraph_store.py`, `src/obqc_validator.py`, …): pure domain logic with **no MCP dependencies** — independently testable and importable for batch use.
+
+**Database drivers** (`src/drivers/`): `BaseDriver` (`base.py`) defines the abstract interface; one driver per dialect (postgresql, mysql, snowflake, clickhouse, dremio, bigquery, duckdb, databricks). Adding a database = implement `BaseDriver` + register in `database_manager.py`. Dialect quirks matter (e.g. Snowflake UPPERCASE/case-sensitive identifiers, ClickHouse has no FKs and uses `ORDER BY` as sort key) — account for case sensitivity, constraint models, and query syntax when touching schema or query logic.
+
+**Per-session / per-schema state** (`src/session.py`): each MCP session owns a `SessionData`. Ontology state is isolated **per schema** (`SchemaState` → `OntologyState`), but **GraphRAG and the Oxigraph RDF store are connection-scoped and accumulative** — successive `discover_schema()` calls add tables to the *same* graph/vector store/named-graphs, so cross-schema join discovery and unified search work, and switching schemas does not destroy a prior schema's ontology. Idle sessions are auto-evicted.
+
+**OBQC (Ontology-Based Query Check)** — the core differentiator. `src/obqc_validator.py` deterministically validates every SQL statement (parsed with `sqlglot`) against the loaded ontology: table/column existence, join validity, type compatibility, GROUP BY correctness, and **fan-trap detection** (aggregation across 1:many joins that silently multiplies rows). Runs inside `execute_sql_query` — **errors block execution, warnings attach to the response** for the LLM to self-correct. No LLM calls; fully deterministic.
+
+**Ontology / RDF**: `ontology_generator.py` emits OWL where tables → classes and FKs → object properties, annotated in the `oba:` namespace (`oba:tableName`, `oba:primaryKey`, `oba:sqlJoinCondition`) so SQL is recoverable from the graph. `oxigraph_store.py` persists triples for SPARQL 1.1. The shipped vocabulary lives in `ontology/oba.ttl` + `ontology/oba-shacl.ttl` (force-included into the wheel; SHACL conformance via `src/shacl_validator.py`).
+
+**GraphRAG** (`src/graphrag/`): `manager.py` orchestrates graph traversal (`retriever.py`, up to 12 hops), embeddings (`embedder.py`), community detection, and a ChromaDB vector store. Auto-initialized by `discover_schema()` when `AUTO_GRAPHRAG=true`.
+
+**MCP resources**: skill files under `.claude/skills/` (fan-trap prevention, SQL best practices, chart examples, workflows) are exposed via `@mcp.resource()` in `main.py`.
+
+`docs/development.md` has the full layout, design rationale, and contributing guide — read it for deeper context. Per-feature docs: `docs/obqc.md`, `docs/graphrag.md`, `docs/fan-trap-prevention.md`, `docs/configuration.md`, `docs/tools-reference.md`.
+
+## Conventions
+
+- **Conventional commits** (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, `chore:`).
+- Type hints required on all public functions (strict mypy); Google-style docstrings; 88-char lines; async handlers.
+- Tests in `tests/` as `test_*.py`; `pytest-asyncio` in `auto` mode (no `@pytest.mark.asyncio` needed).
+- Releases are **squash-only** (merge commits disabled) and PyPI publish is irreversible — see `scripts/bump-version.sh` and the release-process note in memory before cutting a release.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center"><strong>The Ontology-based MCP server for your Text-2-SQL convenience.</strong></p>
 
-[![Version 1.5.3](https://img.shields.io/badge/version-1.5.3-purple.svg)](https://github.com/ralfbecher/orionbelt-analytics/releases)
+[![Version 1.6.0](https://img.shields.io/badge/version-1.6.0-purple.svg)](https://github.com/ralfbecher/orionbelt-analytics/releases)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralfbecher/orionbelt-analytics/blob/main/LICENSE)
 [![FastMCP](https://img.shields.io/badge/FastMCP-3.3.1+-blue)](https://github.com/jlowin/fastmcp)
@@ -150,7 +150,7 @@ OrionBelt works with LangChain, OpenAI Agents SDK, CrewAI, Google ADK, Vercel AI
 
 ## Tools
 
-OrionBelt exposes 23 MCP tools. Here is a summary by category:
+OrionBelt exposes 26 MCP tools. Here is a summary by category:
 
 ### Connection & Schema
 
@@ -188,6 +188,9 @@ OrionBelt exposes 23 MCP tools. Here is a summary by category:
 | `graphrag_search`         | Semantic search + schema overview (auto-initialized by `discover_schema`) |
 | `graphrag_query_context`  | Get optimized context for SQL generation (85-95% token reduction)         |
 | `graphrag_find_join_path` | Discover join paths between tables via graph traversal                    |
+| `reachable_from`          | Dimension-capable tables for an anchor grain (many-to-one closure)        |
+| `measurable_from`         | Measure-capable tables for an anchor grain (one-to-many closure)          |
+| `plan_composite_query`    | Advise a fan-trap-safe Composite Fact Layer (UNION ALL) decomposition     |
 
 ### SPARQL & RDF
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-<!-- mcp-name: io.github.ralfbecher/orionbelt-analytics -->
+<!-- mcp-name: io.github.ralforion/orionbelt-analytics -->
 <p align="center">
-  <img src="https://raw.githubusercontent.com/ralfbecher/orionbelt-analytics/main/assets/ORIONBELT_Logo.png" alt="OrionBelt Logo" width="400">
+  <img src="https://raw.githubusercontent.com/ralforion/orionbelt-analytics/main/assets/ORIONBELT_Logo.png" alt="OrionBelt Logo" width="400">
 </p>
 
 <h1 align="center">OrionBelt Analytics</h1>
 
 <p align="center"><strong>The Ontology-based MCP server for your Text-2-SQL convenience.</strong></p>
 
-[![Version 1.6.0](https://img.shields.io/badge/version-1.6.0-purple.svg)](https://github.com/ralfbecher/orionbelt-analytics/releases)
+[![Version 1.6.0](https://img.shields.io/badge/version-1.6.0-purple.svg)](https://github.com/ralforion/orionbelt-analytics/releases)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
-[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralfbecher/orionbelt-analytics/blob/main/LICENSE)
+[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-analytics/blob/main/LICENSE)
 [![FastMCP](https://img.shields.io/badge/FastMCP-3.3.1+-blue)](https://github.com/jlowin/fastmcp)
 [![RDF/OWL](https://img.shields.io/badge/RDF%2FOWL-Ontology-orange)](https://www.w3.org/OWL/)
 
@@ -38,7 +38,7 @@ Run Analytics and Semantic Layer side-by-side in Claude Desktop for schema-aware
 ## Architecture
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/ralfbecher/orionbelt-analytics/main/assets/architecture.png" alt="OrionBelt Analytics Architecture" width="900">
+  <img src="https://raw.githubusercontent.com/ralforion/orionbelt-analytics/main/assets/architecture.png" alt="OrionBelt Analytics Architecture" width="900">
 </p>
 
 - **8 database connectors** -- PostgreSQL, MySQL, Snowflake, ClickHouse, Dremio, BigQuery, DuckDB/MotherDuck, Databricks SQL
@@ -79,7 +79,7 @@ OBQC is fully deterministic -- no LLM calls, no probabilistic reasoning. It acts
 ### 1. Install
 
 ```bash
-git clone https://github.com/ralfbecher/orionbelt-analytics
+git clone https://github.com/ralforion/orionbelt-analytics
 cd orionbelt-analytics
 uv sync
 ```
@@ -264,6 +264,6 @@ For commercial licensing inquiries, contact: licensing@ralforion.com
 
 <p align="center">
   <a href="https://ralforion.com">
-    <img src="https://raw.githubusercontent.com/ralfbecher/orionbelt-analytics/main/assets/RALFORION_doo_Logo.png" alt="RALFORION d.o.o." width="200">
+    <img src="https://raw.githubusercontent.com/ralforion/orionbelt-analytics/main/assets/RALFORION_doo_Logo.png" alt="RALFORION d.o.o." width="200">
   </a>
 </p>

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,7 +24,7 @@ Optional but recommended:
 ### 1. Clone and install
 
 ```bash
-git clone https://github.com/ralfbecher/orionbelt-analytics
+git clone https://github.com/ralforion/orionbelt-analytics
 cd orionbelt-analytics
 uv sync
 ```

--- a/ontology/oba-example.ttl
+++ b/ontology/oba-example.ttl
@@ -244,6 +244,9 @@ ns:customers_referenced_by_orders a owl:ObjectProperty ;
     rdfs:range ns:orders ;
     owl:inverseOf ns:orders_has_customers .
 
+# Shared traversable join edge (many-to-one / finer->coarser grain).
+ns:orders oba:joinsTo ns:customers .
+
 # =============================================================================
 # RELATIONSHIP: returns -> customers (declared FK)
 # =============================================================================
@@ -266,6 +269,9 @@ ns:customers_referenced_by_returns a owl:ObjectProperty ;
     rdfs:domain ns:customers ;
     rdfs:range ns:returns ;
     owl:inverseOf ns:returns_has_customers .
+
+# Shared traversable join edge (many-to-one / finer->coarser grain).
+ns:returns oba:joinsTo ns:customers .
 
 # =============================================================================
 # AXIOM: owl:disjointWith --- orders and returns are distinct populations

--- a/ontology/oba-shacl.ttl
+++ b/ontology/oba-shacl.ttl
@@ -6,7 +6,7 @@
 @prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 # =============================================================================
-# OBA SHACL Shapes 0.1
+# OBA SHACL Shapes 0.2
 #
 # Validation shapes for ontologies annotated with the OBA vocabulary.
 # These shapes target OWL entities (owl:Class, owl:DatatypeProperty,
@@ -235,7 +235,11 @@ oba:ColumnShape a sh:NodeShape ;
     ] .
 
 # -----------------------------------------------------------------------------
-# Relationship Shape (base) --- validates ALL owl:ObjectProperty instances
+# Relationship Shape (base) --- validates generated relationship properties
+#
+# Targets subjects of oba:relationshipType (every generated forward/inverse
+# relationship), not owl:ObjectProperty at large, so meta-level vocabulary
+# object properties (e.g. oba:joinsTo) are not treated as focus nodes.
 #
 # Both forward (FK-holding) and inverse relationships carry these properties.
 # FK-specific annotations (foreignKeyColumn, referencedTable, etc.) are only
@@ -243,9 +247,9 @@ oba:ColumnShape a sh:NodeShape ;
 # -----------------------------------------------------------------------------
 
 oba:RelationshipShape a sh:NodeShape ;
-    sh:targetClass owl:ObjectProperty ;
+    sh:targetSubjectsOf oba:relationshipType ;
     rdfs:label "OBA Relationship Shape" ;
-    rdfs:comment "Base shape for all OWL object properties (forward and inverse).  Validates structural properties common to both directions." ;
+    rdfs:comment "Base shape for generated relationship object properties (forward and inverse).  Targets subjects of oba:relationshipType so it validates only generated relationships, never meta-level vocabulary terms such as oba:joinsTo (which is an owl:ObjectProperty but carries no oba:relationshipType).  This keeps the shapes correct even when the OBA vocabulary is merged into the data graph (e.g. pyshacl -e oba.ttl)." ;
 
     # Required on both forward and inverse
     sh:property [

--- a/ontology/oba.ttl
+++ b/ontology/oba.ttl
@@ -20,8 +20,8 @@
 # =============================================================================
 
 <https://ralforion.com/ns/oba> a owl:Ontology ;
-    owl:versionIRI <https://ralforion.com/ns/oba/0.1> ;
-    owl:versionInfo "0.1" ;
+    owl:versionIRI <https://ralforion.com/ns/oba/0.2> ;
+    owl:versionInfo "0.2" ;
     rdfs:label "OrionBelt Analytics Ontology" ;
     rdfs:comment "Annotation vocabulary for physical database schema metadata.  Complements OBSL (OrionBelt Semantic Layer) which describes business-level concepts." ;
     dcterms:creator "Ralf Becher" ;
@@ -99,6 +99,12 @@ oba:isNullable a owl:AnnotationProperty ;
 # =============================================================================
 # 3. RELATIONSHIP PROPERTIES (used on owl:ObjectProperty)
 # =============================================================================
+
+oba:joinsTo a owl:ObjectProperty ;
+    rdfs:label "joins to" ;
+    rdfs:comment "Directed, transitive-capable join edge between two table classes in the many-to-one (finer grain -> coarser grain) direction.  Emitted once per declared or inferred foreign-key relationship so that a single SPARQL property path `?from oba:joinsTo+ ?to` answers directed reachability (the dimension-capable closure for a query anchored on ?from) without enumerating each per-FK object property.  The one-to-many (measure-capable) direction is the inverse path `^oba:joinsTo`." ;
+    rdfs:domain owl:Class ;
+    rdfs:range owl:Class .
 
 oba:foreignKeyColumn a owl:AnnotationProperty ;
     rdfs:label "foreign key column" ;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-analytics"
-version = "1.5.3"
+version = "1.6.0"
 description = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "ralf.becher@web.de"}]
 readme = "README.md"
@@ -43,6 +43,8 @@ dependencies = [
     # Semantic web libraries
     "rdflib>=7.5.0",
     "owlrl>=7.1.4",
+    # SHACL conformance checking of generated/loaded ontologies (Phase 4)
+    "pyshacl>=0.26.0",
     # Visualization libraries
     "plotly>=6.5.2",
     "kaleido>=1.2.0",
@@ -76,6 +78,12 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
+
+# Ship the OBA ontology vocabulary + SHACL shapes so in-process SHACL
+# validation (Phase 4) works from an installed wheel, not only from source.
+[tool.hatch.build.targets.wheel.force-include]
+"ontology/oba.ttl" = "ontology/oba.ttl"
+"ontology/oba-shacl.ttl" = "ontology/oba-shacl.ttl"
 
 [tool.hatch.version]
 path = "src/__init__.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,10 +67,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/ralfbecher/orionbelt-analytics"
-Repository = "https://github.com/ralfbecher/orionbelt-analytics"
-Documentation = "https://github.com/ralfbecher/orionbelt-analytics#readme"
-Issues = "https://github.com/ralfbecher/orionbelt-analytics/issues"
+Homepage = "https://github.com/ralforion/orionbelt-analytics"
+Repository = "https://github.com/ralforion/orionbelt-analytics"
+Documentation = "https://github.com/ralforion/orionbelt-analytics#readme"
+Issues = "https://github.com/ralforion/orionbelt-analytics/issues"
 
 [build-system]
 requires = ["hatchling"]

--- a/server.json
+++ b/server.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
-  "name": "io.github.ralfbecher/orionbelt-analytics",
+  "name": "io.github.ralforion/orionbelt-analytics",
   "description": "Ontology-based MCP server for database schema analysis and RDF/OWL ontology generation",
   "version": "1.6.0",
   "repository": {
-    "url": "https://github.com/ralfbecher/orionbelt-analytics",
+    "url": "https://github.com/ralforion/orionbelt-analytics",
     "source": "github"
   },
   "packages": [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.ralfbecher/orionbelt-analytics",
   "description": "Ontology-based MCP server for database schema analysis and RDF/OWL ontology generation",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "repository": {
     "url": "https://github.com/ralfbecher/orionbelt-analytics",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "pypi",
       "identifier": "orionbelt-analytics",
-      "version": "1.5.3",
+      "version": "1.6.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """OrionBelt Analytics - Ontology-based MCP server for your Text-2-SQL convenience."""
 
-__version__ = "1.5.3"
+__version__ = "1.6.0"
 __author__ = "OrionBelt Analytics Contributors"
 __email__ = "contributors@example.com"
 __description__ = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"

--- a/src/graphrag/retriever.py
+++ b/src/graphrag/retriever.py
@@ -289,6 +289,70 @@ class GraphRetriever:
 
         return dict(related)
 
+    def _directed_closure(
+        self,
+        table_name: str,
+        max_hops: Optional[int],
+        neighbor_fn,
+    ) -> Dict[str, Any]:
+        """Cycle-safe directed transitive closure from a table.
+
+        Edges in the FK DiGraph point finer grain -> coarser grain (a table to
+        the table it references). Following ``successors`` walks the many-to-one
+        (dimension) direction; following ``predecessors`` walks the one-to-many
+        (measure) direction.
+
+        Args:
+            table_name: Anchor table
+            max_hops: Maximum hops (None = unbounded full closure)
+            neighbor_fn: ``self.graph.successors`` or ``self.graph.predecessors``
+
+        Returns:
+            Dict with ``exists``, ordered ``tables`` list, and ``by_hop`` mapping.
+        """
+        if table_name not in self.graph:
+            return {"exists": False, "tables": [], "by_hop": {}}
+
+        visited = {table_name}
+        order: List[str] = []
+        by_hop: Dict[int, List[str]] = {}
+        queue = deque([(table_name, 0)])
+
+        while queue:
+            current, dist = queue.popleft()
+            if max_hops is not None and dist >= max_hops:
+                continue
+            for neighbor in neighbor_fn(current):
+                if neighbor not in visited:
+                    visited.add(neighbor)  # cycle-safe: each node enqueued once
+                    order.append(neighbor)
+                    by_hop.setdefault(dist + 1, []).append(neighbor)
+                    queue.append((neighbor, dist + 1))
+
+        return {"exists": True, "tables": order, "by_hop": by_hop}
+
+    def reachable_from(
+        self, table_name: str, max_hops: Optional[int] = None
+    ) -> Dict[str, Any]:
+        """Dimension-capable tables for a query anchored on ``table_name``.
+
+        Directed many-to-one closure (``successors``): coarser-grain tables that
+        can be joined from the anchor without row multiplication (every hop is
+        functional), so their columns are safe to GROUP BY / filter on.
+        """
+        return self._directed_closure(table_name, max_hops, self.graph.successors)
+
+    def measurable_from(
+        self, table_name: str, max_hops: Optional[int] = None
+    ) -> Dict[str, Any]:
+        """Measure-capable tables for a query anchored on ``table_name``.
+
+        Directed one-to-many closure (``predecessors``): finer-grain tables that
+        fan out the anchor, so their values can only be aggregated into measures
+        (SUM/COUNT/...), never used as dimensions at this grain.
+        """
+        return self._directed_closure(table_name, max_hops, self.graph.predecessors)
+
     def detect_fan_traps(self, tables: List[str]) -> List[Dict[str, Any]]:
         """
         Detect potential fan-trap scenarios in a set of tables.

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -451,6 +451,208 @@ async def graphrag_find_join_path(
         )
 
 
+async def reachable_from(
+    ctx: Context,
+    table: str,
+    max_hops: Optional[int],
+    get_session_data,
+    create_error_response,
+) -> Dict[str, Any]:
+    """Dimension-capable tables for a query anchored on ``table`` (many-to-one closure)."""
+    session = get_session_data(ctx)
+
+    if not session.graphrag_initialized or session.graphrag_manager is None:
+        return create_error_response(
+            "GraphRAG not initialized. Please call discover_schema() first.",
+            "graphrag_not_initialized",
+        )
+
+    try:
+        result = session.graphrag_manager.graph_retriever.reachable_from(
+            table, max_hops=max_hops
+        )
+        if not result["exists"]:
+            return create_error_response(
+                f"Table '{table}' not found in the schema graph.", "data_error"
+            )
+
+        await ctx.info(
+            f"{len(result['tables'])} dimension-capable tables reachable from '{table}'"
+        )
+        return {
+            "success": True,
+            "table": table,
+            "direction": "many_to_one",
+            "capability": "dimension",
+            "reachable_tables": result["tables"],
+            "by_hop": result["by_hop"],
+            "guidance": (
+                f"These coarser-grain tables can be joined from '{table}' without "
+                "row multiplication (each join is many-to-one / functional), so their "
+                "columns are safe to use as dimensions (GROUP BY / filter)."
+            ),
+        }
+
+    except Exception as e:
+        logger.error(f"reachable_from failed: {e}", exc_info=True)
+        return create_error_response(f"reachable_from failed: {str(e)}", "graphrag_error")
+
+
+async def measurable_from(
+    ctx: Context,
+    table: str,
+    max_hops: Optional[int],
+    get_session_data,
+    create_error_response,
+) -> Dict[str, Any]:
+    """Measure-capable tables for a query anchored on ``table`` (one-to-many closure)."""
+    session = get_session_data(ctx)
+
+    if not session.graphrag_initialized or session.graphrag_manager is None:
+        return create_error_response(
+            "GraphRAG not initialized. Please call discover_schema() first.",
+            "graphrag_not_initialized",
+        )
+
+    try:
+        result = session.graphrag_manager.graph_retriever.measurable_from(
+            table, max_hops=max_hops
+        )
+        if not result["exists"]:
+            return create_error_response(
+                f"Table '{table}' not found in the schema graph.", "data_error"
+            )
+
+        await ctx.info(
+            f"{len(result['tables'])} measure-capable tables for anchor '{table}'"
+        )
+        return {
+            "success": True,
+            "table": table,
+            "direction": "one_to_many",
+            "capability": "measure",
+            "measurable_tables": result["tables"],
+            "by_hop": result["by_hop"],
+            "guidance": (
+                f"These finer-grain tables fan out '{table}' (one-to-many), so their "
+                "values must be aggregated into measures (SUM/COUNT/...) and must NOT "
+                f"be used as dimensions at the grain of '{table}' — doing so is a fan-trap."
+            ),
+        }
+
+    except Exception as e:
+        logger.error(f"measurable_from failed: {e}", exc_info=True)
+        return create_error_response(f"measurable_from failed: {str(e)}", "graphrag_error")
+
+
+async def plan_composite_query(
+    ctx: Context,
+    facts: List[str],
+    dimensions: Optional[List[str]],
+    get_session_data,
+    create_error_response,
+) -> Dict[str, Any]:
+    """Advise a Composite Fact Layer (CFL) decomposition for a multi-fact query.
+
+    Detects whether the requested facts are independent grains (disjoint
+    siblings) that require a UNION ALL composite, and computes the leg
+    structure: per-leg dimensions, conformed (shared) GROUP BY keys, and the
+    NULL-pad set for each leg. Advisory only — OBA does not compile SQL; OBSL
+    owns CFL compilation.
+    """
+    session = get_session_data(ctx)
+
+    if not session.graphrag_initialized or session.graphrag_manager is None:
+        return create_error_response(
+            "GraphRAG not initialized. Please call discover_schema() first.",
+            "graphrag_not_initialized",
+        )
+
+    if not facts:
+        return create_error_response(
+            "Provide at least one fact (measure-source) table.", "parameter_error"
+        )
+
+    retriever = session.graphrag_manager.graph_retriever
+
+    missing = [f for f in facts if f not in retriever.graph]
+    if missing:
+        return create_error_response(
+            f"Tables not found in schema graph: {', '.join(missing)}", "data_error"
+        )
+
+    facts = list(dict.fromkeys(facts))  # de-dupe, preserve order
+
+    # Dimension-capable set reachable from each fact (many-to-one closure).
+    reach = {f: set(retriever.reachable_from(f)["tables"]) for f in facts}
+
+    # Leg-root facts = facts that are NOT reachable from another fact. A fact
+    # reachable from another sits on that fact's grain chain (a coarser table),
+    # so it is a dimension of it, not an independent leg.
+    leg_roots = [
+        f for f in facts if not any(f in reach[g] for g in facts if g != f)
+    ]
+    leg_roots = list(dict.fromkeys(leg_roots))
+
+    cfl_required = len(leg_roots) >= 2
+
+    # Requested dimensions: explicit list, else the union of all reachable dims.
+    if dimensions:
+        requested = list(dict.fromkeys(dimensions))
+    else:
+        requested = sorted(set().union(*reach.values()) if reach else set())
+
+    # Conformed dims = reachable from every leg root → safe GROUP BY keys.
+    if leg_roots:
+        conformed_set = set.intersection(*[reach[f] for f in leg_roots])
+    else:
+        conformed_set = set()
+    conformed = [d for d in requested if d in conformed_set]
+
+    legs = []
+    for root in leg_roots:
+        leg_dims = [d for d in requested if d in reach[root]]
+        null_pad = [d for d in requested if d not in reach[root]]
+        legs.append(
+            {
+                "root": root,
+                "dimensions": leg_dims,
+                "null_pad": null_pad,
+            }
+        )
+
+    if cfl_required:
+        guidance = (
+            "These facts are independent grains (disjoint siblings). Emit one "
+            "UNION ALL leg per leg root, aggregating its own measures; project the "
+            "conformed dimensions in every leg as GROUP BY keys and CAST(NULL AS "
+            "<type>) for each leg's null_pad dimensions. OBA advises only — when "
+            "OrionBelt Semantic Layer is connected, defer the actual CFL compilation "
+            "to it."
+        )
+    elif leg_roots:
+        guidance = (
+            f"Single grain '{leg_roots[0]}' — a normal star join suffices, no "
+            "Composite Fact Layer needed. The other facts sit on this grain's "
+            "chain and act as dimensions."
+        )
+    else:
+        guidance = "Could not determine a leg root."
+
+    await ctx.info(
+        f"CFL decomposition: cfl_required={cfl_required}, {len(legs)} leg(s)"
+    )
+    return {
+        "success": True,
+        "cfl_required": cfl_required,
+        "facts": facts,
+        "leg_roots": leg_roots,
+        "conformed_dimensions": conformed,
+        "legs": legs,
+        "guidance": guidance,
+    }
+
+
 async def graphrag_overview(
     ctx: Context,
     get_session_data,

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -581,6 +581,16 @@ async def plan_composite_query(
             f"Tables not found in schema graph: {', '.join(missing)}", "data_error"
         )
 
+    # Validate explicit dimensions too — an unknown dimension would otherwise be
+    # silently null-padded into every leg and mislead downstream SQL planning.
+    if dimensions:
+        missing_dims = [d for d in dimensions if d not in retriever.graph]
+        if missing_dims:
+            return create_error_response(
+                f"Dimensions not found in schema graph: {', '.join(missing_dims)}",
+                "data_error",
+            )
+
     facts = list(dict.fromkeys(facts))  # de-dupe, preserve order
 
     # Dimension-capable set reachable from each fact (many-to-one closure).

--- a/src/handlers/ontology.py
+++ b/src/handlers/ontology.py
@@ -242,6 +242,27 @@ async def generate_ontology(
     generator = _server_state.get_ontology_generator(base_uri=base_uri)
     ontology_ttl = generator.generate_from_schema(tables_info)
 
+    # Optional SHACL conformance check (Phase 4). Default on, gated by setting;
+    # never hard-fails generation — surfaces violations as a warning only.
+    if os.getenv("OBA_SHACL_VALIDATE", "true").lower() == "true":
+        try:
+            from ..shacl_validator import validate_ontology
+
+            shacl = validate_ontology(ontology_ttl)
+            if shacl["available"] and not shacl["conforms"]:
+                logger.warning(
+                    "SHACL: generated ontology has %d violation(s):\n%s",
+                    shacl["violations"], shacl["report"],
+                )
+                await ctx.info(
+                    f"SHACL validation: {shacl['violations']} violation(s) in the "
+                    "generated ontology (non-blocking; see server logs for detail)."
+                )
+            elif shacl["available"]:
+                logger.info("SHACL: generated ontology conforms to oba-shacl shapes.")
+        except Exception as e:
+            logger.warning(f"SHACL validation step skipped: {e}")
+
     # Save ontology to connection-scoped output folder
     ontology_filename = None
     try:

--- a/src/main.py
+++ b/src/main.py
@@ -1062,6 +1062,95 @@ async def graphrag_find_join_path(
     )
 
 
+@mcp.tool()
+async def reachable_from(
+    ctx: Context,
+    table: _Identifier,
+    max_hops: Optional[int] = None,
+) -> Dict[str, Any]:
+    """List the dimension-capable tables for a query anchored on a table.
+
+    Follows foreign keys in the many-to-one (finer grain -> coarser grain)
+    direction: the returned tables can be joined from `table` without row
+    multiplication (each join is functional), so their columns are safe to use
+    as dimensions (GROUP BY / filter). This is the directed reachability the
+    bidirectional `graphrag_find_join_path` cannot express. Pair with
+    `measurable_from` for the measure side.
+
+    Args:
+        table: Anchor table name (the query grain)
+        max_hops: Maximum FK hops to follow (None = full closure)
+
+    Returns:
+        Dictionary with reachable (dimension-capable) tables and per-hop breakdown
+    """
+    return await _h_graphrag.reachable_from(
+        ctx, table, max_hops,
+        get_session_data=get_session_data,
+        create_error_response=create_error_response,
+    )
+
+
+@mcp.tool()
+async def measurable_from(
+    ctx: Context,
+    table: _Identifier,
+    max_hops: Optional[int] = None,
+) -> Dict[str, Any]:
+    """List the measure-capable tables for a query anchored on a table.
+
+    Follows foreign keys in the one-to-many (toward finer grain) direction: the
+    returned tables fan out `table`, so their values can only be aggregated into
+    measures (SUM/COUNT/...) and must NOT be used as dimensions at this grain
+    (doing so is a fan-trap). The inverse of `reachable_from`.
+
+    Args:
+        table: Anchor table name (the query grain)
+        max_hops: Maximum FK hops to follow (None = full closure)
+
+    Returns:
+        Dictionary with measure-capable tables and per-hop breakdown
+    """
+    return await _h_graphrag.measurable_from(
+        ctx, table, max_hops,
+        get_session_data=get_session_data,
+        create_error_response=create_error_response,
+    )
+
+
+@mcp.tool()
+async def plan_composite_query(
+    ctx: Context,
+    facts: List[_Identifier],
+    dimensions: Optional[List[_Identifier]] = None,
+) -> Dict[str, Any]:
+    """Advise a Composite Fact Layer (CFL) decomposition for a multi-fact query.
+
+    Given the fact (measure-source) tables a query needs, determines whether
+    they are independent grains (disjoint siblings) requiring a UNION ALL
+    composite, and returns the leg structure: per-leg dimensions, the conformed
+    (shared) dimensions that become GROUP BY keys in every leg, and each leg's
+    NULL-pad set. Use this before writing cross-fact SQL to avoid fan-traps.
+
+    Advisory only: OBA does not compile SQL. When OrionBelt Semantic Layer is
+    connected, defer the actual CFL compilation to it.
+
+    Args:
+        facts: The fact (measure-source) tables the query aggregates
+        dimensions: Optional explicit dimension tables to project (default: all
+            tables reachable from the facts)
+
+    Returns:
+        Dictionary with cfl_required flag, leg roots, conformed dimensions, and
+        per-leg dimension/NULL-pad decomposition
+    """
+    return await _h_graphrag.plan_composite_query(
+        ctx, facts, dimensions,
+        get_session_data=get_session_data,
+        create_error_response=create_error_response,
+    )
+
+
 # --- Oxigraph RDF Store & SPARQL Tools ---
 
 @mcp.tool()

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -169,6 +169,10 @@ class OBQCValidator:
         self._base_uri: Optional[Namespace] = None
         self._oba_ns: Optional[Namespace] = None
         self._is_compatible: bool = False  # Whether ontology has oba: annotations
+        # Fan-trap topology read straight from the ontology axioms (Phase 2):
+        # pairs of lower-cased table names declared owl:disjointWith each other
+        # (sibling facts sharing a dimension — the canonical fan-trap shape).
+        self._disjoint_pairs: Set[frozenset] = set()
 
     def load_ontology(self, ontology_graph: Graph, base_uri: str) -> None:
         """Load and cache schema from ontology graph.
@@ -181,6 +185,7 @@ class OBQCValidator:
         self._base_uri = Namespace(base_uri)
         self._oba_ns = Namespace(OBA_NAMESPACE)
         self._schema_cache = self._extract_schema_from_ontology()
+        self._disjoint_pairs = self._extract_disjoint_pairs()
 
         # Check if ontology has required oba: annotations for OBQC
         self._is_compatible = self._check_ontology_compatibility()
@@ -312,6 +317,26 @@ class OBQCValidator:
                         col.fk_referenced_column = ref_column
 
         return schema
+
+    def _extract_disjoint_pairs(self) -> Set[frozenset]:
+        """Read owl:disjointWith axioms as pairs of lower-cased table names.
+
+        The generator emits owl:disjointWith between sibling fact tables that
+        share a dimension but have no FK between them — exactly the fan-trap
+        topology. Reading it here lets OBQC ground fan-trap detection in the
+        ontology instead of re-deriving it from the relationship heuristic.
+        """
+        pairs: Set[frozenset] = set()
+        if self._graph is None or self._oba_ns is None:
+            return pairs
+
+        for a_uri, b_uri in self._graph.subject_objects(OWL.disjointWith):
+            a_name = self._get_literal(a_uri, self._oba_ns.tableName)
+            b_name = self._get_literal(b_uri, self._oba_ns.tableName)
+            if a_name and b_name and a_name.lower() != b_name.lower():
+                pairs.add(frozenset((a_name.lower(), b_name.lower())))
+
+        return pairs
 
     def _get_literal(self, subject: URIRef, predicate: URIRef) -> Optional[str]:
         """Get string value of a literal predicate."""
@@ -790,7 +815,13 @@ class OBQCValidator:
         return False
 
     def _detect_fan_trap(self, result: OBQCResult) -> None:
-        """Rule: Detect potential fan-trap patterns."""
+        """Rule: Detect potential fan-trap patterns.
+
+        Prefers the ontology's own ``owl:disjointWith`` axioms (sibling facts
+        sharing a dimension — the canonical fan-trap shape) so OBQC and the
+        ontology agree by construction. Falls back to the relationship heuristic
+        when no disjointness axioms are present (e.g. minimal imports).
+        """
         if not result.has_aggregation:
             return
 
@@ -800,7 +831,35 @@ class OBQCValidator:
         if self._schema_cache is None:
             return
 
-        # Count one-to-many relationships in the join graph
+        # --- Axiom-grounded path: disjoint sibling facts in the same query ----
+        queried = {t.lower() for t in result.parsed_tables}
+        disjoint_hits: Set[frozenset] = {
+            pair for pair in self._disjoint_pairs if pair <= queried
+        }
+        if disjoint_hits:
+            result.fan_trap_risk = True
+            involved = sorted({t for pair in disjoint_hits for t in pair})
+            result.issues.append(
+                OBQCIssue(
+                    issue_type=OBQCIssueType.FAN_TRAP_DETECTED,
+                    severity=OBQCSeverity.WARNING,
+                    message=(
+                        "Potential fan-trap: query aggregates across tables the ontology "
+                        f"declares disjoint (sibling facts sharing a dimension): "
+                        f"{', '.join(involved)}"
+                    ),
+                    location="Query structure",
+                    suggestion=(
+                        "These facts are at different grains sharing a common dimension. "
+                        "Aggregate each fact separately and combine with UNION ALL "
+                        "(Composite Fact Layer), or pre-aggregate in CTEs before joining."
+                    ),
+                    related_entities=involved,
+                )
+            )
+            return
+
+        # --- Heuristic fallback: count one-to-many joins (no disjointness axioms)
         one_to_many_count = 0
         involved_tables: List[str] = []
 

--- a/src/ontology_generator.py
+++ b/src/ontology_generator.py
@@ -376,6 +376,11 @@ class OntologyGenerator:
         # Add relationship type annotation
         self.graph.add((prop_uri, self.oba_ns.relationshipType, Literal("many_to_one")))
 
+        # Shared traversable join edge (finer grain -> coarser grain) so a single
+        # SPARQL property path `oba:joinsTo+` answers directed reachability across
+        # all FKs without per-property paths. Many-to-one direction only.
+        self.graph.add((table_uri, self.oba_ns.joinsTo, referenced_table_uri))
+
         # Add inverse relationship
         inverse_rel_name = f"{self._clean_name(referenced_table)}_referenced_by_{self._clean_name(table_name)}"
         inverse_prop_uri = self.base_uri[inverse_rel_name]
@@ -760,6 +765,10 @@ class OntologyGenerator:
         self.graph.add((prop_uri, self.oba_ns.inferenceConfidence, Literal(inferred_rel.confidence)))
         self.graph.add((prop_uri, self.oba_ns.inferencePattern, Literal(inferred_rel.pattern_matched)))
         self.graph.add((prop_uri, self.oba_ns.relationshipType, Literal("many_to_one")))
+
+        # Shared traversable join edge (finer grain -> coarser grain); see
+        # _add_relationship_to_ontology. Many-to-one direction only.
+        self.graph.add((source_table_uri, self.oba_ns.joinsTo, target_table_uri))
 
         # Add inverse relationship
         inverse_rel_name = (

--- a/src/ontology_generator.py
+++ b/src/ontology_generator.py
@@ -846,7 +846,12 @@ class OntologyGenerator:
                         str(ref_table), set()
                     ).add(str(source_name))
 
-        # Build set of tables that have a direct FK relationship between them
+        # Build set of tables that have a direct FK relationship between them.
+        # Must mirror dimension_to_sources, which includes inferred relationships:
+        # if a sibling pair is connected by an *inferred* FK, declaring them
+        # disjoint would contradict the relationship and feed OBQC bad input.
+        # So derive the exclusion set from both declared FKs and the inferred
+        # many-to-one relationships already materialized in the graph.
         fk_pairs: Set[Tuple[str, str]] = set()
         for table in tables_info:
             for fk in table.foreign_keys:
@@ -854,6 +859,18 @@ class OntologyGenerator:
                 if ref:
                     fk_pairs.add((table.name, ref))
                     fk_pairs.add((ref, table.name))
+
+        for subj in self.graph.subjects(RDF.type, OWL.ObjectProperty):
+            rel_type = self.graph.value(subj, self.oba_ns.relationshipType)
+            if str(rel_type) != "many_to_one":
+                continue
+            ref_table = self.graph.value(subj, self.oba_ns.referencedTable)
+            domain = self.graph.value(subj, RDFS.domain)
+            if ref_table and domain:
+                source_name = self.graph.value(domain, self.oba_ns.tableName)
+                if source_name:
+                    fk_pairs.add((str(source_name), str(ref_table)))
+                    fk_pairs.add((str(ref_table), str(source_name)))
 
         # Declare disjoint pairs: siblings sharing a dimension, no FK between them
         declared: Set[Tuple[str, str]] = set()

--- a/src/shacl_validator.py
+++ b/src/shacl_validator.py
@@ -1,0 +1,98 @@
+"""Optional in-process SHACL validation of generated/loaded ontologies.
+
+Validates an OBA ontology against the published shapes in
+``ontology/oba-shacl.ttl`` using ``pyshacl``. Both the dependency and the shapes
+file are treated as optional: if ``pyshacl`` is not installed or the shapes file
+is not found, validation degrades to a no-op (``available=False``) instead of
+raising. This keeps ontology generation/import working everywhere while enabling
+real conformance checking wherever the pieces are present.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from .paths import PROJECT_ROOT
+
+logger = logging.getLogger(__name__)
+
+# SHACL shapes live in the repo's ontology/ directory (force-included in the
+# wheel). Resolve lazily so a missing file is a graceful skip, not an error.
+_SHAPES_PATH = PROJECT_ROOT / "ontology" / "oba-shacl.ttl"
+
+
+def shacl_available() -> bool:
+    """True if pyshacl is importable and the shapes file exists."""
+    if not _SHAPES_PATH.exists():
+        return False
+    try:
+        import pyshacl  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def validate_ontology(ontology_ttl: str) -> Dict[str, Any]:
+    """Validate ontology Turtle against the OBA SHACL shapes.
+
+    Returns a structured report. When validation cannot run (missing dependency
+    or shapes file), returns ``{"available": False, ...}`` and never raises.
+
+    Args:
+        ontology_ttl: The ontology in Turtle format.
+
+    Returns:
+        Dict with keys: ``available`` (bool), ``conforms`` (bool|None),
+        ``violations`` (int), ``report`` (str summary).
+    """
+    if not _SHAPES_PATH.exists():
+        return {
+            "available": False,
+            "conforms": None,
+            "violations": 0,
+            "report": f"SHACL shapes not found at {_SHAPES_PATH}; validation skipped.",
+        }
+
+    try:
+        from pyshacl import validate as _pyshacl_validate
+    except Exception:
+        return {
+            "available": False,
+            "conforms": None,
+            "violations": 0,
+            "report": "pyshacl not installed; SHACL validation skipped.",
+        }
+
+    try:
+        # NB: the OBA vocabulary (oba.ttl) is intentionally NOT merged as an
+        # ont_graph. The RelationshipShape targets every owl:ObjectProperty, and
+        # merging the vocab would pull in meta-level term declarations (e.g.
+        # oba:joinsTo) as focus nodes, producing spurious violations. The shapes
+        # target by RDF types already present in the generated data graph, so the
+        # vocabulary is not needed for correct validation.
+        conforms, _results_graph, results_text = _pyshacl_validate(
+            data_graph=ontology_ttl,
+            shacl_graph=_SHAPES_PATH.read_text(encoding="utf-8"),
+            data_graph_format="turtle",
+            shacl_graph_format="turtle",
+            inference="none",
+            advanced=True,
+            meta_shacl=False,
+        )
+
+        violations = 0 if conforms else max(results_text.count("Constraint Violation"), 1)
+        return {
+            "available": True,
+            "conforms": bool(conforms),
+            "violations": violations,
+            "report": results_text.strip(),
+        }
+    except Exception as e:  # never let validation break generation/import
+        logger.warning("SHACL validation errored, skipping: %s", e)
+        return {
+            "available": False,
+            "conforms": None,
+            "violations": 0,
+            "report": f"SHACL validation errored: {e}",
+        }

--- a/tests/test_cfl_decomposition.py
+++ b/tests/test_cfl_decomposition.py
@@ -1,0 +1,96 @@
+"""Tests for Phase 5 CFL (Composite Fact Layer) decomposition advice."""
+
+from types import SimpleNamespace
+
+from src.graphrag.retriever import GraphRetriever
+from src.handlers import graphrag as h
+
+
+def _tbl(name, fks=None):
+    return {"name": name, "schema": "public", "columns": [], "primary_keys": ["id"],
+            "foreign_keys": fks or []}
+
+
+def _session():
+    """A fake session exposing a real GraphRetriever via graphrag_manager."""
+    tables = [
+        _tbl("customers"),
+        _tbl("products"),
+        _tbl("orders", [
+            {"column": "customer_id", "referenced_table": "customers", "referenced_column": "id"},
+        ]),
+        _tbl("order_items", [
+            {"column": "order_id", "referenced_table": "orders", "referenced_column": "id"},
+            {"column": "product_id", "referenced_table": "products", "referenced_column": "id"},
+        ]),
+        _tbl("returns", [
+            {"column": "customer_id", "referenced_table": "customers", "referenced_column": "id"},
+        ]),
+    ]
+    retriever = GraphRetriever()
+    retriever.build_graph(tables)
+    manager = SimpleNamespace(graph_retriever=retriever)
+    return SimpleNamespace(graphrag_initialized=True, graphrag_manager=manager)
+
+
+class _Ctx:
+    async def info(self, *_a, **_k):
+        return None
+
+
+def _err(message, code):
+    return {"success": False, "error": message, "code": code}
+
+
+async def _call(facts, dimensions=None, session=None):
+    sess = session or _session()
+    return await h.plan_composite_query(
+        _Ctx(), facts, dimensions,
+        get_session_data=lambda _ctx: sess,
+        create_error_response=_err,
+    )
+
+
+async def test_two_disjoint_facts_require_cfl():
+    res = await _call(["orders", "returns"])
+    assert res["success"] is True
+    assert res["cfl_required"] is True
+    assert set(res["leg_roots"]) == {"orders", "returns"}
+    # customers reachable from both -> conformed GROUP BY key
+    assert "customers" in res["conformed_dimensions"]
+
+
+async def test_legs_have_null_pad_for_unshared_dims():
+    # order_items reaches products + orders + customers; returns reaches customers.
+    res = await _call(["order_items", "returns"], dimensions=["customers", "products"])
+    assert res["cfl_required"] is True
+    legs = {leg["root"]: leg for leg in res["legs"]}
+    # products reachable from order_items, not from returns -> null-padded in returns leg
+    assert "products" in legs["order_items"]["dimensions"]
+    assert "products" in legs["returns"]["null_pad"]
+    # customers is conformed (reachable from both)
+    assert "customers" in res["conformed_dimensions"]
+
+
+async def test_same_grain_chain_is_not_cfl():
+    # orders is reachable from order_items -> same grain chain, single leg root.
+    res = await _call(["order_items", "orders"])
+    assert res["cfl_required"] is False
+    assert res["leg_roots"] == ["order_items"]
+
+
+async def test_single_fact_not_cfl():
+    res = await _call(["orders"])
+    assert res["cfl_required"] is False
+
+
+async def test_missing_table_errors():
+    res = await _call(["nope"])
+    assert res["success"] is False
+    assert res["code"] == "data_error"
+
+
+async def test_empty_facts_errors():
+    res = await _call([])
+    assert res["success"] is False
+    assert res["code"] == "parameter_error"

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -410,6 +410,80 @@ class TestOBQCFanTrapDetection(unittest.TestCase):
         self.assertFalse(result.fan_trap_risk)
 
 
+class TestOBQCAxiomDrivenFanTrap(unittest.TestCase):
+    """Phase 2: fan-trap detection grounded in owl:disjointWith axioms."""
+
+    def setUp(self):
+        from src.ontology_generator import OntologyGenerator
+        from src.database_manager import TableInfo, ColumnInfo
+
+        def fact(name, fk_to):
+            return TableInfo(
+                name=name, schema="public",
+                columns=[
+                    ColumnInfo(name="id", data_type="INTEGER", is_nullable=False,
+                               is_primary_key=True, is_foreign_key=False),
+                    ColumnInfo(name="customer_id", data_type="INTEGER", is_nullable=False,
+                               is_primary_key=False, is_foreign_key=True,
+                               foreign_key_table=fk_to, foreign_key_column="id"),
+                    ColumnInfo(name="amount", data_type="DECIMAL(12,2)", is_nullable=False,
+                               is_primary_key=False, is_foreign_key=False),
+                ],
+                primary_keys=["id"],
+                foreign_keys=[{"column": "customer_id", "referenced_table": fk_to, "referenced_column": "id"}],
+                row_count=1000,
+            )
+
+        customers = TableInfo(
+            name="customers", schema="public",
+            columns=[
+                ColumnInfo(name="id", data_type="INTEGER", is_nullable=False,
+                           is_primary_key=True, is_foreign_key=False),
+                ColumnInfo(name="name", data_type="VARCHAR(200)", is_nullable=False,
+                           is_primary_key=False, is_foreign_key=False),
+            ],
+            primary_keys=["id"], foreign_keys=[], row_count=500,
+        )
+
+        base_uri = "http://test.com/ontology/"
+        gen = OntologyGenerator(base_uri)
+        ttl = gen.generate_from_schema(
+            [customers, fact("orders", "customers"), fact("returns", "customers")],
+            include_inferred_relationships=False,
+        )
+        graph = Graph()
+        graph.parse(data=ttl, format="turtle")
+
+        self.validator = OBQCValidator()
+        self.validator.load_ontology(graph, base_uri)
+
+    def test_disjoint_pairs_extracted(self):
+        self.assertIn(frozenset({"orders", "returns"}), self.validator._disjoint_pairs)
+
+    def test_cross_fact_aggregation_flagged_via_axiom(self):
+        result = self.validator.validate(
+            "SELECT customers.name, SUM(orders.amount), SUM(returns.amount) "
+            "FROM customers "
+            "JOIN orders ON customers.id = orders.customer_id "
+            "JOIN returns ON customers.id = returns.customer_id "
+            "GROUP BY customers.name"
+        )
+        self.assertTrue(result.fan_trap_risk)
+        fan = [i for i in result.issues if i.issue_type == OBQCIssueType.FAN_TRAP_DETECTED]
+        self.assertEqual(len(fan), 1)
+        # cites the actual disjoint pair and recommends a composite (UNION ALL)
+        self.assertEqual(set(fan[0].related_entities), {"orders", "returns"})
+        self.assertIn("UNION ALL", fan[0].suggestion)
+
+    def test_single_fact_not_flagged(self):
+        result = self.validator.validate(
+            "SELECT customers.name, SUM(orders.amount) "
+            "FROM customers JOIN orders ON customers.id = orders.customer_id "
+            "GROUP BY customers.name"
+        )
+        self.assertFalse(result.fan_trap_risk)
+
+
 class TestOBQCIssue(unittest.TestCase):
     """Test suite for OBQCIssue data class."""
 

--- a/tests/test_owl_axioms.py
+++ b/tests/test_owl_axioms.py
@@ -1,11 +1,14 @@
 """Tests for OWL axiom generation: FunctionalProperty, disjointWith, propertyChainAxiom."""
 
 import unittest
-from rdflib import URIRef
+from rdflib import URIRef, Namespace
 from rdflib.namespace import RDF, RDFS, OWL
 
 from src.ontology_generator import OntologyGenerator
 from src.database_manager import TableInfo, ColumnInfo
+from src.constants import OBA_NAMESPACE
+
+OBA = Namespace(OBA_NAMESPACE)
 
 
 class TestOwlAxioms(unittest.TestCase):
@@ -381,6 +384,47 @@ class TestOwlAxioms(unittest.TestCase):
         g = self.generator.graph
         chain_triples = list(g.triples((None, OWL.propertyChainAxiom, None)))
         self.assertEqual(len(chain_triples), 0)
+
+
+    # -------------------------------------------------------------------------
+    # oba:joinsTo shared traversable join predicate tests (Phase 1)
+    # -------------------------------------------------------------------------
+
+    def test_joins_to_emitted_for_declared_fk(self):
+        """A declared many-to-one FK emits a directed oba:joinsTo class edge."""
+        self.generator.generate_from_schema(
+            [self.customers, self.orders],
+            include_inferred_relationships=False,
+        )
+        g = self.generator.graph
+        self.assertIn(
+            (URIRef(self.ns + "orders"), OBA.joinsTo, URIRef(self.ns + "customers")),
+            g,
+        )
+
+    def test_joins_to_is_directed_not_reverse(self):
+        """oba:joinsTo is many-to-one only — never the one-to-many reverse."""
+        self.generator.generate_from_schema(
+            [self.customers, self.orders],
+            include_inferred_relationships=False,
+        )
+        g = self.generator.graph
+        self.assertNotIn(
+            (URIRef(self.ns + "customers"), OBA.joinsTo, URIRef(self.ns + "orders")),
+            g,
+        )
+
+    def test_joins_to_one_edge_per_fk(self):
+        """One oba:joinsTo edge per many-to-one FK (orders, returns -> customers)."""
+        self.generator.generate_from_schema(
+            [self.customers, self.orders, self.returns],
+            include_inferred_relationships=False,
+        )
+        g = self.generator.graph
+        edges = list(g.triples((None, OBA.joinsTo, None)))
+        self.assertEqual(len(edges), 2)
+        targets = {str(o) for _, _, o in edges}
+        self.assertEqual(targets, {self.ns + "customers"})
 
 
 if __name__ == "__main__":

--- a/tests/test_reachability.py
+++ b/tests/test_reachability.py
@@ -1,0 +1,107 @@
+"""Tests for directed grain reachability (Phase 3): reachable_from / measurable_from.
+
+Schema (edges point finer grain -> coarser grain, i.e. many-to-one):
+
+    order_items --> orders --> customers
+    returns --------------------^
+
+So:
+  - reachable_from (descendants, dimension-capable) walks toward customers
+  - measurable_from (ancestors, measure-capable) walks toward order_items/returns
+"""
+
+from src.graphrag.retriever import GraphRetriever
+
+
+def _tbl(name, fks=None):
+    return {
+        "name": name,
+        "schema": "public",
+        "columns": [],
+        "primary_keys": ["id"],
+        "foreign_keys": fks or [],
+    }
+
+
+def _build():
+    tables = [
+        _tbl("customers"),
+        _tbl("orders", [{"column": "customer_id", "referenced_table": "customers", "referenced_column": "id"}]),
+        _tbl("order_items", [{"column": "order_id", "referenced_table": "orders", "referenced_column": "id"}]),
+        _tbl("returns", [{"column": "customer_id", "referenced_table": "customers", "referenced_column": "id"}]),
+    ]
+    r = GraphRetriever()
+    r.build_graph(tables)
+    return r
+
+
+def test_reachable_from_walks_to_coarser_grain():
+    r = _build()
+    result = r.reachable_from("order_items")
+    assert result["exists"] is True
+    assert set(result["tables"]) == {"orders", "customers"}
+
+
+def test_reachable_from_interior_fact():
+    r = _build()
+    # orders reaches only customers (not back down to order_items)
+    assert set(r.reachable_from("orders")["tables"]) == {"customers"}
+
+
+def test_reachable_from_dimension_is_empty():
+    r = _build()
+    # customers is a pure sink — nothing coarser
+    assert r.reachable_from("customers")["tables"] == []
+
+
+def test_measurable_from_walks_to_finer_grain():
+    r = _build()
+    # everything that fans out customers
+    assert set(r.measurable_from("customers")["tables"]) == {"orders", "order_items", "returns"}
+
+
+def test_measurable_from_interior_fact():
+    r = _build()
+    assert set(r.measurable_from("orders")["tables"]) == {"order_items"}
+
+
+def test_reachable_and_measurable_are_inverses():
+    r = _build()
+    nodes = list(r.graph.nodes())
+    for x in nodes:
+        for y in r.reachable_from(x)["tables"]:
+            # X reachable_from Y  <=>  Y measurable_from X
+            assert x in r.measurable_from(y)["tables"]
+
+
+def test_max_hops_bounds_closure():
+    r = _build()
+    one_hop = r.reachable_from("order_items", max_hops=1)
+    assert set(one_hop["tables"]) == {"orders"}
+
+
+def test_unknown_table():
+    r = _build()
+    assert r.reachable_from("nope")["exists"] is False
+    assert r.measurable_from("nope")["exists"] is False
+
+
+def test_cycle_terminates():
+    # Mutual FKs a <-> b must not loop forever.
+    tables = [
+        _tbl("a", [{"column": "b_id", "referenced_table": "b", "referenced_column": "id"}]),
+        _tbl("b", [{"column": "a_id", "referenced_table": "a", "referenced_column": "id"}]),
+    ]
+    r = GraphRetriever()
+    r.build_graph(tables)
+    # Closures are cycle-safe (visited set); the other node is reached exactly once.
+    assert set(r.reachable_from("a")["tables"]) == {"b"}
+    assert set(r.measurable_from("a")["tables"]) == {"b"}
+
+
+def test_self_reference_terminates():
+    tables = [_tbl("employee", [{"column": "manager_id", "referenced_table": "employee", "referenced_column": "id"}])]
+    r = GraphRetriever()
+    r.build_graph(tables)
+    # A self-loop reaches nothing new beyond itself (anchor excluded from results).
+    assert r.reachable_from("employee")["tables"] == []

--- a/tests/test_shacl_validation.py
+++ b/tests/test_shacl_validation.py
@@ -1,0 +1,63 @@
+"""Tests for Phase 4 optional in-process SHACL validation."""
+
+import pytest
+
+from src.shacl_validator import validate_ontology, shacl_available
+from src.ontology_generator import OntologyGenerator
+from src.database_manager import TableInfo, ColumnInfo
+
+
+pytestmark = pytest.mark.skipif(
+    not shacl_available(),
+    reason="pyshacl not installed or oba-shacl.ttl shapes not found",
+)
+
+
+def _ecommerce_ttl() -> str:
+    customers = TableInfo(
+        name="customers", schema="public",
+        columns=[
+            ColumnInfo(name="id", data_type="INTEGER", is_nullable=False,
+                       is_primary_key=True, is_foreign_key=False),
+            ColumnInfo(name="name", data_type="VARCHAR(200)", is_nullable=False,
+                       is_primary_key=False, is_foreign_key=False),
+        ],
+        primary_keys=["id"], foreign_keys=[], row_count=100,
+    )
+    orders = TableInfo(
+        name="orders", schema="public",
+        columns=[
+            ColumnInfo(name="id", data_type="INTEGER", is_nullable=False,
+                       is_primary_key=True, is_foreign_key=False),
+            ColumnInfo(name="customer_id", data_type="INTEGER", is_nullable=False,
+                       is_primary_key=False, is_foreign_key=True,
+                       foreign_key_table="customers", foreign_key_column="id"),
+        ],
+        primary_keys=["id"],
+        foreign_keys=[{"column": "customer_id", "referenced_table": "customers", "referenced_column": "id"}],
+        row_count=1000,
+    )
+    gen = OntologyGenerator("http://test.com/ontology/")
+    return gen.generate_from_schema([customers, orders], include_inferred_relationships=False)
+
+
+def test_generated_ontology_conforms():
+    """A freshly generated ontology should conform to the OBA SHACL shapes."""
+    report = validate_ontology(_ecommerce_ttl())
+    assert report["available"] is True
+    assert report["conforms"] is True, report["report"]
+
+
+def test_non_conformant_ontology_reports_violation():
+    """A table class missing required oba: annotations is flagged."""
+    bad_ttl = """
+    @prefix oba: <https://ralforion.com/ns/oba#> .
+    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+    @prefix ns: <http://test.com/ontology/> .
+    ns:broken a owl:Class .
+    """
+    report = validate_ontology(bad_ttl)
+    assert report["available"] is True
+    # oba-shacl requires oba:tableName on table classes -> non-conformant
+    assert report["conforms"] is False
+    assert report["violations"] >= 1

--- a/uv.lock
+++ b/uv.lock
@@ -1464,6 +1464,15 @@ wheels = [
 ]
 
 [[package]]
+name = "html5rdf"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/55/1b839c43f5ed8207e17a9a02d8b395179520b8b4f00c00a41e113bc205ca/html5rdf-1.2.1.tar.gz", hash = "sha256:ace9b420ce52995bb4f05e7425eedf19e433c981dfe7a831ab391e2fa2e1a195", size = 287899, upload-time = "2024-10-30T05:06:56.384Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/c9/f6e1e8567660bc5b0aba281f2b0017b2a7665fcad6bf3ed67286a0c72cd4/html5rdf-1.2.1-py2.py3-none-any.whl", hash = "sha256:1f519121bc366af3e485310dc8041d2e86e5173c1a320fac3dc9d2604069b83e", size = 109765, upload-time = "2024-10-30T05:06:52.507Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -2464,7 +2473,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-analytics"
-version = "1.5.3"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -2488,6 +2497,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pymysql" },
     { name = "pyoxigraph" },
+    { name = "pyshacl" },
     { name = "python-dotenv" },
     { name = "rdflib" },
     { name = "scikit-learn" },
@@ -2541,6 +2551,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pymysql", specifier = ">=1.1.0" },
     { name = "pyoxigraph", specifier = ">=0.3.22" },
+    { name = "pyshacl", specifier = ">=0.26.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "rdflib", specifier = ">=7.5.0" },
     { name = "scikit-learn", specifier = ">=1.3.0" },
@@ -2832,6 +2843,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/39/3f/b0f01a7b0488724322abfaa1369e40f55b7d291b2357b0646a131528e79f/prefab_ui-0.18.5.tar.gz", hash = "sha256:66f4f0d33ddb0b370684f9a2792886d32942ec91d114bf8b35b3954f87014ccb", size = 4042301, upload-time = "2026-04-07T20:27:39.008Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/6b/c70b0d7ba3d2ec750b92686481d2952775d4123ff7973505229b513a89e6/prefab_ui-0.18.5-py3-none-any.whl", hash = "sha256:f4681a5ac464949dd26432df9594ef96066d03150cb3b9e595fb6999f9eb433c", size = 1843059, upload-time = "2026-04-07T20:27:37.106Z" },
+]
+
+[[package]]
+name = "prettytable"
+version = "3.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
 ]
 
 [[package]]
@@ -3324,6 +3347,21 @@ wheels = [
 ]
 
 [[package]]
+name = "pyshacl"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "owlrl" },
+    { name = "packaging" },
+    { name = "prettytable" },
+    { name = "rdflib", extra = ["html"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/2d/8eaada41b9b57c028a54494688e45cfeefd6756098a6bf1bfa2dd9470cdf/pyshacl-0.31.0.tar.gz", hash = "sha256:327950875a5bb0d1a15c246a8a272b2dbf6bc9b96e28cfa8fdbfa4d73aadc0ba", size = 1406151, upload-time = "2026-01-16T06:34:06.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/3b/ebd7c9595fcdf176555aaf2fd2254f4d890658334ca3556b611e579f8294/pyshacl-0.31.0-py3-none-any.whl", hash = "sha256:5cae2184401d956b67deebb00e3c78ab7052784741a730e52e309e33c8a0b9a5", size = 1297210, upload-time = "2026-01-16T06:34:03.679Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "7.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3562,6 +3600,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ec/1b/4cd9a29841951371304828d13282e27a5f25993702c7c87dcb7e0604bd25/rdflib-7.5.0.tar.gz", hash = "sha256:663083443908b1830e567350d72e74d9948b310f827966358d76eebdc92bf592", size = 4903859, upload-time = "2025-11-28T05:51:54.562Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/20/35d2baebacf357b562bd081936b66cd845775442973cb033a377fd639a84/rdflib-7.5.0-py3-none-any.whl", hash = "sha256:b011dfc40d0fc8a44252e906dcd8fc806a7859bc231be190c37e9568a31ac572", size = 587215, upload-time = "2025-11-28T05:51:38.178Z" },
+]
+
+[package.optional-dependencies]
+html = [
+    { name = "html5rdf" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements `design/PLAN_graph_reasoning.md` across five phases — activating the OWL reasoning OBA already emits and adding fan-trap-safe query-construction tools. Advisory only; OBA does not compile SQL (OBSL owns that).

## Phases

- **Phase 1 — `oba:joinsTo` shared join predicate.** Every declared/inferred many-to-one FK now emits one directed `oba:joinsTo` class edge (finer→coarser). `?from oba:joinsTo+ ?to` answers directed reachability via `query_sparql` without per-FK predicate enumeration or a materialized closure. Vocabulary bumped 0.1 → 0.2.
- **Phase 2 — OBQC reads the axioms.** `_detect_fan_trap` now reads the ontology's `owl:disjointWith` axioms, cites the actual disjoint facts, and recommends a Composite Fact Layer. Relationship heuristic retained as fallback.
- **Phase 3 — `reachable_from` + `measurable_from` MCP tools.** Directed `nx.descendants` (dimension-capable) and `nx.ancestors` (measure-capable) closures, cycle-safe, one shared helper. Not reusing the bidirectional `graphrag_find_join_path`.
- **Phase 5 — `plan_composite_query` MCP tool.** Advisory CFL decomposition: detects independent grains (disjoint siblings), computes leg roots, conformed GROUP BY dims, per-leg NULL-pad sets. Same-grain chains collapse to a single leg.
- **Phase 4 — optional in-process SHACL validation.** Lazily-imported `pyshacl` check in `generate_ontology`, gated by `OBA_SHACL_VALIDATE` (default on), graceful no-op when absent. Shapes force-included in the wheel.

## Tests & validation

- 311 tests pass (24 new): `joinsTo` emission/direction, axiom-driven fan-trap, reachability inverse-property + cycle/self-ref termination, CFL decomposition, SHACL conformance.
- `ruff check` clean. `uv.lock` updated with `pyshacl`.

## Version

1.5.3 → 1.6.0 across `pyproject.toml`, `src/__init__.py`, `server.json`, README badge + tool table (23 → 26 tools), CHANGELOG.

## Notes / caveats

- **mypy:** pre-existing rdflib `Node`/`URIRef` typing noise in `obqc_validator.py`/`retriever.py` (present in untouched methods too); the new standalone module is clean and additions match the file's established pattern. Baseline findings not addressed.
- **Formatting:** repo's pinned `black` (23.x) can't run against its own `py313` target, and `ruff format` isn't canonical (would reformat untouched files). Validated with `ruff check`.
- **Not a release:** version metadata only — PyPI publish is a separate, deliberate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)