### PR TITLE
fix(types): tighten HandlerContext fields to bring mypy below baseline

### DIFF
--- a/src/handler_context.py
+++ b/src/handler_context.py
@@ -9,31 +9,48 @@ and every handler signature long and easy to get out of sync.
 builds it once (capturing the current module-level helpers, so test patches on
 ``src.main`` / ``src.server_state`` are still honored) and passes ``services=``;
 each handler reads what it needs as ``services.<name>``.
+
+The callable fields are non-optional and default to :func:`_unset_service`, a
+sentinel that raises if a handler reaches for a service its wrapper did not
+provide. This keeps the fields statically callable (no ``Optional[Callable]``
+"None not callable" noise) while still failing loudly on real misuse.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Optional
+from typing import Any, Callable
+
+
+def _unset_service(*_args: Any, **_kwargs: Any) -> Any:
+    """Placeholder for a service the wrapper did not supply."""
+    raise RuntimeError(
+        "HandlerContext service was not provided by the caller. "
+        "Build the context with the helper this handler needs."
+    )
 
 
 @dataclass(frozen=True)
 class HandlerContext:
     """Request-scoped services available to handler functions.
 
-    All fields are optional so a wrapper only needs to populate the services its
-    handler actually uses; unused ones stay ``None``.
+    Every wrapper populates the services its handler uses via ``_services()``;
+    any field left at :func:`_unset_service` raises if actually called.
     """
 
-    get_session_data: Optional[Callable] = None
-    get_session_db_manager: Optional[Callable] = None
-    get_session_safe_filename: Optional[Callable] = None
-    get_session_obqc_validator: Optional[Callable] = None
-    get_oxigraph_store: Optional[Callable] = None
-    load_ontology_from_session: Optional[Callable] = None
-    create_error_response: Optional[Callable] = None
+    get_session_data: Callable[..., Any] = _unset_service
+    get_session_db_manager: Callable[..., Any] = _unset_service
+    get_session_safe_filename: Callable[..., Any] = _unset_service
+    get_session_obqc_validator: Callable[..., Any] = _unset_service
+    get_oxigraph_store: Callable[..., Any] = _unset_service
+    load_ontology_from_session: Callable[..., Any] = _unset_service
+    create_error_response: Callable[..., Any] = _unset_service
     server_state: Any = None
-    get_connection_fingerprint: Optional[Callable] = None
-    clear_session_state: Optional[Callable] = None
-    auto_initialize_graphrag_background: Optional[Callable] = None
-    add_resource: Optional[Callable] = None
+    get_connection_fingerprint: Callable[..., Any] = _unset_service
+    clear_session_state: Callable[..., Any] = _unset_service
+    auto_initialize_graphrag_background: Callable[..., Any] = _unset_service
+    add_resource: Callable[..., Any] = _unset_service
+
+    def provides(self, name: str) -> bool:
+        """Return True if the named service was supplied (not the sentinel)."""
+        return getattr(self, name) is not _unset_service

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -120,7 +120,7 @@ async def generate_chart(
             chart_id = uuid4()
             chart_uri = f"ui://orionbelt/chart/{chart_id}"
             chart_json_uri = f"ui://orionbelt/chart-json/{chart_id}"
-            if services.add_resource:
+            if services.provides("add_resource"):
                 from fastmcp.resources import TextResource
                 services.add_resource(TextResource(
                     uri=chart_uri,

--- a/src/handlers/connection.py
+++ b/src/handlers/connection.py
@@ -295,7 +295,7 @@ async def connect_database(
         # Detect and auto-restore existing workspace
         response = f"Successfully connected to {db_type} database: {db_name}"
         workspace = detect_workspace(new_conn_id)
-        if workspace and services.get_oxigraph_store:
+        if workspace and services.provides("get_oxigraph_store"):
             try:
                 restore_result = await _restore_workspace_core(
                     ctx, session, new_conn_id, None, services

--- a/src/handlers/ontology_io.py
+++ b/src/handlers/ontology_io.py
@@ -227,7 +227,7 @@ async def load_my_ontology(
 
         # Check compatibility with connected database
         compatibility = None
-        if services.get_session_db_manager:
+        if services.provides("get_session_db_manager"):
             compatibility = _check_ontology_db_compatibility(
                 graph, ctx, services.get_session_db_manager, session
             )


### PR DESCRIPTION
Follow-up to #28.

The HandlerContext refactor typed its service fields as `Optional[Callable] = None`, which made mypy flag every `services.x(...)` call site as "None not callable" (+~110 errors, baseline 536 → 613).

This makes the callable fields non-optional with a raising sentinel default (`_unset_service`):
- statically callable → no "None not callable" noise
- still fails loudly if a handler reaches for a service its wrapper didn't provide
- `HandlerContext.provides(name)` preserves the few presence-guards (`add_resource`, `get_oxigraph_store`, `get_session_db_manager`) without tripping mypy's `truthy-function` check

**mypy: 613 → 503** (below the pre-refactor baseline of 536). 358 tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)