### PR TITLE
chore(format): black + isort across the repo, enforce in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Blocking gates: these currently pass and must stay green on every PR.
+  # Blocking gates: these pass and must stay green on every PR.
   quality:
     runs-on: ubuntu-latest
     steps:
@@ -27,12 +27,18 @@ jobs:
       - name: Lint (ruff)
         run: uv run ruff check src/ tests/
 
+      - name: Format check (black)
+        run: uv run black --check src/ tests/
+
+      - name: Import order (isort)
+        run: uv run isort --check-only src/ tests/
+
       - name: Tests
         run: uv run pytest
 
-  # Advisory gates: known baselines (the repo is not yet black/isort/mypy clean).
-  # They run on every PR so the debt is visible and trends down, but do not block
-  # merges. Flip continue-on-error to false per check once it is clean.
+  # Advisory gate: mypy is not yet clean (known strict-mode baseline). It runs on
+  # every PR so the count is visible and trends down, but does not block merges.
+  # Flip continue-on-error to false once src/ type-checks clean.
   baseline:
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -47,14 +53,5 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: Format check (black, advisory)
-        if: always()
-        run: uv run black --check src/ tests/
-
-      - name: Import order (isort, advisory)
-        if: always()
-        run: uv run isort --check-only src/ tests/
-
       - name: Type check (mypy, advisory)
-        if: always()
         run: uv run mypy src

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -6,12 +6,12 @@ __email__ = "contributors@example.com"
 __description__ = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"
 __name__ = "OrionBelt Analytics"
 
-# Export main components for easier imports
-from .database_manager import DatabaseManager, TableInfo, ColumnInfo
-from .ontology_generator import OntologyGenerator
 from .config import config_manager
 from .constants import SUPPORTED_DB_TYPES
 
+# Export main components for easier imports
+from .database_manager import ColumnInfo, DatabaseManager, TableInfo
+from .ontology_generator import OntologyGenerator
 from .session import SessionData
 
 __all__ = [

--- a/src/async_utils.py
+++ b/src/async_utils.py
@@ -7,7 +7,7 @@ replacing the 8+ duplicated ThreadPoolExecutor patterns in database_manager.py.
 import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from typing import TypeVar, Coroutine, Any
+from typing import Any, Coroutine, TypeVar
 
 from .constants import CONNECTION_TIMEOUT
 

--- a/src/chart_utils.py
+++ b/src/chart_utils.py
@@ -15,7 +15,7 @@ def format_measure_name(measure: str) -> str:
     Returns:
         Formatted measure name (e.g., "Total Revenue", "Profit Margin Pct")
     """
-    return measure.replace('_', ' ').title()
+    return measure.replace("_", " ").title()
 
 
 def get_quarter_sort_order(values, ascending=True):
@@ -36,6 +36,7 @@ def get_quarter_sort_order(values, ascending=True):
         List of values in chronological order, or None if not quarterly data
     """
     import re
+
     import pandas as pd
 
     # Check if all values match any quarterly pattern
@@ -43,8 +44,8 @@ def get_quarter_sort_order(values, ascending=True):
 
     # Multiple patterns to support different formats
     patterns = [
-        r'^Q([1-4])\s*[\-/]?\s*(\d{4})$',  # Q1 2024, Q1-2024, Q1/2024
-        r'^(\d{4})\s*[\-/]?\s*Q([1-4])$',  # 2024 Q1, 2024-Q1, 2024/Q1
+        r"^Q([1-4])\s*[\-/]?\s*(\d{4})$",  # Q1 2024, Q1-2024, Q1/2024
+        r"^(\d{4})\s*[\-/]?\s*Q([1-4])$",  # 2024 Q1, 2024-Q1, 2024/Q1
     ]
 
     def parse_quarter(q_str):
@@ -93,8 +94,16 @@ def _get_ordinal_sort_key(values):
     values_lower = [v.lower() for v in values_str]
 
     # --- Weekday detection ---
-    weekday_full = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
-    weekday_abbr = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
+    weekday_full = [
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+    ]
+    weekday_abbr = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
 
     if all(v in weekday_full for v in values_lower):
         order = {d: i for i, d in enumerate(weekday_full)}
@@ -105,16 +114,16 @@ def _get_ordinal_sort_key(values):
         return (lambda v: order.get(str(v).strip().lower(), 99), True)
 
     # --- 12-hour time detection ---
-    time_pat = re.compile(r'^(\d{1,2})(?::(\d{2}))?\s*(am|pm)$', re.IGNORECASE)
+    time_pat = re.compile(r"^(\d{1,2})(?::(\d{2}))?\s*(am|pm)$", re.IGNORECASE)
 
     def parse_12h(v):
         m = time_pat.match(str(v).strip())
         if not m:
             return None
         h, _, ampm = int(m.group(1)), m.group(2), m.group(3).lower()
-        if ampm == 'am' and h == 12:
+        if ampm == "am" and h == 12:
             h = 0
-        elif ampm == 'pm' and h != 12:
+        elif ampm == "pm" and h != 12:
             h += 12
         return h
 
@@ -146,11 +155,23 @@ def _clean_dataframe_for_plotly(df):
 
     # Create a fresh DataFrame from records - this completely removes any
     # index metadata (name, type, etc.) that could conflict with columns
-    clean_df = pd.DataFrame(df.to_dict('records'))
+    clean_df = pd.DataFrame(df.to_dict("records"))
     return clean_df
 
 
-def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title, chart_style, width=800, height=600, sort_by=None, sort_order=None):
+def create_plotly_chart(
+    df,
+    chart_type,
+    x_column,
+    y_column,
+    color_column,
+    title,
+    chart_style,
+    width=800,
+    height=600,
+    sort_by=None,
+    sort_order=None,
+):
     """Create Plotly chart based on type.
 
     Args:
@@ -172,19 +193,45 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
     if chart_type == "bar":
         # Check if x_column contains chronological data (quarters, months, or dates)
         x_values_lower = df[x_column].astype(str).str.lower().unique()
-        month_names_full = ['january', 'february', 'march', 'april', 'may', 'june',
-                           'july', 'august', 'september', 'october', 'november', 'december']
-        month_names_short = ['jan', 'feb', 'mar', 'apr', 'may', 'jun',
-                            'jul', 'aug', 'sep', 'oct', 'nov', 'dec']
+        month_names_full = [
+            "january",
+            "february",
+            "march",
+            "april",
+            "may",
+            "june",
+            "july",
+            "august",
+            "september",
+            "october",
+            "november",
+            "december",
+        ]
+        month_names_short = [
+            "jan",
+            "feb",
+            "mar",
+            "apr",
+            "may",
+            "jun",
+            "jul",
+            "aug",
+            "sep",
+            "oct",
+            "nov",
+            "dec",
+        ]
 
-        is_month_column = any(val in month_names_full for val in x_values_lower) or \
-                         any(val in month_names_short for val in x_values_lower)
+        is_month_column = any(val in month_names_full for val in x_values_lower) or any(
+            val in month_names_short for val in x_values_lower
+        )
         is_quarterly_x = get_quarter_sort_order(df[x_column].unique()) is not None
 
         # Try to detect datetime
         is_datetime = False
         try:
             import warnings
+
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 pd.to_datetime(df[x_column])
@@ -199,89 +246,158 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
         # Non-chronological data: sort descending by y_column (measure, largest first)
         if is_chronological:
             effective_sort_by = sort_by if sort_by is not None else x_column
-            effective_sort_order = sort_order if sort_order is not None else 'ascending'
+            effective_sort_order = sort_order if sort_order is not None else "ascending"
         elif isinstance(y_column, list):
             effective_sort_by = sort_by if sort_by else x_column
-            effective_sort_order = sort_order if sort_order else 'ascending'
+            effective_sort_order = sort_order if sort_order else "ascending"
         else:
             effective_sort_by = sort_by if sort_by else y_column
-            effective_sort_order = sort_order if sort_order else 'descending'
+            effective_sort_order = sort_order if sort_order else "descending"
 
-        sort_ascending = (effective_sort_order == 'ascending')
+        sort_ascending = effective_sort_order == "ascending"
 
         if isinstance(y_column, list):
             agg_df = df.groupby(x_column, as_index=False)[y_column].sum()
             agg_df = _clean_dataframe_for_plotly(agg_df)
-            quarter_order = get_quarter_sort_order(agg_df[x_column].unique(), ascending=sort_ascending)
+            quarter_order = get_quarter_sort_order(
+                agg_df[x_column].unique(), ascending=sort_ascending
+            )
             if quarter_order:
                 category_order = quarter_order
             else:
-                sorted_df = agg_df.sort_values(by=effective_sort_by, ascending=sort_ascending)
+                sorted_df = agg_df.sort_values(
+                    by=effective_sort_by, ascending=sort_ascending
+                )
                 category_order = sorted_df[x_column].tolist()
-            barmode = 'stack' if chart_style == 'stacked' else 'group'
+            barmode = "stack" if chart_style == "stacked" else "group"
             labels = {x_column: format_measure_name(x_column)}
             labels.update({col: format_measure_name(col) for col in y_column})
-            fig = px.bar(agg_df, x=x_column, y=y_column, title=title,
-                        barmode=barmode, category_orders={x_column: category_order},
-                        labels=labels)
+            fig = px.bar(
+                agg_df,
+                x=x_column,
+                y=y_column,
+                title=title,
+                barmode=barmode,
+                category_orders={x_column: category_order},
+                labels=labels,
+            )
             fig.update_layout(bargap=0.15, bargroupgap=0.05)
         elif chart_style == "stacked" and color_column:
             # Stacked bar chart with two dimensions: x_column (categories) and color_column (stack groups)
             # Aggregate data first to handle duplicates
-            agg_df = df.groupby([x_column, color_column], as_index=False)[y_column].sum()
-            agg_df = _clean_dataframe_for_plotly(agg_df)  # Clean for pandas index conflicts
+            agg_df = df.groupby([x_column, color_column], as_index=False)[
+                y_column
+            ].sum()
+            agg_df = _clean_dataframe_for_plotly(
+                agg_df
+            )  # Clean for pandas index conflicts
             # Check for quarterly data first
-            quarter_order = get_quarter_sort_order(agg_df[x_column].unique(), ascending=sort_ascending)
+            quarter_order = get_quarter_sort_order(
+                agg_df[x_column].unique(), ascending=sort_ascending
+            )
             if quarter_order:
                 category_order = quarter_order
             elif effective_sort_by == y_column:
-                total_by_category = agg_df.groupby(x_column)[y_column].sum().sort_values(ascending=sort_ascending)
+                total_by_category = (
+                    agg_df.groupby(x_column)[y_column]
+                    .sum()
+                    .sort_values(ascending=sort_ascending)
+                )
                 category_order = total_by_category.index.tolist()
             else:
                 # Sort by x_column or another column
-                total_by_category = agg_df.groupby(x_column)[effective_sort_by].sum().sort_values(ascending=sort_ascending)
+                total_by_category = (
+                    agg_df.groupby(x_column)[effective_sort_by]
+                    .sum()
+                    .sort_values(ascending=sort_ascending)
+                )
                 category_order = total_by_category.index.tolist()
-            fig = px.bar(agg_df, x=x_column, y=y_column, color=color_column, title=title,
-                        barmode='stack', category_orders={x_column: category_order},
-                        labels={x_column: format_measure_name(x_column),
-                                y_column: format_measure_name(y_column)})
+            fig = px.bar(
+                agg_df,
+                x=x_column,
+                y=y_column,
+                color=color_column,
+                title=title,
+                barmode="stack",
+                category_orders={x_column: category_order},
+                labels={
+                    x_column: format_measure_name(x_column),
+                    y_column: format_measure_name(y_column),
+                },
+            )
         elif color_column:
             # Grouped bar chart - aggregate data first to handle duplicates
-            agg_df = df.groupby([x_column, color_column], as_index=False)[y_column].sum()
-            agg_df = _clean_dataframe_for_plotly(agg_df)  # Clean for pandas index conflicts
+            agg_df = df.groupby([x_column, color_column], as_index=False)[
+                y_column
+            ].sum()
+            agg_df = _clean_dataframe_for_plotly(
+                agg_df
+            )  # Clean for pandas index conflicts
             # Check for quarterly data first
-            quarter_order = get_quarter_sort_order(agg_df[x_column].unique(), ascending=sort_ascending)
+            quarter_order = get_quarter_sort_order(
+                agg_df[x_column].unique(), ascending=sort_ascending
+            )
             if quarter_order:
                 category_order = quarter_order
             elif effective_sort_by == y_column:
-                total_by_category = agg_df.groupby(x_column)[y_column].sum().sort_values(ascending=sort_ascending)
+                total_by_category = (
+                    agg_df.groupby(x_column)[y_column]
+                    .sum()
+                    .sort_values(ascending=sort_ascending)
+                )
                 category_order = total_by_category.index.tolist()
             else:
                 # Sort by x_column or another column
-                total_by_category = agg_df.groupby(x_column)[effective_sort_by].sum().sort_values(ascending=sort_ascending)
+                total_by_category = (
+                    agg_df.groupby(x_column)[effective_sort_by]
+                    .sum()
+                    .sort_values(ascending=sort_ascending)
+                )
                 category_order = total_by_category.index.tolist()
-            fig = px.bar(agg_df, x=x_column, y=y_column, color=color_column, title=title,
-                        barmode='group', category_orders={x_column: category_order},
-                        labels={x_column: format_measure_name(x_column),
-                                y_column: format_measure_name(y_column)})
+            fig = px.bar(
+                agg_df,
+                x=x_column,
+                y=y_column,
+                color=color_column,
+                title=title,
+                barmode="group",
+                category_orders={x_column: category_order},
+                labels={
+                    x_column: format_measure_name(x_column),
+                    y_column: format_measure_name(y_column),
+                },
+            )
             # Make bars wider for grouped charts
             fig.update_layout(bargap=0.15, bargroupgap=0.05)
         else:
             # Simple bar chart - aggregate first, then sort by measure (default) or specified column
             agg_df = df.groupby(x_column, as_index=False)[y_column].sum()
-            agg_df = _clean_dataframe_for_plotly(agg_df)  # Clean for pandas index conflicts
+            agg_df = _clean_dataframe_for_plotly(
+                agg_df
+            )  # Clean for pandas index conflicts
             # Check for quarterly data first
-            quarter_order = get_quarter_sort_order(agg_df[x_column].unique(), ascending=sort_ascending)
+            quarter_order = get_quarter_sort_order(
+                agg_df[x_column].unique(), ascending=sort_ascending
+            )
             if quarter_order:
                 category_order = quarter_order
             else:
                 # Sort by aggregated measure (default) or specified column
-                sorted_df = agg_df.sort_values(by=effective_sort_by, ascending=sort_ascending)
+                sorted_df = agg_df.sort_values(
+                    by=effective_sort_by, ascending=sort_ascending
+                )
                 category_order = sorted_df[x_column].tolist()
-            fig = px.bar(agg_df, x=x_column, y=y_column, title=title,
-                        category_orders={x_column: category_order},
-                        labels={x_column: format_measure_name(x_column),
-                                y_column: format_measure_name(y_column)})
+            fig = px.bar(
+                agg_df,
+                x=x_column,
+                y=y_column,
+                title=title,
+                category_orders={x_column: category_order},
+                labels={
+                    x_column: format_measure_name(x_column),
+                    y_column: format_measure_name(y_column),
+                },
+            )
     elif chart_type == "line":
         # Work with a clean copy to avoid modifying the original dataframe
         # and prevent Plotly 6.x index/column conflicts
@@ -290,34 +406,61 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
         # Determine sorting for line charts
         # Default: sort by dimension (x_column) ascending
         effective_sort_by = sort_by if sort_by else x_column
-        effective_sort_order = sort_order if sort_order else 'ascending'
-        sort_ascending = (effective_sort_order == 'ascending')
+        effective_sort_order = sort_order if sort_order else "ascending"
+        sort_ascending = effective_sort_order == "ascending"
 
         # Define month names and abbreviations for chronological sorting
-        month_names_full = ['january', 'february', 'march', 'april', 'may', 'june',
-                           'july', 'august', 'september', 'october', 'november', 'december']
-        month_names_short = ['jan', 'feb', 'mar', 'apr', 'may', 'jun',
-                            'jul', 'aug', 'sep', 'oct', 'nov', 'dec']
+        month_names_full = [
+            "january",
+            "february",
+            "march",
+            "april",
+            "may",
+            "june",
+            "july",
+            "august",
+            "september",
+            "october",
+            "november",
+            "december",
+        ]
+        month_names_short = [
+            "jan",
+            "feb",
+            "mar",
+            "apr",
+            "may",
+            "jun",
+            "jul",
+            "aug",
+            "sep",
+            "oct",
+            "nov",
+            "dec",
+        ]
 
         # Check if the x_column contains month values (full or abbreviated)
         x_values_lower = sorted_df[x_column].astype(str).str.lower().unique()
-        is_month_column = (
-            any(val in month_names_full for val in x_values_lower) or
-            any(val in month_names_short for val in x_values_lower)
+        is_month_column = any(val in month_names_full for val in x_values_lower) or any(
+            val in month_names_short for val in x_values_lower
         )
 
         # Check if the x_column contains quarterly values (e.g., "Q1 2024", "Q2 2024")
         import re
+
         x_values_str = sorted_df[x_column].astype(str).unique()
         is_quarter_column = all(
-            re.match(r'^Q[1-4]\s*\d{4}$', str(val).strip(), re.IGNORECASE)
-            for val in x_values_str if pd.notna(val)
+            re.match(r"^Q[1-4]\s*\d{4}$", str(val).strip(), re.IGNORECASE)
+            for val in x_values_str
+            if pd.notna(val)
         )
 
         if is_quarter_column and effective_sort_by == x_column:
             # Extract quarter and year for proper sorting
             def parse_quarter(q_str):
-                match = re.match(r'^Q([1-4])\s*(\d{4})$', str(q_str).strip(), re.IGNORECASE)
+                match = re.match(
+                    r"^Q([1-4])\s*(\d{4})$", str(q_str).strip(), re.IGNORECASE
+                )
                 if match:
                     qtr = int(match.group(1))
                     year = int(match.group(2))
@@ -325,7 +468,7 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
                 return (0, 0)  # Fallback for invalid formats
 
             # Add a temporary column for sorting (use unique name to avoid conflicts)
-            temp_col = '_qtr_sort_order'
+            temp_col = "_qtr_sort_order"
             if temp_col in sorted_df.columns:
                 sorted_df = sorted_df.drop(columns=[temp_col])
             sorted_df[temp_col] = sorted_df[x_column].apply(parse_quarter)
@@ -341,13 +484,17 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
             month_order.update({month: i for i, month in enumerate(month_names_short)})
 
             # Add a temporary column for sorting
-            sorted_df['_month_order'] = sorted_df[x_column].astype(str).str.lower().map(month_order)
+            sorted_df["_month_order"] = (
+                sorted_df[x_column].astype(str).str.lower().map(month_order)
+            )
 
             # Sort by the temporary column
-            sorted_df = sorted_df.sort_values(by='_month_order', ascending=sort_ascending)
+            sorted_df = sorted_df.sort_values(
+                by="_month_order", ascending=sort_ascending
+            )
 
             # Remove the temporary column
-            sorted_df = sorted_df.drop(columns=['_month_order'])
+            sorted_df = sorted_df.drop(columns=["_month_order"])
         else:
             # Try to convert x_column to datetime if it looks like a date
             # This ensures proper chronological sorting
@@ -358,85 +505,118 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
                 pass
 
             # Sort data by x-axis column (default) or specified column for proper line chart ordering
-            sorted_df = sorted_df.sort_values(by=effective_sort_by, ascending=sort_ascending)
+            sorted_df = sorted_df.sort_values(
+                by=effective_sort_by, ascending=sort_ascending
+            )
 
         # Support multiple measures for line charts
         if isinstance(y_column, list):
             # Multiple measures - separate into regular and percentage measures
             # Strip spaces and check case-insensitively for percentage measures
-            pct_measures = [m for m in y_column if m in sorted_df.columns and (
-                m.strip().lower().endswith('_pct') or
-                m.strip().lower().endswith('_percent') or
-                m.strip().lower().endswith('_percentage')
-            )]
-            value_measures = [m for m in y_column if m in sorted_df.columns and m not in pct_measures]
+            pct_measures = [
+                m
+                for m in y_column
+                if m in sorted_df.columns
+                and (
+                    m.strip().lower().endswith("_pct")
+                    or m.strip().lower().endswith("_percent")
+                    or m.strip().lower().endswith("_percentage")
+                )
+            ]
+            value_measures = [
+                m for m in y_column if m in sorted_df.columns and m not in pct_measures
+            ]
 
             fig = go.Figure()
 
             # Plot value measures on primary y-axis
             for measure in value_measures:
-                fig.add_trace(go.Scatter(
-                    x=sorted_df[x_column],
-                    y=sorted_df[measure],
-                    mode='lines+markers',
-                    name=format_measure_name(measure),
-                    yaxis='y',
-                    showlegend=True
-                ))
+                fig.add_trace(
+                    go.Scatter(
+                        x=sorted_df[x_column],
+                        y=sorted_df[measure],
+                        mode="lines+markers",
+                        name=format_measure_name(measure),
+                        yaxis="y",
+                        showlegend=True,
+                    )
+                )
 
             # Plot percentage measures on secondary y-axis if we have both types
             for measure in pct_measures:
-                fig.add_trace(go.Scatter(
-                    x=sorted_df[x_column],
-                    y=sorted_df[measure],
-                    mode='lines+markers',
-                    name=format_measure_name(measure),
-                    yaxis='y2' if value_measures else 'y',
-                    line=dict(dash='dash') if value_measures else None,
-                    showlegend=True
-                ))
+                fig.add_trace(
+                    go.Scatter(
+                        x=sorted_df[x_column],
+                        y=sorted_df[measure],
+                        mode="lines+markers",
+                        name=format_measure_name(measure),
+                        yaxis="y2" if value_measures else "y",
+                        line=dict(dash="dash") if value_measures else None,
+                        showlegend=True,
+                    )
+                )
 
             # Configure layout with dual y-axes if needed
             layout_config = {
-                'title': title,
-                'xaxis_title': format_measure_name(x_column),
-                'showlegend': True
+                "title": title,
+                "xaxis_title": format_measure_name(x_column),
+                "showlegend": True,
             }
 
             if pct_measures and value_measures:
                 # Dual y-axis configuration
-                layout_config['yaxis'] = dict(
+                layout_config["yaxis"] = dict(
                     title=", ".join([format_measure_name(m) for m in value_measures]),
-                    side='left'
+                    side="left",
                 )
-                layout_config['yaxis2'] = dict(
+                layout_config["yaxis2"] = dict(
                     title=", ".join([format_measure_name(m) for m in pct_measures]),
-                    side='right',
-                    overlaying='y',
-                    titlefont=dict(color='gray'),
-                    tickfont=dict(color='gray'),
-                    ticksuffix='%'
+                    side="right",
+                    overlaying="y",
+                    titlefont=dict(color="gray"),
+                    tickfont=dict(color="gray"),
+                    ticksuffix="%",
                 )
             elif pct_measures:
-                layout_config['yaxis_title'] = ", ".join([format_measure_name(m) for m in pct_measures])
+                layout_config["yaxis_title"] = ", ".join(
+                    [format_measure_name(m) for m in pct_measures]
+                )
             else:
-                layout_config['yaxis_title'] = ", ".join([format_measure_name(m) for m in value_measures])
+                layout_config["yaxis_title"] = ", ".join(
+                    [format_measure_name(m) for m in value_measures]
+                )
 
             fig.update_layout(**layout_config)
         else:
             # Single measure with optional color grouping
-            fig = px.line(sorted_df, x=x_column, y=y_column, color=color_column, title=title,
-                         labels={x_column: format_measure_name(x_column),
-                                 y_column: format_measure_name(y_column)})
+            fig = px.line(
+                sorted_df,
+                x=x_column,
+                y=y_column,
+                color=color_column,
+                title=title,
+                labels={
+                    x_column: format_measure_name(x_column),
+                    y_column: format_measure_name(y_column),
+                },
+            )
 
         # Enhance for time series
-        if sorted_df[x_column].dtype in ['datetime64[ns]']:
-            fig.update_xaxes(title=format_measure_name(x_column), type='date')
+        if sorted_df[x_column].dtype in ["datetime64[ns]"]:
+            fig.update_xaxes(title=format_measure_name(x_column), type="date")
     elif chart_type == "scatter":
-        fig = px.scatter(df, x=x_column, y=y_column, color=color_column, title=title,
-                        size_max=15,
-                        labels={x_column: format_measure_name(x_column),
-                                y_column: format_measure_name(y_column)})
+        fig = px.scatter(
+            df,
+            x=x_column,
+            y=y_column,
+            color=color_column,
+            title=title,
+            size_max=15,
+            labels={
+                x_column: format_measure_name(x_column),
+                y_column: format_measure_name(y_column),
+            },
+        )
     elif chart_type == "heatmap":
         if y_column:
             # Pivot table heatmap
@@ -445,14 +625,16 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
             if color_column and color_column in df.columns:
                 # Use color_column as the z-values (color intensity)
                 pivot_df = df.pivot_table(
-                    index=y_column, columns=x_column,
-                    values=color_column, aggfunc='sum', fill_value=0
+                    index=y_column,
+                    columns=x_column,
+                    values=color_column,
+                    aggfunc="sum",
+                    fill_value=0,
                 )
             else:
                 # No value column — count occurrences (frequency heatmap)
                 pivot_df = df.pivot_table(
-                    index=y_column, columns=x_column,
-                    aggfunc='size', fill_value=0
+                    index=y_column, columns=x_column, aggfunc="size", fill_value=0
                 )
 
             # Sort index (y_column) — use ordinal order for weekdays/times,
@@ -460,11 +642,14 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
             idx_ordinal = _get_ordinal_sort_key(pivot_df.index)
             if idx_ordinal:
                 key_fn, default_asc = idx_ordinal
-                asc = (sort_order == 'ascending') if sort_order else default_asc
-                pivot_df = pivot_df.iloc[sorted(
-                    range(len(pivot_df)), key=lambda i: key_fn(pivot_df.index[i]),
-                    reverse=not asc
-                )]
+                asc = (sort_order == "ascending") if sort_order else default_asc
+                pivot_df = pivot_df.iloc[
+                    sorted(
+                        range(len(pivot_df)),
+                        key=lambda i: key_fn(pivot_df.index[i]),
+                        reverse=not asc,
+                    )
+                ]
             else:
                 pivot_df = pivot_df.sort_index(ascending=False)
 
@@ -473,48 +658,52 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
             col_ordinal = _get_ordinal_sort_key(pivot_df.columns)
             if col_ordinal:
                 key_fn, default_asc = col_ordinal
-                asc = (sort_order == 'ascending') if sort_order else default_asc
+                asc = (sort_order == "ascending") if sort_order else default_asc
                 ordered_cols = sorted(pivot_df.columns, key=key_fn, reverse=not asc)
                 pivot_df = pivot_df[ordered_cols]
             elif not sort_by or sort_by == x_column:
-                x_sort_order = sort_order if sort_order else 'ascending'
-                pivot_df = pivot_df.sort_index(axis=1, ascending=(x_sort_order == 'ascending'))
+                x_sort_order = sort_order if sort_order else "ascending"
+                pivot_df = pivot_df.sort_index(
+                    axis=1, ascending=(x_sort_order == "ascending")
+                )
         else:
             # Correlation heatmap
-            numeric_cols = df.select_dtypes(include=['number']).columns
+            numeric_cols = df.select_dtypes(include=["number"]).columns
             pivot_df = df[numeric_cols].corr()
 
             # Sort correlation heatmap indices
             if sort_order:
-                pivot_df = pivot_df.sort_index(ascending=(sort_order == 'ascending'))
-                pivot_df = pivot_df.sort_index(axis=1, ascending=(sort_order == 'ascending'))
+                pivot_df = pivot_df.sort_index(ascending=(sort_order == "ascending"))
+                pivot_df = pivot_df.sort_index(
+                    axis=1, ascending=(sort_order == "ascending")
+                )
 
         fig = px.imshow(pivot_df, title=title, aspect="auto")
     else:
         raise ValueError(f"Unsupported chart type: {chart_type}")
-    
+
     # Check if x-axis labels are long and need rotation
     if chart_type in ["bar", "line", "scatter"]:
         # Use the appropriate dataframe based on chart type
         check_df = sorted_df if chart_type == "line" else df
         x_labels = check_df[x_column].astype(str).unique()
-        max_label_length = max([len(str(label)) for label in x_labels]) if len(x_labels) > 0 else 0
+        max_label_length = (
+            max([len(str(label)) for label in x_labels]) if len(x_labels) > 0 else 0
+        )
 
         if max_label_length > 10 or len(x_labels) > 8:
             # Rotate x-axis labels for better readability
             fig.update_xaxes(tickangle=45)
-    
+
     # Apply consistent styling
     # Determine if we should show legend
-    show_legend = bool(color_column or (isinstance(y_column, list) and chart_type in ["bar", "line"]))
+    show_legend = bool(
+        color_column or (isinstance(y_column, list) and chart_type in ["bar", "line"])
+    )
 
     if show_legend:
         legend_config = dict(
-            orientation="v",
-            yanchor="middle",
-            y=0.5,
-            xanchor="left",
-            x=1.02
+            orientation="v", yanchor="middle", y=0.5, xanchor="left", x=1.02
         )
         margin_config = dict(b=100, t=60, l=60, r=200)
     else:
@@ -523,19 +712,21 @@ def create_plotly_chart(df, chart_type, x_column, y_column, color_column, title,
 
     fig.update_layout(
         font=dict(size=12),
-        plot_bgcolor='white',
-        paper_bgcolor='white',
+        plot_bgcolor="white",
+        paper_bgcolor="white",
         margin=margin_config,
         showlegend=show_legend,
         legend=legend_config,
         modebar=dict(
-            bgcolor='white', color='gray', activecolor='black',
-            orientation='h',
+            bgcolor="white",
+            color="gray",
+            activecolor="black",
+            orientation="h",
         ),
         width=width,
-        height=height
+        height=height,
     )
-    
+
     return fig
 
 
@@ -563,7 +754,7 @@ def save_image_to_tmp(
         charts_dir = get_charts_dir(connection_id)
         image_file_path = charts_dir / image_filename
 
-        with open(image_file_path, 'wb') as f:
+        with open(image_file_path, "wb") as f:
             f.write(image_bytes)
 
         logger.debug(f"Saved {format.upper()} chart to: {image_file_path}")

--- a/src/config.py
+++ b/src/config.py
@@ -1,19 +1,20 @@
 """Configuration management for OrionBelt Analytics."""
 
-import os
 import logging
-from typing import Optional, Dict, Any
+import os
 from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
 from dotenv import load_dotenv
 
 from .constants import (
     DEFAULT_BASE_URI,
-    DEFAULT_POSTGRES_PORT,
-    DEFAULT_SNOWFLAKE_SCHEMA,
-    DEFAULT_DREMIO_PORT,
     DEFAULT_CLICKHOUSE_PORT,
+    DEFAULT_DREMIO_PORT,
+    DEFAULT_POSTGRES_PORT,
     DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS,
     DEFAULT_SESSION_SCAN_INTERVAL_SECONDS,
+    DEFAULT_SNOWFLAKE_SCHEMA,
 )
 
 logger = logging.getLogger(__name__)
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class ServerConfig:
     """Server configuration settings."""
+
     log_level: str
     ontology_base_uri: str
     mcp_transport: str = "http"  # Default to http transport
@@ -34,25 +36,28 @@ class ServerConfig:
 
     def __post_init__(self):
         """Validate configuration after initialization."""
-        if not self.ontology_base_uri.endswith('/'):
-            self.ontology_base_uri += '/'
+        if not self.ontology_base_uri.endswith("/"):
+            self.ontology_base_uri += "/"
 
         # Validate transport type
         if self.mcp_transport not in ["http", "sse"]:
-            logger.warning(f"Invalid MCP_TRANSPORT value '{self.mcp_transport}'. Defaulting to 'http'.")
+            logger.warning(
+                f"Invalid MCP_TRANSPORT value '{self.mcp_transport}'. Defaulting to 'http'."
+            )
             self.mcp_transport = "http"
 
 
 @dataclass
 class DatabaseConfig:
     """Database connection configuration."""
+
     # PostgreSQL settings
     postgres_host: Optional[str] = None
     postgres_port: int = DEFAULT_POSTGRES_PORT
     postgres_database: Optional[str] = None
     postgres_username: Optional[str] = None
     postgres_password: Optional[str] = None
-    
+
     # Snowflake settings
     snowflake_account: Optional[str] = None
     snowflake_username: Optional[str] = None
@@ -61,9 +66,11 @@ class DatabaseConfig:
     snowflake_database: Optional[str] = None
     snowflake_schema: str = DEFAULT_SNOWFLAKE_SCHEMA
     snowflake_role: str = "PUBLIC"
-    
+
     # Dremio settings (following official dremio-mcp approach)
-    dremio_uri: Optional[str] = None  # Full API endpoint like https://api.dremio.cloud or https://host:port
+    dremio_uri: Optional[
+        str
+    ] = None  # Full API endpoint like https://api.dremio.cloud or https://host:port
     dremio_pat: Optional[str] = None  # Personal Access Token
     # Legacy settings for backward compatibility
     dremio_host: Optional[str] = None
@@ -84,15 +91,15 @@ class DatabaseConfig:
 
 class ConfigManager:
     """Manages application configuration."""
-    
+
     def __init__(self):
         """Initialize configuration manager."""
         # Load .env from project root (one level up from src)
-        env_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env')
+        env_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), ".env")
         load_dotenv(env_path)
         self._server_config: Optional[ServerConfig] = None
         self._db_config: Optional[DatabaseConfig] = None
-    
+
     def get_server_config(self) -> ServerConfig:
         """Get server configuration."""
         if self._server_config is None:
@@ -102,20 +109,25 @@ class ConfigManager:
                 mcp_transport=os.getenv("MCP_TRANSPORT", "http").lower(),
                 mcp_server_host=os.getenv("MCP_SERVER_HOST", "localhost"),
                 mcp_server_port=int(os.getenv("MCP_SERVER_PORT", "9000")),
-                session_idle_timeout=int(os.getenv(
-                    "SESSION_IDLE_TIMEOUT_SECONDS",
-                    str(DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS),
-                )),
-                session_scan_interval=int(os.getenv(
-                    "SESSION_SCAN_INTERVAL_SECONDS",
-                    str(DEFAULT_SESSION_SCAN_INTERVAL_SECONDS),
-                )),
-                chart_return_binary=os.getenv("CHART_RETURN_BINARY", "false").lower() == "true",
+                session_idle_timeout=int(
+                    os.getenv(
+                        "SESSION_IDLE_TIMEOUT_SECONDS",
+                        str(DEFAULT_SESSION_IDLE_TIMEOUT_SECONDS),
+                    )
+                ),
+                session_scan_interval=int(
+                    os.getenv(
+                        "SESSION_SCAN_INTERVAL_SECONDS",
+                        str(DEFAULT_SESSION_SCAN_INTERVAL_SECONDS),
+                    )
+                ),
+                chart_return_binary=os.getenv("CHART_RETURN_BINARY", "false").lower()
+                == "true",
                 enable_sampling=os.getenv("ENABLE_SAMPLING", "true").lower() == "true",
             )
             logger.info("Server configuration loaded")
         return self._server_config
-    
+
     def get_database_config(self) -> DatabaseConfig:
         """Get database configuration."""
         if self._db_config is None:
@@ -130,12 +142,13 @@ class ConfigManager:
                 snowflake_password=os.getenv("SNOWFLAKE_PASSWORD"),
                 snowflake_warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
                 snowflake_database=os.getenv("SNOWFLAKE_DATABASE"),
-                snowflake_schema=os.getenv("SNOWFLAKE_SCHEMA", DEFAULT_SNOWFLAKE_SCHEMA),
+                snowflake_schema=os.getenv(
+                    "SNOWFLAKE_SCHEMA", DEFAULT_SNOWFLAKE_SCHEMA
+                ),
                 snowflake_role=os.getenv("SNOWFLAKE_ROLE", "PUBLIC"),
                 # New PAT-based settings (preferred)
                 dremio_uri=os.getenv("DREMIO_URI"),
                 dremio_pat=os.getenv("DREMIO_PAT"),
-
                 # Legacy settings for backward compatibility
                 dremio_host=os.getenv("DREMIO_HOST"),
                 dremio_port=int(os.getenv("DREMIO_PORT", DEFAULT_DREMIO_PORT)),
@@ -144,16 +157,19 @@ class ConfigManager:
                 dremio_ssl=os.getenv("DREMIO_SSL", "false").lower() == "true",
                 # ClickHouse settings
                 clickhouse_host=os.getenv("CLICKHOUSE_HOST"),
-                clickhouse_port=int(os.getenv("CLICKHOUSE_PORT", DEFAULT_CLICKHOUSE_PORT)),
+                clickhouse_port=int(
+                    os.getenv("CLICKHOUSE_PORT", DEFAULT_CLICKHOUSE_PORT)
+                ),
                 clickhouse_database=os.getenv("CLICKHOUSE_DATABASE"),
                 clickhouse_username=os.getenv("CLICKHOUSE_USERNAME", "default"),
                 clickhouse_password=os.getenv("CLICKHOUSE_PASSWORD", ""),
                 clickhouse_protocol=os.getenv("CLICKHOUSE_PROTOCOL", "http"),
-                clickhouse_secure=os.getenv("CLICKHOUSE_SECURE", "false").lower() == "true"
+                clickhouse_secure=os.getenv("CLICKHOUSE_SECURE", "false").lower()
+                == "true",
             )
             logger.info("Database configuration loaded")
         return self._db_config
-    
+
     def validate_config(self) -> None:
         """Validate core server configuration at startup.
 
@@ -186,14 +202,14 @@ class ConfigManager:
         """Validate database configuration for a specific type."""
         config = self.get_database_config()
         missing_params = []
-        
+
         if db_type == "postgresql":
             required_fields = {
                 "host": config.postgres_host,
                 "port": config.postgres_port,
                 "database": config.postgres_database,
                 "username": config.postgres_username,
-                "password": config.postgres_password
+                "password": config.postgres_password,
             }
         elif db_type == "snowflake":
             required_fields = {
@@ -201,15 +217,12 @@ class ConfigManager:
                 "username": config.snowflake_username,
                 "password": config.snowflake_password,
                 "warehouse": config.snowflake_warehouse,
-                "database": config.snowflake_database
+                "database": config.snowflake_database,
             }
         elif db_type == "dremio":
             # Prefer new PAT-based authentication
             if config.dremio_uri and config.dremio_pat:
-                required_fields = {
-                    "uri": config.dremio_uri,
-                    "pat": config.dremio_pat
-                }
+                required_fields = {"uri": config.dremio_uri, "pat": config.dremio_pat}
             else:
                 # Fall back to legacy username/password authentication
                 required_fields = {
@@ -217,22 +230,22 @@ class ConfigManager:
                     "port": config.dremio_port,
                     "username": config.dremio_username,
                     "password": config.dremio_password,
-                    "ssl": config.dremio_ssl
+                    "ssl": config.dremio_ssl,
                 }
         elif db_type == "clickhouse":
             required_fields = {
                 "host": config.clickhouse_host,
-                "database": config.clickhouse_database
+                "database": config.clickhouse_database,
             }
         else:
             raise ValueError(f"Unsupported database type: {db_type}")
-        
+
         missing_params = [k for k, v in required_fields.items() if not v]
-        
+
         return {
             "valid": len(missing_params) == 0,
             "missing_params": missing_params,
-            "config": required_fields
+            "config": required_fields,
         }
 
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -31,7 +31,7 @@ DEFAULT_R2RML_BASE_IRI = "http://mycompany.com/"
 DEFAULT_OUTPUT_DIR = "tmp"
 
 # Identifier validation pattern
-IDENTIFIER_PATTERN = r'^[a-zA-Z_][a-zA-Z0-9_-]*$'
+IDENTIFIER_PATTERN = r"^[a-zA-Z_][a-zA-Z0-9_-]*$"
 
 # Canonical database metadata: maps each supported db_type to its sqlglot
 # dialect. This is the single source of truth — add a database here once and

--- a/src/database_manager.py
+++ b/src/database_manager.py
@@ -11,24 +11,20 @@ import re
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, List, Optional
 
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import OperationalError, DatabaseError
+from sqlalchemy.exc import DatabaseError, OperationalError
 
-from .constants import (
-    IDENTIFIER_PATTERN,
-    DEFAULT_SAMPLE_LIMIT,
-    DB_SQLGLOT_DIALECTS,
-)
+from .constants import DB_SQLGLOT_DIALECTS, DEFAULT_SAMPLE_LIMIT, IDENTIFIER_PATTERN
 from .security import (
     SecureCredentialManager,
-    sql_validator,
-    analyze_sql_statement,
-    identifier_validator,
-    audit_log_security_event,
     SecurityLevel,
+    analyze_sql_statement,
+    audit_log_security_event,
+    identifier_validator,
+    sql_validator,
 )
 
 logger = logging.getLogger(__name__)
@@ -38,9 +34,11 @@ logger = logging.getLogger(__name__)
 # Data classes (imported by many modules - must stay here)
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class ColumnInfo:
     """Information about a database column."""
+
     name: str
     data_type: str
     is_nullable: bool
@@ -54,6 +52,7 @@ class ColumnInfo:
 @dataclass
 class TableInfo:
     """Information about a database table."""
+
     name: str
     schema: str
     columns: List[ColumnInfo]
@@ -97,6 +96,7 @@ class TableInfo:
 # DatabaseManager - orchestrator
 # ---------------------------------------------------------------------------
 
+
 class DatabaseManager:
     """Manages database connections and schema analysis with enhanced reliability and security.
 
@@ -127,7 +127,6 @@ class DatabaseManager:
         self._cache_ttl = 300  # 5 minutes
         self._connection_id: Optional[str] = None
 
-
     # ------------------------------------------------------------------
     # Cache helpers
     # ------------------------------------------------------------------
@@ -138,7 +137,7 @@ class DatabaseManager:
 
     def _is_cache_valid(self, cache_entry: Dict) -> bool:
         """Check if cache entry is still valid."""
-        return time.time() - cache_entry.get('timestamp', 0) < self._cache_ttl
+        return time.time() - cache_entry.get("timestamp", 0) < self._cache_ttl
 
     def _get_from_cache(self, cache_key: str) -> Optional[Any]:
         """Get value from cache if valid."""
@@ -146,32 +145,33 @@ class DatabaseManager:
             entry = self._metadata_cache[cache_key]
             if self._is_cache_valid(entry):
                 logger.debug(f"Cache hit for {cache_key}")
-                return entry['data']
+                return entry["data"]
             else:
                 del self._metadata_cache[cache_key]
         return None
 
     def _store_in_cache(self, cache_key: str, data: Any) -> None:
         """Store data in cache with timestamp."""
-        self._metadata_cache[cache_key] = {
-            'data': data,
-            'timestamp': time.time()
-        }
+        self._metadata_cache[cache_key] = {"data": data, "timestamp": time.time()}
         logger.debug(f"Cached data for {cache_key}")
 
     # ------------------------------------------------------------------
     # SQL / identifier helpers
     # ------------------------------------------------------------------
 
-    def _log_sql_query(self, query: str, params: Optional[Dict[str, Any]] = None) -> None:
+    def _log_sql_query(
+        self, query: str, params: Optional[Dict[str, Any]] = None
+    ) -> None:
         """Log SQL query with parameters for debugging."""
         db_type = self.connection_info.get("type", "unknown")
         if params:
             safe_params = {
-                k: '***' if 'password' in k.lower() or 'secret' in k.lower() else v
+                k: "***" if "password" in k.lower() or "secret" in k.lower() else v
                 for k, v in params.items()
             }
-            logger.info(f"\U0001f50d {db_type.upper()} SQL QUERY: {query} | PARAMS: {safe_params}")
+            logger.info(
+                f"\U0001f50d {db_type.upper()} SQL QUERY: {query} | PARAMS: {safe_params}"
+            )
         else:
             logger.info(f"\U0001f50d {db_type.upper()} SQL QUERY: {query}")
 
@@ -198,7 +198,7 @@ class DatabaseManager:
         Handles both -- (line comments) and /* */ (block comments) at the
         beginning of queries.
         """
-        lines = sql_query.split('\n')
+        lines = sql_query.split("\n")
         result_lines = []
         in_block_comment = False
 
@@ -206,8 +206,8 @@ class DatabaseManager:
             line = original_line.strip()
 
             if in_block_comment:
-                if '*/' in line:
-                    after_comment = line.split('*/', 1)[1].strip()
+                if "*/" in line:
+                    after_comment = line.split("*/", 1)[1].strip()
                     in_block_comment = False
                     if after_comment:
                         result_lines.append(after_comment)
@@ -216,12 +216,12 @@ class DatabaseManager:
             if not line:
                 continue
 
-            if line.startswith('--'):
+            if line.startswith("--"):
                 continue
 
-            if line.startswith('/*'):
-                if '*/' in line:
-                    after_comment = line.split('*/', 1)[1].strip()
+            if line.startswith("/*"):
+                if "*/" in line:
+                    after_comment = line.split("*/", 1)[1].strip()
                     if after_comment:
                         result_lines.append(after_comment)
                         break
@@ -235,7 +235,7 @@ class DatabaseManager:
                 result_lines.extend(lines[remaining_index:])
             break
 
-        return '\n'.join(result_lines).strip()
+        return "\n".join(result_lines).strip()
 
     def _escape_sql_literal(self, value: str) -> str:
         """Escape a value for safe use inside a single-quoted SQL literal."""
@@ -245,7 +245,7 @@ class DatabaseManager:
         """Quote and escape a Dremio identifier or path safely."""
         if identifier is None:
             return ""
-        parts = [p for p in str(identifier).split('.') if p != ""]
+        parts = [p for p in str(identifier).split(".") if p != ""]
         if not parts:
             return ""
         escaped_parts = [part.replace('"', '""') for part in parts]
@@ -257,9 +257,9 @@ class DatabaseManager:
 
     def _sync_engine_from_driver(self):
         """Keep legacy ``self.engine`` attribute in sync with the active driver."""
-        if self._driver and hasattr(self._driver, 'engine'):
+        if self._driver and hasattr(self._driver, "engine"):
             self.engine = self._driver.engine
-            self.metadata = getattr(self._driver, 'metadata', None)
+            self.metadata = getattr(self._driver, "metadata", None)
         else:
             self.engine = None
             self.metadata = None
@@ -291,23 +291,35 @@ class DatabaseManager:
             return
 
         logger.debug(f"_ensure_connection: engine exists: {self.engine is not None}")
-        logger.debug(f"_ensure_connection: last_params available: {self._last_connection_params is not None}")
+        logger.debug(
+            f"_ensure_connection: last_params available: {self._last_connection_params is not None}"
+        )
 
         if not self.engine:
             if self._last_connection_params:
-                logger.info("No engine found, reconnecting to database using stored parameters")
+                logger.info(
+                    "No engine found, reconnecting to database using stored parameters"
+                )
                 self._reconnect()
             else:
-                raise RuntimeError("No database connection established and no connection parameters available")
+                raise RuntimeError(
+                    "No database connection established and no connection parameters available"
+                )
         elif not self._test_connection():
             if self._last_connection_params:
                 logger.info("Connection health check failed, reconnecting to database")
                 self._reconnect()
             else:
-                logger.error("Connection unhealthy but no reconnection parameters available")
-                raise RuntimeError("Database connection is unhealthy and cannot be restored")
+                logger.error(
+                    "Connection unhealthy but no reconnection parameters available"
+                )
+                raise RuntimeError(
+                    "Database connection is unhealthy and cannot be restored"
+                )
 
-        logger.debug(f"_ensure_connection: final engine state: {self.engine is not None}")
+        logger.debug(
+            f"_ensure_connection: final engine state: {self.engine is not None}"
+        )
 
     def _reconnect(self):
         """Reconnect to the database using stored parameters."""
@@ -317,33 +329,48 @@ class DatabaseManager:
         params = self._last_connection_params
         if params["type"] == "postgresql":
             success = self.connect_postgresql(
-                params["host"], params["port"], params["database"],
-                params["username"], params["password"],
+                params["host"],
+                params["port"],
+                params["database"],
+                params["username"],
+                params["password"],
             )
         elif params["type"] == "snowflake":
             success = self.connect_snowflake(
-                params["account"], params["username"], params["password"],
-                params["warehouse"], params["database"], params.get("schema", "PUBLIC"),
+                params["account"],
+                params["username"],
+                params["password"],
+                params["warehouse"],
+                params["database"],
+                params.get("schema", "PUBLIC"),
             )
         elif params["type"] == "clickhouse":
             success = self.connect_clickhouse(
-                params["host"], params["port"], params["database"],
-                params.get("username", "default"), params.get("password", ""),
-                params.get("protocol", "http"), params.get("secure", False),
+                params["host"],
+                params["port"],
+                params["database"],
+                params.get("username", "default"),
+                params.get("password", ""),
+                params.get("protocol", "http"),
+                params.get("secure", False),
             )
         elif params["type"] == "dremio":
             if params.get("uri") and params.get("pat"):
                 success = self.connect_dremio(uri=params["uri"], pat=params["pat"])
             else:
                 success = self.connect_dremio(
-                    params.get("host"), params.get("port"),
-                    params.get("username"), params.get("password"),
+                    params.get("host"),
+                    params.get("port"),
+                    params.get("username"),
+                    params.get("password"),
                     params.get("ssl", True),
                 )
         elif params["type"] == "bigquery":
             success = self.connect_bigquery(
-                params["project_id"], params.get("dataset", ""),
-                params.get("credentials_path"), params.get("credentials_json"),
+                params["project_id"],
+                params.get("dataset", ""),
+                params.get("credentials_path"),
+                params.get("credentials_json"),
             )
         elif params["type"] == "duckdb":
             success = self.connect_duckdb(
@@ -353,18 +380,25 @@ class DatabaseManager:
             )
         elif params["type"] == "databricks":
             success = self.connect_databricks(
-                params["server_hostname"], params["http_path"],
-                params["access_token"], params.get("catalog", "hive_metastore"),
+                params["server_hostname"],
+                params["http_path"],
+                params["access_token"],
+                params.get("catalog", "hive_metastore"),
                 params.get("schema", "default"),
             )
         elif params["type"] == "mysql":
             success = self.connect_mysql(
-                params["host"], params["port"], params["database"],
-                params["username"], params["password"],
+                params["host"],
+                params["port"],
+                params["database"],
+                params["username"],
+                params["password"],
                 params.get("charset", "utf8mb4"),
             )
         else:
-            raise RuntimeError(f"Unsupported database type for reconnection: {params['type']}")
+            raise RuntimeError(
+                f"Unsupported database type for reconnection: {params['type']}"
+            )
 
         if not success:
             raise RuntimeError(f"Failed to reconnect to {params['type']} database")
@@ -399,18 +433,23 @@ class DatabaseManager:
                         except Exception as reconnect_error:
                             logger.error(f"Reconnection failed: {reconnect_error}")
                     else:
-                        logger.error("No connection parameters available for reconnection")
+                        logger.error(
+                            "No connection parameters available for reconnection"
+                        )
                         break
 
         logger.error(f"All connection attempts failed. Last error: {last_exception}")
-        raise RuntimeError(f"Database connection failed after {max_retries} attempts: {last_exception}")
+        raise RuntimeError(
+            f"Database connection failed after {max_retries} attempts: {last_exception}"
+        )
 
     # ------------------------------------------------------------------
     # connect_* methods - instantiate the appropriate driver
     # ------------------------------------------------------------------
 
-    def connect_postgresql(self, host: str, port: int, database: str,
-                           username: str, password: str) -> bool:
+    def connect_postgresql(
+        self, host: str, port: int, database: str, username: str, password: str
+    ) -> bool:
         """Connect to PostgreSQL database with enhanced security and reliability."""
         from .drivers.postgresql import PostgreSQLDriver
 
@@ -419,8 +458,11 @@ class DatabaseManager:
             max_overflow=self._max_overflow,
         )
         success = driver.connect(
-            host=host, port=port, database=database,
-            username=username, password=password,
+            host=host,
+            port=port,
+            database=database,
+            username=username,
+            password=password,
         )
         if success:
             self._driver = driver
@@ -448,9 +490,16 @@ class DatabaseManager:
             }
         return success
 
-    def connect_snowflake(self, account: str, username: str, password: str,
-                          warehouse: str, database: str, schema: str = "PUBLIC",
-                          role: str = "PUBLIC") -> bool:
+    def connect_snowflake(
+        self,
+        account: str,
+        username: str,
+        password: str,
+        warehouse: str,
+        database: str,
+        schema: str = "PUBLIC",
+        role: str = "PUBLIC",
+    ) -> bool:
         """Connect to Snowflake database with enhanced security and reliability."""
         from .drivers.snowflake import SnowflakeDriver
 
@@ -459,8 +508,13 @@ class DatabaseManager:
             max_overflow=self._max_overflow,
         )
         success = driver.connect(
-            account=account, username=username, password=password,
-            warehouse=warehouse, database=database, schema=schema, role=role,
+            account=account,
+            username=username,
+            password=password,
+            warehouse=warehouse,
+            database=database,
+            schema=schema,
+            role=role,
         )
         if success:
             self._driver = driver
@@ -488,10 +542,16 @@ class DatabaseManager:
             }
         return success
 
-    def connect_clickhouse(self, host: str, port: int = 8123,
-                           database: str = "default", username: str = "default",
-                           password: str = "", protocol: str = "http",
-                           secure: bool = False) -> bool:
+    def connect_clickhouse(
+        self,
+        host: str,
+        port: int = 8123,
+        database: str = "default",
+        username: str = "default",
+        password: str = "",
+        protocol: str = "http",
+        secure: bool = False,
+    ) -> bool:
         """Connect to ClickHouse database via SQLAlchemy."""
         from .drivers.clickhouse import ClickHouseDriver
 
@@ -500,9 +560,13 @@ class DatabaseManager:
             max_overflow=self._max_overflow,
         )
         success = driver.connect(
-            host=host, port=port, database=database,
-            username=username, password=password,
-            protocol=protocol, secure=secure,
+            host=host,
+            port=port,
+            database=database,
+            username=username,
+            password=password,
+            protocol=protocol,
+            secure=secure,
         )
         if success:
             self._driver = driver
@@ -532,10 +596,16 @@ class DatabaseManager:
             }
         return success
 
-    def connect_dremio(self, host: str = None, port: int = None,
-                       username: str = None, password: str = None,
-                       ssl: bool = False, uri: str = None,
-                       pat: str = None) -> bool:
+    def connect_dremio(
+        self,
+        host: str = None,
+        port: int = None,
+        username: str = None,
+        password: str = None,
+        ssl: bool = False,
+        uri: str = None,
+        pat: str = None,
+    ) -> bool:
         """Connect to Dremio using REST API instead of PostgreSQL protocol."""
         from .drivers.dremio import DremioDriver
 
@@ -547,8 +617,13 @@ class DatabaseManager:
 
         driver = DremioDriver()
         success = driver.connect(
-            host=host, port=port, username=username,
-            password=password, ssl=ssl, uri=uri, pat=pat,
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            ssl=ssl,
+            uri=uri,
+            pat=pat,
         )
         if success:
             self._driver = driver
@@ -596,8 +671,13 @@ class DatabaseManager:
                 }
         return success
 
-    def connect_bigquery(self, project_id: str, dataset: str = "",
-                        credentials_path: str = None, credentials_json: str = None) -> bool:
+    def connect_bigquery(
+        self,
+        project_id: str,
+        dataset: str = "",
+        credentials_path: str = None,
+        credentials_json: str = None,
+    ) -> bool:
         """Connect to Google BigQuery."""
         from .drivers.bigquery import BigQueryDriver
 
@@ -634,8 +714,12 @@ class DatabaseManager:
             }
         return success
 
-    def connect_duckdb(self, database_path: str = ":memory:",
-                      motherduck_token: str = None, read_only: bool = False) -> bool:
+    def connect_duckdb(
+        self,
+        database_path: str = ":memory:",
+        motherduck_token: str = None,
+        read_only: bool = False,
+    ) -> bool:
         """Connect to DuckDB or MotherDuck."""
         from .drivers.duckdb import DuckDBDriver
 
@@ -672,9 +756,14 @@ class DatabaseManager:
             }
         return success
 
-    def connect_databricks(self, server_hostname: str, http_path: str,
-                          access_token: str, catalog: str = "hive_metastore",
-                          schema: str = "default") -> bool:
+    def connect_databricks(
+        self,
+        server_hostname: str,
+        http_path: str,
+        access_token: str,
+        catalog: str = "hive_metastore",
+        schema: str = "default",
+    ) -> bool:
         """Connect to Databricks SQL."""
         from .drivers.databricks import DatabricksDriver
 
@@ -715,8 +804,15 @@ class DatabaseManager:
             }
         return success
 
-    def connect_mysql(self, host: str, port: int, database: str,
-                      username: str, password: str, charset: str = "utf8mb4") -> bool:
+    def connect_mysql(
+        self,
+        host: str,
+        port: int,
+        database: str,
+        username: str,
+        password: str,
+        charset: str = "utf8mb4",
+    ) -> bool:
         """Connect to MySQL 8.0+ or MariaDB 10.5+ database.
 
         Args:
@@ -842,8 +938,9 @@ class DatabaseManager:
                 log_sql=self._log_sql_query,
             )
 
-    def analyze_table(self, table_name: str,
-                      schema_name: Optional[str] = None) -> Optional[TableInfo]:
+    def analyze_table(
+        self, table_name: str, schema_name: Optional[str] = None
+    ) -> Optional[TableInfo]:
         """Analyze a specific table and return detailed information."""
         logger.debug(
             f"analyze_table: Starting analysis of {table_name}, "
@@ -881,9 +978,12 @@ class DatabaseManager:
     # Sample & query (delegated to driver with validation layer)
     # ------------------------------------------------------------------
 
-    def sample_table_data(self, table_name: str,
-                          schema_name: Optional[str] = None,
-                          limit: int = DEFAULT_SAMPLE_LIMIT) -> List[Dict[str, Any]]:
+    def sample_table_data(
+        self,
+        table_name: str,
+        schema_name: Optional[str] = None,
+        limit: int = DEFAULT_SAMPLE_LIMIT,
+    ) -> List[Dict[str, Any]]:
         """Sample data from a table for analysis with enhanced validation."""
         # Dremio REST bypasses engine check
         if not self._dremio_rest_connection:
@@ -927,9 +1027,9 @@ class DatabaseManager:
         }
 
         if not security_validation.get("is_safe", False):
-            validation_result["error"] = (
-                f"Security validation failed: {'; '.join(security_validation['issues'])}"
-            )
+            validation_result[
+                "error"
+            ] = f"Security validation failed: {'; '.join(security_validation['issues'])}"
             validation_result["error_type"] = "security_error"
             audit_log_security_event(
                 "sql_injection_attempt",
@@ -963,25 +1063,27 @@ class DatabaseManager:
 
             if parsed["parsed"]:
                 if not parsed["single_statement"]:
-                    validation_result["error"] = "Multiple SQL statements not allowed for security"
+                    validation_result[
+                        "error"
+                    ] = "Multiple SQL statements not allowed for security"
                     validation_result["error_type"] = "security_error"
                     validation_result["suggestions"].append(
                         "Split multiple statements into separate requests"
                     )
                     return validation_result
                 if parsed["query_type"] == "WRITE":
-                    validation_result["error"] = (
-                        f"Destructive operations not allowed: {', '.join(parsed['write_operations'])}"
-                    )
+                    validation_result[
+                        "error"
+                    ] = f"Destructive operations not allowed: {', '.join(parsed['write_operations'])}"
                     validation_result["error_type"] = "forbidden_operation"
                     validation_result["suggestions"].append(
                         "Use SELECT queries for data retrieval only"
                     )
                     return validation_result
                 if parsed["query_type"] == "UNKNOWN":
-                    validation_result["error"] = (
-                        "Only SELECT, CTE, and metadata queries are allowed"
-                    )
+                    validation_result[
+                        "error"
+                    ] = "Only SELECT, CTE, and metadata queries are allowed"
                     validation_result["error_type"] = "query_type_error"
                     validation_result["suggestions"].append(
                         "Start your query with SELECT, WITH, EXPLAIN, or SHOW"
@@ -991,46 +1093,58 @@ class DatabaseManager:
             else:
                 # Fallback: parser could not handle this SQL (dialect quirk) —
                 # use the legacy string heuristics so valid queries still pass.
-                query_without_comments = self._strip_leading_sql_comments(query_stripped)
+                query_without_comments = self._strip_leading_sql_comments(
+                    query_stripped
+                )
                 query_upper = query_without_comments.upper()
 
-                if ';' in query_stripped[:-1]:
-                    validation_result["error"] = "Multiple SQL statements not allowed for security"
+                if ";" in query_stripped[:-1]:
+                    validation_result[
+                        "error"
+                    ] = "Multiple SQL statements not allowed for security"
                     validation_result["error_type"] = "security_error"
                     validation_result["suggestions"].append(
                         "Split multiple statements into separate requests"
                     )
                     return validation_result
 
-                if query_upper.startswith('SELECT'):
+                if query_upper.startswith("SELECT"):
                     validation_result["query_type"] = "SELECT"
-                elif query_upper.startswith('WITH'):
+                elif query_upper.startswith("WITH"):
                     validation_result["query_type"] = "CTE_SELECT"
-                    if 'SELECT' not in query_upper:
+                    if "SELECT" not in query_upper:
                         validation_result["warnings"].append(
                             "CTE should end with SELECT statement"
                         )
-                elif query_upper.startswith(('EXPLAIN', 'DESCRIBE', 'DESC', 'SHOW')):
+                elif query_upper.startswith(("EXPLAIN", "DESCRIBE", "DESC", "SHOW")):
                     validation_result["query_type"] = "METADATA"
                 else:
                     dangerous_ops = [
-                        'DROP', 'DELETE', 'TRUNCATE', 'ALTER',
-                        'CREATE', 'INSERT', 'UPDATE', 'MERGE',
+                        "DROP",
+                        "DELETE",
+                        "TRUNCATE",
+                        "ALTER",
+                        "CREATE",
+                        "INSERT",
+                        "UPDATE",
+                        "MERGE",
                     ]
-                    detected_ops = [op for op in dangerous_ops if query_upper.startswith(op)]
+                    detected_ops = [
+                        op for op in dangerous_ops if query_upper.startswith(op)
+                    ]
                     if detected_ops:
-                        validation_result["error"] = (
-                            f"Destructive operations not allowed: {', '.join(detected_ops)}"
-                        )
+                        validation_result[
+                            "error"
+                        ] = f"Destructive operations not allowed: {', '.join(detected_ops)}"
                         validation_result["error_type"] = "forbidden_operation"
                         validation_result["suggestions"].append(
                             "Use SELECT queries for data retrieval only"
                         )
                         return validation_result
                     else:
-                        validation_result["error"] = (
-                            "Only SELECT, CTE, and metadata queries are allowed"
-                        )
+                        validation_result[
+                            "error"
+                        ] = "Only SELECT, CTE, and metadata queries are allowed"
                         validation_result["error_type"] = "query_type_error"
                         validation_result["suggestions"].append(
                             "Start your query with SELECT, WITH, EXPLAIN, or SHOW"
@@ -1056,7 +1170,7 @@ class DatabaseManager:
                 tables = set()
                 for pattern in table_patterns:
                     matches = re.findall(pattern, query_stripped, re.IGNORECASE)
-                    tables.update(match.strip('"\'`[]') for match in matches)
+                    tables.update(match.strip("\"'`[]") for match in matches)
 
                 validation_result["affected_tables"] = list(tables)
 
@@ -1102,7 +1216,7 @@ class DatabaseManager:
             return result_data
 
         # Apply safety limits
-        query_to_execute = sql_query.strip().rstrip(';')
+        query_to_execute = sql_query.strip().rstrip(";")
         query_upper = query_to_execute.upper()
 
         needs_limit = (
@@ -1116,7 +1230,9 @@ class DatabaseManager:
         if needs_limit:
             query_to_execute = f"{query_to_execute} LIMIT {limit}"
             limit_applied = True
-            warnings.append(f"Safety LIMIT {limit} applied to prevent large result sets")
+            warnings.append(
+                f"Safety LIMIT {limit} applied to prevent large result sets"
+            )
 
         # Delegate execution to driver
         result_data = self._driver.execute_sql_query(query_to_execute, limit)
@@ -1126,9 +1242,8 @@ class DatabaseManager:
         result_data["warnings"] = warnings + result_data["warnings"]
         if limit_applied:
             result_data["limit_applied"] = True
-            if (
-                result_data.get("row_count", 0) == limit
-                and result_data.get("limit_applied")
+            if result_data.get("row_count", 0) == limit and result_data.get(
+                "limit_applied"
             ):
                 result_data["warnings"].append(
                     f"Result set may be truncated at {limit} rows"
@@ -1155,7 +1270,7 @@ class DatabaseManager:
     def disconnect(self):
         """Close the database connection and clear stored parameters."""
         # Clear metadata cache
-        if hasattr(self, '_metadata_cache'):
+        if hasattr(self, "_metadata_cache"):
             self._metadata_cache.clear()
 
         # Disconnect driver

--- a/src/dremio_client.py
+++ b/src/dremio_client.py
@@ -3,7 +3,8 @@
 import asyncio
 import logging
 import time
-from typing import Dict, Any, List
+from typing import Any, Dict, List
+
 import aiohttp
 
 from .constants import QUERY_TIMEOUT
@@ -13,11 +14,13 @@ logger = logging.getLogger(__name__)
 
 class DremioAuthError(Exception):
     """Authentication error with Dremio."""
+
     pass
 
 
 class DremioQueryError(Exception):
     """Query execution error in Dremio."""
+
     pass
 
 
@@ -34,15 +37,22 @@ def _sanitize_sql_for_logging(sql: str, max_length: int = 200) -> str:
 
 class DremioClient:
     """Dremio REST API client."""
-    
-    def __init__(self, uri: str, username: str = None, password: str = None, token: str = None, pat: str = None):
-        self.uri = uri.rstrip('/')
+
+    def __init__(
+        self,
+        uri: str,
+        username: str = None,
+        password: str = None,
+        token: str = None,
+        pat: str = None,
+    ):
+        self.uri = uri.rstrip("/")
         self.username = username
         self.password = password
         self.token = token
         self.pat = pat  # Personal Access Token (preferred)
         self.session = None
-        
+
     async def __aenter__(self):
         self.session = aiohttp.ClientSession()
         if self.pat:
@@ -53,23 +63,23 @@ class DremioClient:
             # Fall back to username/password authentication
             await self._authenticate()
         return self
-        
+
     async def __aexit__(self, _exc_type, _exc_val, _exc_tb):
         if self.session:
             await self.session.close()
-    
+
     async def _authenticate(self):
         """Authenticate with username/password to get a token (following official Dremio examples)."""
         auth_data = {
             "userName": self.username,  # Official Dremio API uses 'userName' not 'username'
-            "password": self.password
+            "password": self.password,
         }
-        
+
         try:
             async with self.session.post(
                 f"{self.uri}/apiv2/login",
                 json=auth_data,
-                headers={"Content-Type": "application/json"}
+                headers={"Content-Type": "application/json"},
             ) as response:
                 if response.status == 200:
                     data = await response.json()
@@ -79,62 +89,70 @@ class DremioClient:
                     logger.info("Successfully authenticated with Dremio")
                 else:
                     error_text = await response.text()
-                    logger.error(f"Authentication failed: {response.status} - {error_text}")
+                    logger.error(
+                        f"Authentication failed: {response.status} - {error_text}"
+                    )
                     raise DremioAuthError(f"Authentication failed: {response.status}")
         except aiohttp.ClientError as e:
             logger.error(f"Network error during authentication: {e}")
             raise DremioAuthError(f"Network error: {e}")
-    
-    async def _make_request(self, method: str, endpoint: str, **kwargs) -> Dict[str, Any]:
+
+    async def _make_request(
+        self, method: str, endpoint: str, **kwargs
+    ) -> Dict[str, Any]:
         """Make authenticated request to Dremio API."""
         if not self.token:
             raise DremioAuthError("No authentication token available")
-            
+
         headers = {
-            "Authorization": f"Bearer {self.token}" if self.pat else f"_dremio{self.token}",
-            "Content-Type": "application/json"
+            "Authorization": f"Bearer {self.token}"
+            if self.pat
+            else f"_dremio{self.token}",
+            "Content-Type": "application/json",
         }
-        if 'headers' in kwargs:
-            headers.update(kwargs.pop('headers'))
-            
+        if "headers" in kwargs:
+            headers.update(kwargs.pop("headers"))
+
         url = f"{self.uri}{endpoint}"
         logger.debug(f"Making {method} request to {url}")
-        
+
         try:
-            async with self.session.request(method, url, headers=headers, **kwargs) as response:
+            async with self.session.request(
+                method, url, headers=headers, **kwargs
+            ) as response:
                 if response.status == 401:
                     raise DremioAuthError("Authentication token expired or invalid")
-                
-                if response.content_type == 'application/json':
+
+                if response.content_type == "application/json":
                     data = await response.json()
                 else:
                     data = {"text": await response.text()}
-                
+
                 if response.status >= 400:
-                    error_msg = data.get('errorMessage', f"HTTP {response.status}")
+                    error_msg = data.get("errorMessage", f"HTTP {response.status}")
                     raise DremioQueryError(f"API request failed: {error_msg}")
-                
+
                 return data
         except aiohttp.ClientError as e:
             logger.error(f"Network error during API request: {e}")
             raise DremioQueryError(f"Network error: {e}")
-    
+
     async def execute_query(self, sql: str, limit: int = 1000) -> Dict[str, Any]:
         """Execute SQL query and return results."""
         try:
             # Log the SQL query being executed
             logger.info(f"🔍 DREMIO SQL QUERY: {_sanitize_sql_for_logging(sql)}")
-            
+
             # Submit query
             query_data = {"sql": sql}
             job = await self._make_request("POST", "/api/v3/sql", json=query_data)
             job_id = job.get("id")
-            
+
             if not job_id:
                 raise DremioQueryError("No job ID returned from query submission")
-            
+
             logger.info(f"Submitted query with job ID: {job_id}")
-            
+
             # Poll for completion
             start_time = time.monotonic()
             while True:
@@ -146,55 +164,57 @@ class DremioClient:
                 elif state in ["FAILED", "CANCELED"]:
                     error = job_status.get("errorMessage", "Query failed")
                     raise DremioQueryError(f"Query {state.lower()}: {error}")
-                elif state in ["RUNNING", "STARTING", "PLANNING", "PENDING", "QUEUED", "METADATA_RETRIEVAL"]:
+                elif state in [
+                    "RUNNING",
+                    "STARTING",
+                    "PLANNING",
+                    "PENDING",
+                    "QUEUED",
+                    "METADATA_RETRIEVAL",
+                ]:
                     if time.monotonic() - start_time > QUERY_TIMEOUT:
-                        raise DremioQueryError(f"Query timed out after {QUERY_TIMEOUT}s")
+                        raise DremioQueryError(
+                            f"Query timed out after {QUERY_TIMEOUT}s"
+                        )
                     await asyncio.sleep(0.5)  # Poll every 500ms
                 else:
                     logger.warning(f"Unknown job state: {state}")
                     if time.monotonic() - start_time > QUERY_TIMEOUT:
-                        raise DremioQueryError(f"Query timed out after {QUERY_TIMEOUT}s")
+                        raise DremioQueryError(
+                            f"Query timed out after {QUERY_TIMEOUT}s"
+                        )
                     await asyncio.sleep(0.5)
-            
+
             # Get results
             row_count = job_status.get("rowCount", 0)
             if row_count == 0:
-                return {
-                    "success": True,
-                    "data": [],
-                    "row_count": 0,
-                    "columns": []
-                }
-            
+                return {"success": True, "data": [], "row_count": 0, "columns": []}
+
             # Fetch results with limit
             actual_limit = min(limit, row_count)
             results = await self._make_request(
-                "GET", 
+                "GET",
                 f"/api/v3/job/{job_id}/results",
-                params={"offset": 0, "limit": actual_limit}
+                params={"offset": 0, "limit": actual_limit},
             )
-            
+
             rows = results.get("rows", [])
             schema = results.get("schema", [])
             columns = [col.get("name") for col in schema]
-            
+
             return {
                 "success": True,
                 "data": rows,
                 "row_count": len(rows),
                 "total_rows": row_count,
                 "columns": columns,
-                "job_id": job_id
+                "job_id": job_id,
             }
-            
+
         except Exception as e:
             logger.error(f"Query execution failed: {e}")
-            return {
-                "success": False,
-                "error": str(e),
-                "error_type": type(e).__name__
-            }
-    
+            return {"success": False, "error": str(e), "error_type": type(e).__name__}
+
     async def get_catalogs(self) -> List[Dict[str, Any]]:
         """Get list of catalogs (schemas)."""
         try:
@@ -209,19 +229,21 @@ class DremioClient:
                     name = path[-1]  # Get the last element as the name
                 else:
                     name = path if isinstance(path, str) else ""
-                
-                result.append({
-                    "name": name,
-                    "path": path,
-                    "type": item.get("type", ""),
-                    "id": item.get("id", ""),
-                    "tag": item.get("tag", "")
-                })
+
+                result.append(
+                    {
+                        "name": name,
+                        "path": path,
+                        "type": item.get("type", ""),
+                        "id": item.get("id", ""),
+                        "tag": item.get("tag", ""),
+                    }
+                )
             return result
         except Exception as e:
             logger.error(f"Failed to get catalogs: {e}")
             return []
-    
+
     async def get_catalog_info(self, path: List[str]) -> Dict[str, Any]:
         """Get information about a catalog item."""
         try:
@@ -231,12 +253,14 @@ class DremioClient:
             else:
                 # If already a string, convert dots to slashes if present
                 catalog_path = str(path).replace(".", "/")
-            info = await self._make_request("GET", f"/api/v3/catalog/by-path/{catalog_path}")
+            info = await self._make_request(
+                "GET", f"/api/v3/catalog/by-path/{catalog_path}"
+            )
             return info
         except Exception as e:
             logger.error(f"Failed to get catalog info for {path}: {e}")
             return {}
-    
+
     async def test_connection(self) -> Dict[str, Any]:
         """Test the connection to Dremio."""
         try:
@@ -246,29 +270,36 @@ class DremioClient:
                 return {
                     "success": True,
                     "message": "Connection test successful",
-                    "server_info": "Dremio REST API"
+                    "server_info": "Dremio REST API",
                 }
             else:
                 return {
                     "success": False,
                     "error": "Connection test query failed",
-                    "details": result.get("error")
+                    "details": result.get("error"),
                 }
         except Exception as e:
             return {
                 "success": False,
                 "error": f"Connection test failed: {str(e)}",
-                "error_type": type(e).__name__
+                "error_type": type(e).__name__,
             }
 
 
-async def create_dremio_client(host: str = None, port: int = 9047, username: str = None, 
-                              password: str = None, token: str = None, pat: str = None,
-                              uri: str = None, ssl: bool = True) -> DremioClient:
+async def create_dremio_client(
+    host: str = None,
+    port: int = 9047,
+    username: str = None,
+    password: str = None,
+    token: str = None,
+    pat: str = None,
+    uri: str = None,
+    ssl: bool = True,
+) -> DremioClient:
     """Create and authenticate Dremio client.
-    
+
     Supports both new PAT-based authentication and legacy username/password.
-    
+
     Args:
         uri: Full Dremio API URI (preferred, overrides host/port/ssl)
         pat: Personal Access Token (preferred authentication method)
@@ -288,6 +319,8 @@ async def create_dremio_client(host: str = None, port: int = 9047, username: str
         final_uri = f"{protocol}://{host}:{port}"
     else:
         raise ValueError("Either 'uri' or 'host' must be provided")
-    
-    client = DremioClient(uri=final_uri, username=username, password=password, token=token, pat=pat)
+
+    client = DremioClient(
+        uri=final_uri, username=username, password=password, token=token, pat=pat
+    )
     return client

--- a/src/drivers/bigquery.py
+++ b/src/drivers/bigquery.py
@@ -3,26 +3,26 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import create_engine, text, MetaData, inspect
+from sqlalchemy import MetaData, create_engine, inspect, text
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import SQLAlchemyError, OperationalError, DatabaseError
+from sqlalchemy.exc import DatabaseError, OperationalError, SQLAlchemyError
 from sqlalchemy.pool import NullPool
 
 from ..constants import (
-    CONNECTION_TIMEOUT,
     BIGQUERY_SYSTEM_SCHEMAS,
-    MIN_SAMPLE_LIMIT,
-    MAX_SAMPLE_LIMIT,
+    CONNECTION_TIMEOUT,
     DEFAULT_SAMPLE_LIMIT,
-)
-from ..serialization import serialize_rows
-from ..security import (
-    SecureCredentialManager,
-    identifier_validator,
-    audit_log_security_event,
-    SecurityLevel,
+    MAX_SAMPLE_LIMIT,
+    MIN_SAMPLE_LIMIT,
 )
 from ..database_manager import ColumnInfo, TableInfo
+from ..security import (
+    SecureCredentialManager,
+    SecurityLevel,
+    audit_log_security_event,
+    identifier_validator,
+)
+from ..serialization import serialize_rows
 from .base import DatabaseDriver
 
 logger = logging.getLogger(__name__)
@@ -121,7 +121,9 @@ class BigQueryDriver(DatabaseDriver):
                 result = conn.execute(text("SELECT 1"))
                 result.fetchone()
 
-            logger.info(f"Connected to BigQuery project: {project_id}, dataset: {dataset or 'default'}")
+            logger.info(
+                f"Connected to BigQuery project: {project_id}, dataset: {dataset or 'default'}"
+            )
             return True
 
         except (SQLAlchemyError, OperationalError, DatabaseError) as e:
@@ -149,12 +151,14 @@ class BigQueryDriver(DatabaseDriver):
         """
         try:
             # Query INFORMATION_SCHEMA to get datasets
-            query = text(f"""
+            query = text(
+                f"""
                 SELECT schema_name
                 FROM `{self._project_id}`.INFORMATION_SCHEMA.SCHEMATA
                 WHERE schema_name NOT IN UNNEST({BIGQUERY_SYSTEM_SCHEMAS})
                 ORDER BY schema_name
-            """)
+            """
+            )
             with self.engine.connect() as conn:
                 result = conn.execute(query)
                 return [row[0] for row in result.fetchall()]
@@ -175,12 +179,14 @@ class BigQueryDriver(DatabaseDriver):
                 return []
 
             with self.engine.connect() as conn:
-                query = text(f"""
+                query = text(
+                    f"""
                     SELECT table_name
                     FROM `{self._project_id}.{dataset}`.INFORMATION_SCHEMA.TABLES
                     WHERE table_type = 'BASE TABLE'
                     ORDER BY table_name
-                """)
+                """
+                )
                 result = conn.execute(query)
                 return [row[0] for row in result.fetchall()]
         except SQLAlchemyError as e:
@@ -282,14 +288,17 @@ class BigQueryDriver(DatabaseDriver):
                         validation_result["suggestions"].append(
                             "Review BigQuery SQL syntax - it differs from standard SQL in some aspects"
                         )
-                    elif "permission" in error_msg.lower() or "denied" in error_msg.lower():
+                    elif (
+                        "permission" in error_msg.lower()
+                        or "denied" in error_msg.lower()
+                    ):
                         validation_result["suggestions"].append(
                             "Insufficient permissions to access the specified tables/datasets"
                         )
         except Exception as conn_error:
-            validation_result["error"] = (
-                f"Database connection error during validation: {conn_error}"
-            )
+            validation_result[
+                "error"
+            ] = f"Database connection error during validation: {conn_error}"
             validation_result["error_type"] = "connection_error"
 
         return validation_result

--- a/src/drivers/clickhouse.py
+++ b/src/drivers/clickhouse.py
@@ -4,20 +4,20 @@ import logging
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote_plus
 
-from sqlalchemy import create_engine, text, MetaData, inspect
+from sqlalchemy import MetaData, create_engine, inspect, text
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import SQLAlchemyError, OperationalError, DatabaseError
+from sqlalchemy.exc import DatabaseError, OperationalError, SQLAlchemyError
 from sqlalchemy.pool import QueuePool
 
 from ..constants import (
-    CONNECTION_TIMEOUT,
     CLICKHOUSE_SYSTEM_SCHEMAS,
-    MIN_SAMPLE_LIMIT,
-    MAX_SAMPLE_LIMIT,
+    CONNECTION_TIMEOUT,
     DEFAULT_SAMPLE_LIMIT,
+    MAX_SAMPLE_LIMIT,
+    MIN_SAMPLE_LIMIT,
 )
-from ..serialization import serialize_rows
 from ..database_manager import ColumnInfo, TableInfo
+from ..serialization import serialize_rows
 from .base import DatabaseDriver
 
 logger = logging.getLogger(__name__)
@@ -117,12 +117,14 @@ class ClickHouseDriver(DatabaseDriver):
 
     def get_schemas(self) -> List[str]:
         excluded_schemas = "', '".join(CLICKHOUSE_SYSTEM_SCHEMAS)
-        query = text(f"""
+        query = text(
+            f"""
             SELECT name
             FROM system.databases
             WHERE name NOT IN ('{excluded_schemas}')
             ORDER BY name
-        """)
+        """
+        )
         try:
             with self.engine.connect() as conn:
                 result = conn.execute(query)
@@ -135,24 +137,28 @@ class ClickHouseDriver(DatabaseDriver):
         try:
             with self.engine.connect() as conn:
                 if schema_name:
-                    query = text("""
+                    query = text(
+                        """
                         SELECT name
                         FROM system.tables
                         WHERE database = :schema_name
                           AND engine NOT IN ('View', 'MaterializedView')
                         ORDER BY name
-                    """)
+                    """
+                    )
                     result = conn.execute(query, {"schema_name": schema_name})
                 else:
                     # Use the connected database name
                     db_name = self._current_database or "default"
-                    query = text("""
+                    query = text(
+                        """
                         SELECT name
                         FROM system.tables
                         WHERE database = :db_name
                           AND engine NOT IN ('View', 'MaterializedView')
                         ORDER BY name
-                    """)
+                    """
+                    )
                     result = conn.execute(query, {"db_name": db_name})
                 return [row[0] for row in result.fetchall()]
         except SQLAlchemyError as e:
@@ -176,9 +182,7 @@ class ClickHouseDriver(DatabaseDriver):
 
                 if schema_name:
                     if not inspector.has_table(table_name, schema=schema_name):
-                        logger.error(
-                            f"Table {schema_name}.{table_name} not found"
-                        )
+                        logger.error(f"Table {schema_name}.{table_name} not found")
                         return None
                     table_columns = inspector.get_columns(
                         table_name, schema=schema_name
@@ -221,14 +225,11 @@ class ClickHouseDriver(DatabaseDriver):
                     is_fk = False
                     for fk in table_fks:
                         constrained_cols_upper = [
-                            c.upper()
-                            for c in fk.get("constrained_columns", [])
+                            c.upper() for c in fk.get("constrained_columns", [])
                         ]
                         if column_name.upper() in constrained_cols_upper:
                             is_fk = True
-                            fk_idx = constrained_cols_upper.index(
-                                column_name.upper()
-                            )
+                            fk_idx = constrained_cols_upper.index(column_name.upper())
                             fk_table = fk.get("referred_table")
                             referred_cols = fk.get("referred_columns", [])
                             fk_column = (
@@ -270,11 +271,13 @@ class ClickHouseDriver(DatabaseDriver):
                 table_comment = None
                 if schema_name:
                     try:
-                        ch_meta_query = text("""
+                        ch_meta_query = text(
+                            """
                             SELECT engine, sorting_key, total_rows
                             FROM system.tables
                             WHERE database = :db AND name = :tbl
-                        """)
+                        """
+                        )
                         ch_result = conn.execute(
                             ch_meta_query,
                             {"db": schema_name, "tbl": table_name},
@@ -337,9 +340,7 @@ class ClickHouseDriver(DatabaseDriver):
                 except Exception as explain_error:
                     error_msg = str(explain_error)
                     validation_result["database_error"] = error_msg
-                    validation_result["error"] = (
-                        f"ClickHouse syntax error: {error_msg}"
-                    )
+                    validation_result["error"] = f"ClickHouse syntax error: {error_msg}"
                     validation_result["error_type"] = "syntax_error"
 
                     if (
@@ -362,9 +363,9 @@ class ClickHouseDriver(DatabaseDriver):
                             "(ClickHouse is case-sensitive)"
                         )
         except Exception as conn_error:
-            validation_result["error"] = (
-                f"Database connection error during validation: {conn_error}"
-            )
+            validation_result[
+                "error"
+            ] = f"Database connection error during validation: {conn_error}"
             validation_result["error_type"] = "connection_error"
 
         return validation_result

--- a/src/drivers/databricks.py
+++ b/src/drivers/databricks.py
@@ -4,26 +4,26 @@ import logging
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote_plus
 
-from sqlalchemy import create_engine, text, MetaData, inspect
+from sqlalchemy import MetaData, create_engine, inspect, text
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import SQLAlchemyError, OperationalError, DatabaseError
+from sqlalchemy.exc import DatabaseError, OperationalError, SQLAlchemyError
 from sqlalchemy.pool import NullPool
 
 from ..constants import (
     CONNECTION_TIMEOUT,
     DATABRICKS_SYSTEM_SCHEMAS,
-    MIN_SAMPLE_LIMIT,
-    MAX_SAMPLE_LIMIT,
     DEFAULT_SAMPLE_LIMIT,
-)
-from ..serialization import serialize_rows
-from ..security import (
-    SecureCredentialManager,
-    identifier_validator,
-    audit_log_security_event,
-    SecurityLevel,
+    MAX_SAMPLE_LIMIT,
+    MIN_SAMPLE_LIMIT,
 )
 from ..database_manager import ColumnInfo, TableInfo
+from ..security import (
+    SecureCredentialManager,
+    SecurityLevel,
+    audit_log_security_event,
+    identifier_validator,
+)
+from ..serialization import serialize_rows
 from .base import DatabaseDriver
 
 logger = logging.getLogger(__name__)
@@ -170,20 +170,21 @@ class DatabricksDriver(DatabaseDriver):
         """
         try:
             # Query to get schemas in the current catalog
-            query = text("""
+            query = text(
+                """
                 SELECT schema_name
                 FROM information_schema.schemata
                 WHERE catalog_name = :catalog
                 ORDER BY schema_name
-            """)
+            """
+            )
             with self.engine.connect() as conn:
                 result = conn.execute(query, {"catalog": self._catalog})
                 schemas = [row[0] for row in result.fetchall()]
 
                 # Filter out system schemas
                 filtered_schemas = [
-                    s for s in schemas
-                    if s not in DATABRICKS_SYSTEM_SCHEMAS
+                    s for s in schemas if s not in DATABRICKS_SYSTEM_SCHEMAS
                 ]
                 return filtered_schemas
         except SQLAlchemyError as e:
@@ -193,10 +194,7 @@ class DatabricksDriver(DatabaseDriver):
                 with self.engine.connect() as conn:
                     result = conn.execute(text(f"SHOW SCHEMAS IN {self._catalog}"))
                     schemas = [row[0] for row in result.fetchall()]
-                    return [
-                        s for s in schemas
-                        if s not in DATABRICKS_SYSTEM_SCHEMAS
-                    ]
+                    return [s for s in schemas if s not in DATABRICKS_SYSTEM_SCHEMAS]
             except Exception as fallback_error:
                 logger.error(f"Fallback schema query also failed: {fallback_error}")
                 return []
@@ -210,17 +208,18 @@ class DatabricksDriver(DatabaseDriver):
                 return []
 
             with self.engine.connect() as conn:
-                query = text("""
+                query = text(
+                    """
                     SELECT table_name
                     FROM information_schema.tables
                     WHERE table_catalog = :catalog
                     AND table_schema = :schema
                     AND table_type = 'BASE TABLE'
                     ORDER BY table_name
-                """)
+                """
+                )
                 result = conn.execute(
-                    query,
-                    {"catalog": self._catalog, "schema": schema}
+                    query, {"catalog": self._catalog, "schema": schema}
                 )
                 return [row[0] for row in result.fetchall()]
         except SQLAlchemyError as e:
@@ -232,7 +231,9 @@ class DatabricksDriver(DatabaseDriver):
                     result = conn.execute(
                         text(f"SHOW TABLES IN {self._catalog}.{schema}")
                     )
-                    return [row[1] for row in result.fetchall()]  # Table name is in second column
+                    return [
+                        row[1] for row in result.fetchall()
+                    ]  # Table name is in second column
             except Exception as fallback_error:
                 logger.error(f"Fallback table query also failed: {fallback_error}")
                 return []
@@ -256,14 +257,18 @@ class DatabricksDriver(DatabaseDriver):
 
                 # Check if table exists
                 if not inspector.has_table(table_name, schema=schema):
-                    logger.error(f"Table {self._catalog}.{schema}.{table_name} not found")
+                    logger.error(
+                        f"Table {self._catalog}.{schema}.{table_name} not found"
+                    )
                     return None
 
                 table_columns = inspector.get_columns(table_name, schema=schema)
                 table_pk = inspector.get_pk_constraint(table_name, schema=schema)
                 table_fks = inspector.get_foreign_keys(table_name, schema=schema)
 
-                primary_keys = table_pk.get("constrained_columns", []) if table_pk else []
+                primary_keys = (
+                    table_pk.get("constrained_columns", []) if table_pk else []
+                )
                 primary_keys_upper = [pk.upper() for pk in primary_keys]
 
                 logger.info(
@@ -355,7 +360,10 @@ class DatabricksDriver(DatabaseDriver):
                     validation_result["error"] = f"Databricks syntax error: {error_msg}"
                     validation_result["error_type"] = "syntax_error"
 
-                    if "not found" in error_msg.lower() or "does not exist" in error_msg.lower():
+                    if (
+                        "not found" in error_msg.lower()
+                        or "does not exist" in error_msg.lower()
+                    ):
                         validation_result["suggestions"].append(
                             "Check table names - use three-part names (catalog.schema.table) in Unity Catalog"
                         )
@@ -363,14 +371,17 @@ class DatabricksDriver(DatabaseDriver):
                         validation_result["suggestions"].append(
                             "Review Databricks SQL syntax - it's based on Spark SQL"
                         )
-                    elif "permission" in error_msg.lower() or "denied" in error_msg.lower():
+                    elif (
+                        "permission" in error_msg.lower()
+                        or "denied" in error_msg.lower()
+                    ):
                         validation_result["suggestions"].append(
                             "Insufficient permissions to access the specified tables/catalogs"
                         )
         except Exception as conn_error:
-            validation_result["error"] = (
-                f"Database connection error during validation: {conn_error}"
-            )
+            validation_result[
+                "error"
+            ] = f"Database connection error during validation: {conn_error}"
             validation_result["error_type"] = "connection_error"
 
         return validation_result

--- a/src/drivers/dremio.py
+++ b/src/drivers/dremio.py
@@ -6,11 +6,11 @@ from typing import Any, Dict, List, Optional
 from ..async_utils import run_async
 from ..constants import (
     CONNECTION_TIMEOUT,
-    QUERY_TIMEOUT,
-    DREMIO_SYSTEM_SCHEMAS,
-    MIN_SAMPLE_LIMIT,
-    MAX_SAMPLE_LIMIT,
     DEFAULT_SAMPLE_LIMIT,
+    DREMIO_SYSTEM_SCHEMAS,
+    MAX_SAMPLE_LIMIT,
+    MIN_SAMPLE_LIMIT,
+    QUERY_TIMEOUT,
 )
 from ..database_manager import ColumnInfo, TableInfo
 from .base import DatabaseDriver
@@ -165,10 +165,9 @@ class DremioDriver(DatabaseDriver):
             return True
 
         except Exception as e:
-            logger.error(
-                f"\u274c Failed to connect to Dremio: {type(e).__name__}: {e}"
-            )
+            logger.error(f"\u274c Failed to connect to Dremio: {type(e).__name__}: {e}")
             import traceback
+
             logger.error(f"Full traceback: {traceback.format_exc()}")
             self._rest_connection = None
             return False
@@ -200,21 +199,14 @@ class DremioDriver(DatabaseDriver):
                             top_level = path[0]
                             full_path = ".".join(path)
 
-                            if (
-                                top_level
-                                and top_level not in DREMIO_SYSTEM_SCHEMAS
-                            ):
+                            if top_level and top_level not in DREMIO_SYSTEM_SCHEMAS:
                                 schemas.add(top_level)
 
-                            if (
-                                len(path) > 1
-                                and full_path not in DREMIO_SYSTEM_SCHEMAS
-                            ):
+                            if len(path) > 1 and full_path not in DREMIO_SYSTEM_SCHEMAS:
                                 schemas.add(full_path)
 
                             if (
-                                catalog_type
-                                in ("CONTAINER", "SPACE", "SOURCE")
+                                catalog_type in ("CONTAINER", "SPACE", "SOURCE")
                                 and catalog_id
                             ):
                                 await self._add_dremio_children_recursive(
@@ -233,9 +225,7 @@ class DremioDriver(DatabaseDriver):
                     schema_list = sorted(list(schemas))
 
                     if not schema_list:
-                        logger.info(
-                            "No catalogs found, using default Dremio spaces"
-                        )
+                        logger.info("No catalogs found, using default Dremio spaces")
                         schema_list = ["@dremio", "Samples"]
 
                     logger.info(
@@ -260,9 +250,7 @@ class DremioDriver(DatabaseDriver):
     ):
         """Recursively add children of Dremio containers to the schemas set."""
         if current_depth >= max_depth:
-            logger.debug(
-                f"Max depth {max_depth} reached for path: {'.'.join(path)}"
-            )
+            logger.debug(f"Max depth {max_depth} reached for path: {'.'.join(path)}")
             return
 
         try:
@@ -289,10 +277,7 @@ class DremioDriver(DatabaseDriver):
                     "HOME",
                 ):
                     full_child_path = ".".join(child_path)
-                    if (
-                        full_child_path
-                        and full_child_path not in DREMIO_SYSTEM_SCHEMAS
-                    ):
+                    if full_child_path and full_child_path not in DREMIO_SYSTEM_SCHEMAS:
                         schemas.add(full_child_path)
                         logger.debug(
                             f"Added child schema (type: {child_type}): "
@@ -314,9 +299,7 @@ class DremioDriver(DatabaseDriver):
                     )
 
         except Exception as e:
-            logger.warning(
-                f"Failed to get children for path {'.'.join(path)}: {e}"
-            )
+            logger.warning(f"Failed to get children for path {'.'.join(path)}: {e}")
 
     def get_tables(self, schema_name: Optional[str] = None) -> List[str]:
         async def fetch_tables():
@@ -325,14 +308,14 @@ class DremioDriver(DatabaseDriver):
                     if not schema_name:
                         query = (
                             "SELECT TABLE_SCHEMA, TABLE_NAME "
-                            "FROM INFORMATION_SCHEMA.\"TABLES\" "
+                            'FROM INFORMATION_SCHEMA."TABLES" '
                             "WHERE TABLE_TYPE = 'TABLE'"
                         )
                     else:
                         safe_schema = self._escape_sql_literal(schema_name)
                         query = (
                             f"SELECT TABLE_NAME "
-                            f"FROM INFORMATION_SCHEMA.\"TABLES\" "
+                            f'FROM INFORMATION_SCHEMA."TABLES" '
                             f"WHERE TABLE_SCHEMA = '{safe_schema}' "
                             f"AND TABLE_TYPE = 'TABLE'"
                         )
@@ -349,9 +332,7 @@ class DremioDriver(DatabaseDriver):
                                 table_name = row.get("TABLE_NAME", "")
                                 if schema and schema != "INFORMATION_SCHEMA":
                                     table_name = (
-                                        f"{schema}.{table_name}"
-                                        if table_name
-                                        else ""
+                                        f"{schema}.{table_name}" if table_name else ""
                                     )
                             if table_name:
                                 tables.append(table_name)
@@ -378,9 +359,7 @@ class DremioDriver(DatabaseDriver):
                     # If schema_name isn't provided but table_name is qualified
                     if not schema_name and "." in str(table_name):
                         parts = str(table_name).split(".")
-                        schema_name = (
-                            ".".join(parts[:-1]) if len(parts) > 1 else None
-                        )
+                        schema_name = ".".join(parts[:-1]) if len(parts) > 1 else None
                         table_name = parts[-1]
 
                     if schema_name:
@@ -437,9 +416,7 @@ class DremioDriver(DatabaseDriver):
                     )
 
             except Exception as e:
-                logger.error(
-                    f"Failed to analyze Dremio table {table_name}: {e}"
-                )
+                logger.error(f"Failed to analyze Dremio table {table_name}: {e}")
                 return None
 
         return run_async(fetch_table_info(), timeout=CONNECTION_TIMEOUT)
@@ -470,9 +447,7 @@ class DremioDriver(DatabaseDriver):
                     "error", "Unknown Dremio validation error"
                 )
                 validation_result["database_error"] = error_msg
-                validation_result["error"] = (
-                    f"Dremio syntax error: {error_msg}"
-                )
+                validation_result["error"] = f"Dremio syntax error: {error_msg}"
                 validation_result["error_type"] = "syntax_error"
 
                 if (
@@ -535,9 +510,7 @@ class DremioDriver(DatabaseDriver):
                 result_data["columns"] = query_result.get("columns", [])
                 result_data["row_count"] = query_result.get("row_count", 0)
 
-                total_rows = query_result.get(
-                    "total_rows", result_data["row_count"]
-                )
+                total_rows = query_result.get("total_rows", result_data["row_count"])
                 if total_rows > limit:
                     result_data["limit_applied"] = True
                     result_data["warnings"].append(
@@ -550,15 +523,11 @@ class DremioDriver(DatabaseDriver):
                     f"{execution_time:.2f}ms"
                 )
             else:
-                result_data["error"] = query_result.get(
-                    "error", "Unknown Dremio error"
-                )
+                result_data["error"] = query_result.get("error", "Unknown Dremio error")
                 result_data["error_type"] = query_result.get(
                     "error_type", "dremio_error"
                 )
-                logger.error(
-                    f"Dremio query failed: {result_data['error']}"
-                )
+                logger.error(f"Dremio query failed: {result_data['error']}")
 
         except Exception as e:
             result_data["error"] = f"Dremio execution error: {str(e)}"
@@ -588,9 +557,7 @@ class DremioDriver(DatabaseDriver):
                             f".{self._quote_dremio_identifier(table_name)}"
                         )
                     else:
-                        full_table_name = self._quote_dremio_identifier(
-                            table_name
-                        )
+                        full_table_name = self._quote_dremio_identifier(table_name)
 
                     query = f"SELECT * FROM {full_table_name} LIMIT {limit}"
                     result = await client.execute_query(query, limit)
@@ -608,12 +575,8 @@ class DremioDriver(DatabaseDriver):
                         )
 
             except Exception as e:
-                logger.error(
-                    f"Error sampling Dremio table {table_name}: {e}"
-                )
-                raise RuntimeError(
-                    f"Error sampling Dremio table: {str(e)}"
-                )
+                logger.error(f"Error sampling Dremio table {table_name}: {e}")
+                raise RuntimeError(f"Error sampling Dremio table: {str(e)}")
 
         return run_async(fetch_sample(), timeout=CONNECTION_TIMEOUT)
 

--- a/src/drivers/duckdb.py
+++ b/src/drivers/duckdb.py
@@ -3,26 +3,26 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import create_engine, text, MetaData, inspect
+from sqlalchemy import MetaData, create_engine, inspect, text
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import SQLAlchemyError, OperationalError, DatabaseError
+from sqlalchemy.exc import DatabaseError, OperationalError, SQLAlchemyError
 from sqlalchemy.pool import NullPool, StaticPool
 
 from ..constants import (
     CONNECTION_TIMEOUT,
-    DUCKDB_SYSTEM_SCHEMAS,
-    MIN_SAMPLE_LIMIT,
-    MAX_SAMPLE_LIMIT,
     DEFAULT_SAMPLE_LIMIT,
-)
-from ..serialization import serialize_rows
-from ..security import (
-    SecureCredentialManager,
-    identifier_validator,
-    audit_log_security_event,
-    SecurityLevel,
+    DUCKDB_SYSTEM_SCHEMAS,
+    MAX_SAMPLE_LIMIT,
+    MIN_SAMPLE_LIMIT,
 )
 from ..database_manager import ColumnInfo, TableInfo
+from ..security import (
+    SecureCredentialManager,
+    SecurityLevel,
+    audit_log_security_event,
+    identifier_validator,
+)
+from ..serialization import serialize_rows
 from .base import DatabaseDriver
 
 logger = logging.getLogger(__name__)
@@ -74,7 +74,9 @@ class DuckDBDriver(DatabaseDriver):
             if self._is_motherduck:
                 # MotherDuck connection
                 if motherduck_token:
-                    connection_string = f"duckdb:///md:?motherduck_token={motherduck_token}"
+                    connection_string = (
+                        f"duckdb:///md:?motherduck_token={motherduck_token}"
+                    )
                 else:
                     # Try to use default MotherDuck token from environment
                     connection_string = "duckdb:///md:"
@@ -87,7 +89,9 @@ class DuckDBDriver(DatabaseDriver):
                             {"identifier": database_name[:50]},
                             SecurityLevel.MEDIUM,
                         )
-                        logger.error(f"Invalid MotherDuck database name: {database_name}")
+                        logger.error(
+                            f"Invalid MotherDuck database name: {database_name}"
+                        )
                         return False
             else:
                 # Local DuckDB connection
@@ -160,36 +164,40 @@ class DuckDBDriver(DatabaseDriver):
         """
         try:
             excluded_schemas = "', '".join(DUCKDB_SYSTEM_SCHEMAS)
-            query = text(f"""
+            query = text(
+                f"""
                 SELECT schema_name
                 FROM information_schema.schemata
                 WHERE schema_name NOT IN ('{excluded_schemas}')
                 ORDER BY schema_name
-            """)
+            """
+            )
             with self.engine.connect() as conn:
                 result = conn.execute(query)
                 schemas = [row[0] for row in result.fetchall()]
                 # Ensure 'main' is included if it exists
                 if not schemas:
-                    schemas = ['main']
+                    schemas = ["main"]
                 return schemas
         except SQLAlchemyError as e:
             logger.error(f"Failed to get DuckDB schemas: {e}")
-            return ['main']  # Return default schema on error
+            return ["main"]  # Return default schema on error
 
     def get_tables(self, schema_name: Optional[str] = None) -> List[str]:
         """Get tables in a schema."""
         try:
-            schema = schema_name or 'main'
+            schema = schema_name or "main"
 
             with self.engine.connect() as conn:
-                query = text("""
+                query = text(
+                    """
                     SELECT table_name
                     FROM information_schema.tables
                     WHERE table_schema = :schema_name
                     AND table_type = 'BASE TABLE'
                     ORDER BY table_name
-                """)
+                """
+                )
                 result = conn.execute(query, {"schema_name": schema})
                 return [row[0] for row in result.fetchall()]
         except SQLAlchemyError as e:
@@ -201,7 +209,7 @@ class DuckDBDriver(DatabaseDriver):
     ) -> Optional[TableInfo]:
         """Analyze a DuckDB table and return its metadata."""
         try:
-            schema = schema_name or 'main'
+            schema = schema_name or "main"
 
             with self.engine.connect():
                 inspector = inspect(self.engine)
@@ -215,7 +223,9 @@ class DuckDBDriver(DatabaseDriver):
                 table_pk = inspector.get_pk_constraint(table_name, schema=schema)
                 table_fks = inspector.get_foreign_keys(table_name, schema=schema)
 
-                primary_keys = table_pk.get("constrained_columns", []) if table_pk else []
+                primary_keys = (
+                    table_pk.get("constrained_columns", []) if table_pk else []
+                )
                 primary_keys_upper = [pk.upper() for pk in primary_keys]
 
                 logger.info(
@@ -316,9 +326,9 @@ class DuckDBDriver(DatabaseDriver):
                             "Review DuckDB SQL syntax - check for missing commas, parentheses, or keywords"
                         )
         except Exception as conn_error:
-            validation_result["error"] = (
-                f"Database connection error during validation: {conn_error}"
-            )
+            validation_result[
+                "error"
+            ] = f"Database connection error during validation: {conn_error}"
             validation_result["error_type"] = "connection_error"
 
         return validation_result
@@ -408,7 +418,7 @@ class DuckDBDriver(DatabaseDriver):
             logger.warning(f"Sample limit capped at {MAX_SAMPLE_LIMIT}")
 
         try:
-            schema = schema_name or 'main'
+            schema = schema_name or "main"
 
             with self.engine.connect() as conn:
                 full_table_name = f'"{schema}"."{table_name}"'
@@ -416,7 +426,9 @@ class DuckDBDriver(DatabaseDriver):
                 query_str = f"SELECT * FROM {full_table_name} LIMIT :limit"
                 params = {"limit": limit}
                 db_type_str = "MOTHERDUCK" if self._is_motherduck else "DUCKDB"
-                logger.info(f"🔍 {db_type_str} SQL QUERY: {query_str} | PARAMS: {params}")
+                logger.info(
+                    f"🔍 {db_type_str} SQL QUERY: {query_str} | PARAMS: {params}"
+                )
                 result = conn.execute(text(query_str), params)
                 columns = list(result.keys())
                 return serialize_rows(result.fetchall(), columns)

--- a/src/drivers/mysql.py
+++ b/src/drivers/mysql.py
@@ -8,26 +8,26 @@ import logging
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote_plus
 
-from sqlalchemy import create_engine, text, MetaData, inspect
+from sqlalchemy import MetaData, create_engine, inspect, text
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import SQLAlchemyError, OperationalError, DatabaseError
+from sqlalchemy.exc import DatabaseError, OperationalError, SQLAlchemyError
 from sqlalchemy.pool import QueuePool
 
 from ..constants import (
     CONNECTION_TIMEOUT,
-    MYSQL_SYSTEM_SCHEMAS,
-    MIN_SAMPLE_LIMIT,
-    MAX_SAMPLE_LIMIT,
     DEFAULT_SAMPLE_LIMIT,
-)
-from ..serialization import serialize_rows
-from ..security import (
-    SecureCredentialManager,
-    identifier_validator,
-    audit_log_security_event,
-    SecurityLevel,
+    MAX_SAMPLE_LIMIT,
+    MIN_SAMPLE_LIMIT,
+    MYSQL_SYSTEM_SCHEMAS,
 )
 from ..database_manager import ColumnInfo, TableInfo
+from ..security import (
+    SecureCredentialManager,
+    SecurityLevel,
+    audit_log_security_event,
+    identifier_validator,
+)
+from ..serialization import serialize_rows
 from .base import DatabaseDriver
 
 logger = logging.getLogger(__name__)
@@ -79,9 +79,7 @@ class MySQLDriver(DatabaseDriver):
 
             safe_username = quote_plus(username)
             safe_password = quote_plus(password)
-            connection_string = (
-                f"mysql+pymysql://{safe_username}:{safe_password}@{host}:{port}/{database}?charset={charset}"
-            )
+            connection_string = f"mysql+pymysql://{safe_username}:{safe_password}@{host}:{port}/{database}?charset={charset}"
 
             self.engine = create_engine(
                 connection_string,
@@ -137,12 +135,14 @@ class MySQLDriver(DatabaseDriver):
 
     def get_schemas(self) -> List[str]:
         excluded_schemas = "', '".join(MYSQL_SYSTEM_SCHEMAS)
-        query = text(f"""
+        query = text(
+            f"""
             SELECT SCHEMA_NAME
             FROM information_schema.SCHEMATA
             WHERE SCHEMA_NAME NOT IN ('{excluded_schemas}')
             ORDER BY SCHEMA_NAME
-        """)
+        """
+        )
         try:
             with self.engine.connect() as conn:
                 result = conn.execute(query)
@@ -155,21 +155,25 @@ class MySQLDriver(DatabaseDriver):
         try:
             with self.engine.connect() as conn:
                 if schema_name:
-                    query = text("""
+                    query = text(
+                        """
                         SELECT TABLE_NAME
                         FROM information_schema.TABLES
                         WHERE TABLE_SCHEMA = :schema_name
                         AND TABLE_TYPE = 'BASE TABLE'
                         ORDER BY TABLE_NAME
-                    """)
+                    """
+                    )
                     result = conn.execute(query, {"schema_name": schema_name})
                 else:
-                    query = text("""
+                    query = text(
+                        """
                         SELECT TABLE_NAME
                         FROM information_schema.TABLES
                         WHERE TABLE_TYPE = 'BASE TABLE'
                         ORDER BY TABLE_NAME
-                    """)
+                    """
+                    )
                     result = conn.execute(query)
                 return [row[0] for row in result.fetchall()]
         except SQLAlchemyError as e:
@@ -187,9 +191,15 @@ class MySQLDriver(DatabaseDriver):
                     if not inspector.has_table(table_name, schema=schema_name):
                         logger.error(f"Table {schema_name}.{table_name} not found")
                         return None
-                    table_columns = inspector.get_columns(table_name, schema=schema_name)
-                    table_pk = inspector.get_pk_constraint(table_name, schema=schema_name)
-                    table_fks = inspector.get_foreign_keys(table_name, schema=schema_name)
+                    table_columns = inspector.get_columns(
+                        table_name, schema=schema_name
+                    )
+                    table_pk = inspector.get_pk_constraint(
+                        table_name, schema=schema_name
+                    )
+                    table_fks = inspector.get_foreign_keys(
+                        table_name, schema=schema_name
+                    )
                 else:
                     if not inspector.has_table(table_name):
                         logger.error(f"Table {table_name} not found")
@@ -198,7 +208,9 @@ class MySQLDriver(DatabaseDriver):
                     table_pk = inspector.get_pk_constraint(table_name)
                     table_fks = inspector.get_foreign_keys(table_name)
 
-                primary_keys = table_pk.get("constrained_columns", []) if table_pk else []
+                primary_keys = (
+                    table_pk.get("constrained_columns", []) if table_pk else []
+                )
                 primary_keys_upper = [pk.upper() for pk in primary_keys]
 
                 logger.info(
@@ -312,9 +324,9 @@ class MySQLDriver(DatabaseDriver):
                             "Insufficient permissions to access the specified tables"
                         )
         except Exception as conn_error:
-            validation_result["error"] = (
-                f"Database connection error during validation: {conn_error}"
-            )
+            validation_result[
+                "error"
+            ] = f"Database connection error during validation: {conn_error}"
             validation_result["error_type"] = "connection_error"
 
         return validation_result
@@ -412,7 +424,9 @@ class MySQLDriver(DatabaseDriver):
 
                 query_str = f"SELECT * FROM {full_table_name} LIMIT :limit"
                 params = {"limit": limit}
-                logger.info(f"🐬 {self.db_type.upper()} SQL QUERY: {query_str} | PARAMS: {params}")
+                logger.info(
+                    f"🐬 {self.db_type.upper()} SQL QUERY: {query_str} | PARAMS: {params}"
+                )
                 result = conn.execute(text(query_str), params)
                 columns = list(result.keys())
                 return serialize_rows(result.fetchall(), columns)

--- a/src/drivers/postgresql.py
+++ b/src/drivers/postgresql.py
@@ -4,26 +4,26 @@ import logging
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote_plus
 
-from sqlalchemy import create_engine, text, MetaData, inspect
+from sqlalchemy import MetaData, create_engine, inspect, text
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import SQLAlchemyError, OperationalError, DatabaseError
+from sqlalchemy.exc import DatabaseError, OperationalError, SQLAlchemyError
 from sqlalchemy.pool import QueuePool
 
 from ..constants import (
     CONNECTION_TIMEOUT,
-    POSTGRES_SYSTEM_SCHEMAS,
-    MIN_SAMPLE_LIMIT,
-    MAX_SAMPLE_LIMIT,
     DEFAULT_SAMPLE_LIMIT,
-)
-from ..serialization import serialize_rows
-from ..security import (
-    SecureCredentialManager,
-    identifier_validator,
-    audit_log_security_event,
-    SecurityLevel,
+    MAX_SAMPLE_LIMIT,
+    MIN_SAMPLE_LIMIT,
+    POSTGRES_SYSTEM_SCHEMAS,
 )
 from ..database_manager import ColumnInfo, TableInfo
+from ..security import (
+    SecureCredentialManager,
+    SecurityLevel,
+    audit_log_security_event,
+    identifier_validator,
+)
+from ..serialization import serialize_rows
 from .base import DatabaseDriver
 
 logger = logging.getLogger(__name__)
@@ -108,7 +108,9 @@ class PostgreSQLDriver(DatabaseDriver):
                 result = conn.execute(text("SELECT 1"))
                 result.fetchone()
 
-            logger.info(f"Connected to PostgreSQL database: {database} at {host}:{port}")
+            logger.info(
+                f"Connected to PostgreSQL database: {database} at {host}:{port}"
+            )
             return True
 
         except (SQLAlchemyError, OperationalError, DatabaseError) as e:
@@ -131,14 +133,16 @@ class PostgreSQLDriver(DatabaseDriver):
 
     def get_schemas(self) -> List[str]:
         excluded_schemas = "', '".join(POSTGRES_SYSTEM_SCHEMAS)
-        query = text(f"""
+        query = text(
+            f"""
             SELECT schema_name
             FROM information_schema.schemata
             WHERE schema_name NOT IN ('{excluded_schemas}')
               AND schema_name NOT LIKE 'pg_temp_%'
               AND schema_name NOT LIKE 'pg_toast_temp_%'
             ORDER BY schema_name
-        """)
+        """
+        )
         try:
             with self.engine.connect() as conn:
                 result = conn.execute(query)
@@ -151,21 +155,25 @@ class PostgreSQLDriver(DatabaseDriver):
         try:
             with self.engine.connect() as conn:
                 if schema_name:
-                    query = text("""
+                    query = text(
+                        """
                         SELECT table_name
                         FROM information_schema.tables
                         WHERE table_schema = :schema_name
                         AND table_type = 'BASE TABLE'
                         ORDER BY table_name
-                    """)
+                    """
+                    )
                     result = conn.execute(query, {"schema_name": schema_name})
                 else:
-                    query = text("""
+                    query = text(
+                        """
                         SELECT table_name
                         FROM information_schema.tables
                         WHERE table_type = 'BASE TABLE'
                         ORDER BY table_name
-                    """)
+                    """
+                    )
                     result = conn.execute(query)
                 return [row[0] for row in result.fetchall()]
         except SQLAlchemyError as e:
@@ -183,9 +191,15 @@ class PostgreSQLDriver(DatabaseDriver):
                     if not inspector.has_table(table_name, schema=schema_name):
                         logger.error(f"Table {schema_name}.{table_name} not found")
                         return None
-                    table_columns = inspector.get_columns(table_name, schema=schema_name)
-                    table_pk = inspector.get_pk_constraint(table_name, schema=schema_name)
-                    table_fks = inspector.get_foreign_keys(table_name, schema=schema_name)
+                    table_columns = inspector.get_columns(
+                        table_name, schema=schema_name
+                    )
+                    table_pk = inspector.get_pk_constraint(
+                        table_name, schema=schema_name
+                    )
+                    table_fks = inspector.get_foreign_keys(
+                        table_name, schema=schema_name
+                    )
                 else:
                     if not inspector.has_table(table_name):
                         logger.error(f"Table {table_name} not found")
@@ -194,7 +208,9 @@ class PostgreSQLDriver(DatabaseDriver):
                     table_pk = inspector.get_pk_constraint(table_name)
                     table_fks = inspector.get_foreign_keys(table_name)
 
-                primary_keys = table_pk.get("constrained_columns", []) if table_pk else []
+                primary_keys = (
+                    table_pk.get("constrained_columns", []) if table_pk else []
+                )
                 primary_keys_upper = [pk.upper() for pk in primary_keys]
 
                 logger.info(
@@ -310,9 +326,9 @@ class PostgreSQLDriver(DatabaseDriver):
                             "Insufficient permissions to access the specified tables"
                         )
         except Exception as conn_error:
-            validation_result["error"] = (
-                f"Database connection error during validation: {conn_error}"
-            )
+            validation_result[
+                "error"
+            ] = f"Database connection error during validation: {conn_error}"
             validation_result["error_type"] = "connection_error"
 
         return validation_result
@@ -409,7 +425,9 @@ class PostgreSQLDriver(DatabaseDriver):
 
                 query_str = f"SELECT * FROM {full_table_name} LIMIT :limit"
                 params = {"limit": limit}
-                logger.info(f"\U0001f50d {self.db_type.upper()} SQL QUERY: {query_str} | PARAMS: {params}")
+                logger.info(
+                    f"\U0001f50d {self.db_type.upper()} SQL QUERY: {query_str} | PARAMS: {params}"
+                )
                 result = conn.execute(text(query_str), params)
                 columns = list(result.keys())
                 return serialize_rows(result.fetchall(), columns)

--- a/src/drivers/snowflake.py
+++ b/src/drivers/snowflake.py
@@ -4,20 +4,20 @@ import logging
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote_plus
 
-from sqlalchemy import create_engine, text, MetaData, inspect
+from sqlalchemy import MetaData, create_engine, inspect, text
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import SQLAlchemyError, OperationalError, DatabaseError
+from sqlalchemy.exc import DatabaseError, OperationalError, SQLAlchemyError
 from sqlalchemy.pool import QueuePool
 
 from ..constants import (
     CONNECTION_TIMEOUT,
-    SNOWFLAKE_SYSTEM_SCHEMAS,
-    MIN_SAMPLE_LIMIT,
-    MAX_SAMPLE_LIMIT,
     DEFAULT_SAMPLE_LIMIT,
+    MAX_SAMPLE_LIMIT,
+    MIN_SAMPLE_LIMIT,
+    SNOWFLAKE_SYSTEM_SCHEMAS,
 )
-from ..serialization import serialize_rows
 from ..database_manager import ColumnInfo, TableInfo
+from ..serialization import serialize_rows
 from .base import DatabaseDriver
 
 logger = logging.getLogger(__name__)
@@ -114,12 +114,14 @@ class SnowflakeDriver(DatabaseDriver):
 
     def get_schemas(self) -> List[str]:
         excluded_schemas = "', '".join(SNOWFLAKE_SYSTEM_SCHEMAS)
-        query = text(f"""
+        query = text(
+            f"""
             SELECT schema_name
             FROM information_schema.schemata
             WHERE schema_name NOT IN ('{excluded_schemas}')
             ORDER BY schema_name
-        """)
+        """
+        )
         try:
             with self.engine.connect() as conn:
                 result = conn.execute(query)
@@ -132,21 +134,25 @@ class SnowflakeDriver(DatabaseDriver):
         try:
             with self.engine.connect() as conn:
                 if schema_name:
-                    query = text("""
+                    query = text(
+                        """
                         SELECT table_name
                         FROM information_schema.tables
                         WHERE table_schema = :schema_name
                         AND table_type = 'BASE TABLE'
                         ORDER BY table_name
-                    """)
+                    """
+                    )
                     result = conn.execute(query, {"schema_name": schema_name})
                 else:
-                    query = text("""
+                    query = text(
+                        """
                         SELECT table_name
                         FROM information_schema.tables
                         WHERE table_type = 'BASE TABLE'
                         ORDER BY table_name
-                    """)
+                    """
+                    )
                     result = conn.execute(query)
                 return [row[0] for row in result.fetchall()]
         except SQLAlchemyError as e:
@@ -224,9 +230,7 @@ class SnowflakeDriver(DatabaseDriver):
                 fk_by_table: Dict[str, List[Dict]] = {}
                 fk_success = False
                 try:
-                    fk_query = text(
-                        f"SHOW IMPORTED KEYS IN SCHEMA {full_schema_path}"
-                    )
+                    fk_query = text(f"SHOW IMPORTED KEYS IN SCHEMA {full_schema_path}")
                     log_sql(str(fk_query))
                     result = conn.execute(fk_query)
                     for row in result.fetchall():
@@ -265,7 +269,8 @@ class SnowflakeDriver(DatabaseDriver):
                 cols_by_table: Dict[str, List[Dict]] = {}
                 cols_success = False
                 try:
-                    cols_query = text("""
+                    cols_query = text(
+                        """
                         SELECT table_name, column_name, data_type,
                                character_maximum_length, numeric_precision,
                                numeric_scale, is_nullable, column_default,
@@ -273,20 +278,17 @@ class SnowflakeDriver(DatabaseDriver):
                         FROM information_schema.columns
                         WHERE table_schema = :schema_name
                         ORDER BY table_name, ordinal_position
-                    """)
-                    log_sql(str(cols_query))
-                    result = conn.execute(
-                        cols_query, {"schema_name": schema_name}
+                    """
                     )
+                    log_sql(str(cols_query))
+                    result = conn.execute(cols_query, {"schema_name": schema_name})
                     for row in result.fetchall():
                         row_dict = (
                             row._asdict()
                             if hasattr(row, "_asdict")
                             else dict(row._mapping)
                         )
-                        table = row_dict.get("table_name") or row_dict.get(
-                            "TABLE_NAME"
-                        )
+                        table = row_dict.get("table_name") or row_dict.get("TABLE_NAME")
                         if table:
                             cols_by_table.setdefault(table, []).append(
                                 {
@@ -305,9 +307,7 @@ class SnowflakeDriver(DatabaseDriver):
                                     or row_dict.get("COMMENT"),
                                 }
                             )
-                    logger.info(
-                        f"Prefetched columns for {len(cols_by_table)} tables"
-                    )
+                    logger.info(f"Prefetched columns for {len(cols_by_table)} tables")
                     cols_success = True
                 except Exception as e:
                     logger.warning(f"Failed to prefetch columns: {e}")
@@ -319,8 +319,11 @@ class SnowflakeDriver(DatabaseDriver):
             logger.error(f"Failed to prefetch schema metadata: {e}")
 
     def analyze_table(
-        self, table_name: str, schema_name: Optional[str] = None,
-        cache_get: callable = None, log_sql: callable = None,
+        self,
+        table_name: str,
+        schema_name: Optional[str] = None,
+        cache_get: callable = None,
+        log_sql: callable = None,
     ) -> Optional[TableInfo]:
         """Analyze a Snowflake table.
 
@@ -345,9 +348,9 @@ class SnowflakeDriver(DatabaseDriver):
                     cached_fks = cache_get(fk_cache_key)
 
                     if cached_cols is not None:
-                        table_columns = cached_cols.get(
-                            table_name
-                        ) or cached_cols.get(table_name.upper())
+                        table_columns = cached_cols.get(table_name) or cached_cols.get(
+                            table_name.upper()
+                        )
                         if table_columns:
                             logger.debug(
                                 f"Using cached columns for {table_name}: "
@@ -360,9 +363,9 @@ class SnowflakeDriver(DatabaseDriver):
                             return None
 
                     if cached_pks is not None:
-                        primary_keys = cached_pks.get(
-                            table_name, []
-                        ) or cached_pks.get(table_name.upper(), [])
+                        primary_keys = cached_pks.get(table_name, []) or cached_pks.get(
+                            table_name.upper(), []
+                        )
                         logger.debug(
                             f"Using cached PKs for {table_name}: {primary_keys}"
                         )
@@ -371,15 +374,13 @@ class SnowflakeDriver(DatabaseDriver):
                             table_name, schema=schema_name
                         )
                         primary_keys = (
-                            table_pk.get("constrained_columns", [])
-                            if table_pk
-                            else []
+                            table_pk.get("constrained_columns", []) if table_pk else []
                         )
 
                     if cached_fks is not None:
-                        table_fks = cached_fks.get(
-                            table_name, []
-                        ) or cached_fks.get(table_name.upper(), [])
+                        table_fks = cached_fks.get(table_name, []) or cached_fks.get(
+                            table_name.upper(), []
+                        )
                         logger.debug(
                             f"Using cached FKs for {table_name}: "
                             f"{len(table_fks)} constraints"
@@ -391,12 +392,8 @@ class SnowflakeDriver(DatabaseDriver):
                 else:
                     # No cache - use inspector
                     if schema_name:
-                        if not inspector.has_table(
-                            table_name, schema=schema_name
-                        ):
-                            logger.error(
-                                f"Table {schema_name}.{table_name} not found"
-                            )
+                        if not inspector.has_table(table_name, schema=schema_name):
+                            logger.error(f"Table {schema_name}.{table_name} not found")
                             return None
                         table_columns = inspector.get_columns(
                             table_name, schema=schema_name
@@ -415,22 +412,22 @@ class SnowflakeDriver(DatabaseDriver):
                         table_pk = inspector.get_pk_constraint(table_name)
                         table_fks = inspector.get_foreign_keys(table_name)
                     primary_keys = (
-                        table_pk.get("constrained_columns", [])
-                        if table_pk
-                        else []
+                        table_pk.get("constrained_columns", []) if table_pk else []
                     )
 
                 # Fallback: if columns not from cache, fetch with query
                 if table_columns is None and schema_name:
                     try:
-                        cols_query = text("""
+                        cols_query = text(
+                            """
                             SELECT column_name, data_type, is_nullable,
                                    column_default, comment
                             FROM information_schema.columns
                             WHERE table_schema = :schema_name
                               AND table_name = :table_name
                             ORDER BY ordinal_position
-                        """)
+                        """
+                        )
                         if log_sql:
                             log_sql(str(cols_query))
                         result = conn.execute(
@@ -442,9 +439,7 @@ class SnowflakeDriver(DatabaseDriver):
                         )
                         rows = result.fetchall()
                         if not rows:
-                            logger.error(
-                                f"Table {schema_name}.{table_name} not found"
-                            )
+                            logger.error(f"Table {schema_name}.{table_name} not found")
                             return None
                         table_columns = []
                         for row in rows:
@@ -481,12 +476,8 @@ class SnowflakeDriver(DatabaseDriver):
 
                 if table_columns is None:
                     if schema_name:
-                        if not inspector.has_table(
-                            table_name, schema=schema_name
-                        ):
-                            logger.error(
-                                f"Table {schema_name}.{table_name} not found"
-                            )
+                        if not inspector.has_table(table_name, schema=schema_name):
+                            logger.error(f"Table {schema_name}.{table_name} not found")
                             return None
                         table_columns = inspector.get_columns(
                             table_name, schema=schema_name
@@ -519,14 +510,11 @@ class SnowflakeDriver(DatabaseDriver):
                     is_fk = False
                     for fk in table_fks:
                         constrained_cols_upper = [
-                            c.upper()
-                            for c in fk.get("constrained_columns", [])
+                            c.upper() for c in fk.get("constrained_columns", [])
                         ]
                         if column_name.upper() in constrained_cols_upper:
                             is_fk = True
-                            fk_idx = constrained_cols_upper.index(
-                                column_name.upper()
-                            )
+                            fk_idx = constrained_cols_upper.index(column_name.upper())
                             fk_table = fk.get("referred_table")
                             referred_cols = fk.get("referred_columns", [])
                             fk_column = (
@@ -595,9 +583,7 @@ class SnowflakeDriver(DatabaseDriver):
                 except Exception as explain_error:
                     error_msg = str(explain_error)
                     validation_result["database_error"] = error_msg
-                    validation_result["error"] = (
-                        f"Snowflake syntax error: {error_msg}"
-                    )
+                    validation_result["error"] = f"Snowflake syntax error: {error_msg}"
                     validation_result["error_type"] = "syntax_error"
 
                     if "does not exist" in error_msg.lower():
@@ -615,9 +601,9 @@ class SnowflakeDriver(DatabaseDriver):
                             "double quotes for case-sensitive names"
                         )
         except Exception as conn_error:
-            validation_result["error"] = (
-                f"Database connection error during validation: {conn_error}"
-            )
+            validation_result[
+                "error"
+            ] = f"Database connection error during validation: {conn_error}"
             validation_result["error_type"] = "connection_error"
 
         return validation_result

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -5,11 +5,12 @@ that replace ad-hoc string-based error_type fields.
 """
 
 from enum import Enum
-from typing import Optional, List
+from typing import List, Optional
 
 
 class ErrorType(str, Enum):
     """Enumeration of all error types for consistent error reporting."""
+
     VALIDATION = "validation_error"
     PARAMETER = "parameter_error"
     CONNECTION = "connection_error"
@@ -29,8 +30,12 @@ class OrionBeltError(Exception):
 
     error_type: ErrorType = ErrorType.INTERNAL
 
-    def __init__(self, message: str, details: Optional[str] = None,
-                 suggestions: Optional[List[str]] = None):
+    def __init__(
+        self,
+        message: str,
+        details: Optional[str] = None,
+        suggestions: Optional[List[str]] = None,
+    ):
         self.message = message
         self.details = details
         self.suggestions = suggestions or []
@@ -52,34 +57,41 @@ class OrionBeltError(Exception):
 
 class ConnectionError(OrionBeltError):
     """Database connection failures."""
+
     error_type = ErrorType.CONNECTION
 
 
 class DatabaseError(OrionBeltError):
     """Database operation failures (query execution, schema analysis)."""
+
     error_type = ErrorType.DATABASE
 
 
 class ValidationError(OrionBeltError):
     """Input validation failures."""
+
     error_type = ErrorType.VALIDATION
 
 
 class ParameterError(OrionBeltError):
     """Missing or invalid tool parameters."""
+
     error_type = ErrorType.PARAMETER
 
 
 class RDFError(OrionBeltError):
     """RDF/ontology store errors."""
+
     error_type = ErrorType.RDF
 
 
 class StoreNotInitializedError(OrionBeltError):
     """RDF or vector store not initialized."""
+
     error_type = ErrorType.STORE
 
 
 class DependencyError(OrionBeltError):
     """Missing optional dependency."""
+
     error_type = ErrorType.DEPENDENCY

--- a/src/graphrag/__init__.py
+++ b/src/graphrag/__init__.py
@@ -19,11 +19,11 @@ Components:
 - CommunityDetector: Identifies logical schema groupings
 """
 
-from .manager import GraphRAGManager
+from .community_detector import CommunityDetector
 from .embedder import SchemaEmbedder
+from .manager import GraphRAGManager
 from .retriever import GraphRetriever
 from .vector_store import VectorStore
-from .community_detector import CommunityDetector
 
 __all__ = [
     "GraphRAGManager",

--- a/src/graphrag/community_detector.py
+++ b/src/graphrag/community_detector.py
@@ -6,9 +6,10 @@ helping organize large schemas into understandable domains.
 """
 
 import logging
-from typing import List, Dict, Any, Set, Optional
-import networkx as nx
 from collections import defaultdict
+from typing import Any, Dict, List, Optional, Set
+
+import networkx as nx
 
 logger = logging.getLogger(__name__)
 
@@ -69,12 +70,16 @@ class CommunityDetector:
                 self.table_to_community[table] = community_id
 
             self.communities = dict(communities)
-            logger.info(f"Detected {len(self.communities)} communities using Louvain method")
+            logger.info(
+                f"Detected {len(self.communities)} communities using Louvain method"
+            )
 
             return self.communities
 
         except ImportError:
-            logger.warning("python-louvain not installed, falling back to connected components")
+            logger.warning(
+                "python-louvain not installed, falling back to connected components"
+            )
             return self._detect_connected_components()
 
     def _detect_connected_components(self) -> Dict[int, Set[str]]:
@@ -97,7 +102,9 @@ class CommunityDetector:
                 self.table_to_community[table] = idx
 
         self.communities = communities
-        logger.info(f"Detected {len(self.communities)} communities using connected components")
+        logger.info(
+            f"Detected {len(self.communities)} communities using connected components"
+        )
 
         return self.communities
 
@@ -122,7 +129,9 @@ class CommunityDetector:
                 self.table_to_community[table] = idx
 
         self.communities = communities
-        logger.info(f"Detected {len(self.communities)} communities using label propagation")
+        logger.info(
+            f"Detected {len(self.communities)} communities using label propagation"
+        )
 
         return self.communities
 
@@ -207,7 +216,7 @@ class CommunityDetector:
             "tables": sorted(list(tables)),
             "internal_relationships": internal_edges,
             "central_table": central_table,
-            "avg_connections": sum(degrees.values()) / len(degrees) if degrees else 0
+            "avg_connections": sum(degrees.values()) / len(degrees) if degrees else 0,
         }
 
     def get_all_summaries(self) -> List[Dict[str, Any]]:
@@ -238,13 +247,13 @@ class CommunityDetector:
             table_names = list(tables)
 
             if len(table_names) == 1:
-                domain_names[community_id] = table_names[0].replace('_', ' ').title()
+                domain_names[community_id] = table_names[0].replace("_", " ").title()
                 continue
 
             # Find common words in table names
             word_counts = defaultdict(int)
             for table in table_names:
-                words = table.lower().split('_')
+                words = table.lower().split("_")
                 for word in words:
                     if len(word) > 2:  # Ignore very short words
                         word_counts[word] += 1

--- a/src/graphrag/embedder.py
+++ b/src/graphrag/embedder.py
@@ -8,9 +8,10 @@ Uses a lightweight embedding model to create semantic representations of:
 """
 
 import logging
-from typing import List, Dict, Any, Optional
-import numpy as np
 from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class SchemaElement:
     """Represents a schema element with its embedding."""
+
     element_type: str  # "table", "column", "relationship"
     element_id: str
     name: str
@@ -43,19 +45,23 @@ class SchemaEmbedder:
         """Initialize the embedding model."""
         if self.embedding_model == "tfidf":
             from sklearn.feature_extraction.text import TfidfVectorizer
+
             self.vectorizer = TfidfVectorizer(
                 max_features=384,  # Standard embedding size
                 ngram_range=(1, 2),
-                stop_words='english'
+                stop_words="english",
             )
             self._is_fitted = False
         elif self.embedding_model == "sentence-transformers":
             try:
                 from sentence_transformers import SentenceTransformer
-                self.model = SentenceTransformer('all-MiniLM-L6-v2')
+
+                self.model = SentenceTransformer("all-MiniLM-L6-v2")
                 logger.info("Loaded sentence-transformers model: all-MiniLM-L6-v2")
             except ImportError:
-                logger.warning("sentence-transformers not available, falling back to TF-IDF")
+                logger.warning(
+                    "sentence-transformers not available, falling back to TF-IDF"
+                )
                 self.embedding_model = "tfidf"
                 self._initialize_model()
 
@@ -64,7 +70,7 @@ class SchemaEmbedder:
         table_name: str,
         columns: List[Dict[str, Any]],
         comment: Optional[str] = None,
-        foreign_keys: Optional[List[Dict[str, Any]]] = None
+        foreign_keys: Optional[List[Dict[str, Any]]] = None,
     ) -> SchemaElement:
         """
         Create embedding for a table.
@@ -79,7 +85,7 @@ class SchemaEmbedder:
             SchemaElement with embedding
         """
         # Build text representation
-        text_parts = [table_name.replace('_', ' ')]
+        text_parts = [table_name.replace("_", " ")]
 
         if comment:
             text_parts.append(comment)
@@ -87,7 +93,7 @@ class SchemaEmbedder:
         # Add column names and types
         for col in columns:
             col_text = f"{col['name']} {col['data_type']}"
-            if col.get('comment'):
+            if col.get("comment"):
                 col_text += f" {col['comment']}"
             text_parts.append(col_text)
 
@@ -108,12 +114,12 @@ class SchemaEmbedder:
             name=table_name,
             description=description,
             metadata={
-                "columns": [col['name'] for col in columns],
+                "columns": [col["name"] for col in columns],
                 "column_count": len(columns),
                 "has_foreign_keys": bool(foreign_keys),
-                "comment": comment
+                "comment": comment,
             },
-            embedding=embedding
+            embedding=embedding,
         )
 
     def create_column_embedding(
@@ -124,7 +130,7 @@ class SchemaEmbedder:
         is_primary_key: bool = False,
         is_foreign_key: bool = False,
         foreign_key_table: Optional[str] = None,
-        comment: Optional[str] = None
+        comment: Optional[str] = None,
     ) -> SchemaElement:
         """
         Create embedding for a column.
@@ -143,9 +149,9 @@ class SchemaEmbedder:
         """
         # Build text representation
         text_parts = [
-            table_name.replace('_', ' '),
-            column_name.replace('_', ' '),
-            data_type
+            table_name.replace("_", " "),
+            column_name.replace("_", " "),
+            data_type,
         ]
 
         if comment:
@@ -172,9 +178,9 @@ class SchemaEmbedder:
                 "data_type": data_type,
                 "is_primary_key": is_primary_key,
                 "is_foreign_key": is_foreign_key,
-                "foreign_key_table": foreign_key_table
+                "foreign_key_table": foreign_key_table,
             },
-            embedding=embedding
+            embedding=embedding,
         )
 
     def create_relationship_embedding(
@@ -182,7 +188,7 @@ class SchemaEmbedder:
         from_table: str,
         to_table: str,
         join_columns: List[tuple],
-        relationship_type: str = "one_to_many"
+        relationship_type: str = "one_to_many",
     ) -> SchemaElement:
         """
         Create embedding for a relationship/join path.
@@ -198,7 +204,9 @@ class SchemaEmbedder:
         """
         # Build text representation
         join_desc = ", ".join([f"{fc} to {tc}" for fc, tc in join_columns])
-        description = f"{from_table} joins {to_table} on {join_desc} ({relationship_type})"
+        description = (
+            f"{from_table} joins {to_table} on {join_desc} ({relationship_type})"
+        )
 
         # Generate embedding
         embedding = self._embed_text(description)
@@ -212,9 +220,9 @@ class SchemaEmbedder:
                 "from_table": from_table,
                 "to_table": to_table,
                 "join_columns": join_columns,
-                "relationship_type": relationship_type
+                "relationship_type": relationship_type,
             },
-            embedding=embedding
+            embedding=embedding,
         )
 
     def _embed_text(self, text: str) -> np.ndarray:
@@ -240,7 +248,9 @@ class SchemaEmbedder:
             embedding = self.vectorizer.transform([text]).toarray()[0]
             return embedding
 
-    def batch_embed_tables(self, tables_info: List[Dict[str, Any]]) -> List[SchemaElement]:
+    def batch_embed_tables(
+        self, tables_info: List[Dict[str, Any]]
+    ) -> List[SchemaElement]:
         """
         Create embeddings for multiple tables in batch.
 
@@ -254,17 +264,19 @@ class SchemaEmbedder:
 
         for table in tables_info:
             element = self.create_table_embedding(
-                table_name=table['name'],
-                columns=table.get('columns', []),
-                comment=table.get('comment'),
-                foreign_keys=table.get('foreign_keys', [])
+                table_name=table["name"],
+                columns=table.get("columns", []),
+                comment=table.get("comment"),
+                foreign_keys=table.get("foreign_keys", []),
             )
             elements.append(element)
 
         logger.info(f"Created embeddings for {len(elements)} tables")
         return elements
 
-    def batch_embed_schema(self, tables_info: List[Dict[str, Any]]) -> Dict[str, List[SchemaElement]]:
+    def batch_embed_schema(
+        self, tables_info: List[Dict[str, Any]]
+    ) -> Dict[str, List[SchemaElement]]:
         """
         Create embeddings for entire schema (tables, columns, relationships).
 
@@ -274,20 +286,16 @@ class SchemaEmbedder:
         Returns:
             Dictionary with 'tables', 'columns', 'relationships' lists
         """
-        result = {
-            "tables": [],
-            "columns": [],
-            "relationships": []
-        }
+        result = {"tables": [], "columns": [], "relationships": []}
 
         # Collect all text for TF-IDF fitting if needed
         if self.embedding_model == "tfidf" and not self._is_fitted:
             all_texts = []
             for table in tables_info:
-                text_parts = [table['name']]
-                if table.get('comment'):
-                    text_parts.append(table['comment'])
-                for col in table.get('columns', []):
+                text_parts = [table["name"]]
+                if table.get("comment"):
+                    text_parts.append(table["comment"])
+                for col in table.get("columns", []):
                     text_parts.append(f"{col['name']} {col['data_type']}")
                 all_texts.append(" ".join(text_parts))
 
@@ -299,33 +307,33 @@ class SchemaEmbedder:
         for table in tables_info:
             # Table embedding
             table_element = self.create_table_embedding(
-                table_name=table['name'],
-                columns=table.get('columns', []),
-                comment=table.get('comment'),
-                foreign_keys=table.get('foreign_keys', [])
+                table_name=table["name"],
+                columns=table.get("columns", []),
+                comment=table.get("comment"),
+                foreign_keys=table.get("foreign_keys", []),
             )
             result["tables"].append(table_element)
 
             # Column embeddings
-            for col in table.get('columns', []):
+            for col in table.get("columns", []):
                 col_element = self.create_column_embedding(
-                    table_name=table['name'],
-                    column_name=col['name'],
-                    data_type=col['data_type'],
-                    is_primary_key=col.get('is_primary_key', False),
-                    is_foreign_key=col.get('is_foreign_key', False),
-                    foreign_key_table=col.get('foreign_key_table'),
-                    comment=col.get('comment')
+                    table_name=table["name"],
+                    column_name=col["name"],
+                    data_type=col["data_type"],
+                    is_primary_key=col.get("is_primary_key", False),
+                    is_foreign_key=col.get("is_foreign_key", False),
+                    foreign_key_table=col.get("foreign_key_table"),
+                    comment=col.get("comment"),
                 )
                 result["columns"].append(col_element)
 
             # Relationship embeddings
-            for fk in table.get('foreign_keys', []):
+            for fk in table.get("foreign_keys", []):
                 rel_element = self.create_relationship_embedding(
-                    from_table=table['name'],
-                    to_table=fk['referenced_table'],
-                    join_columns=[(fk['column'], fk['referenced_column'])],
-                    relationship_type="many_to_one"
+                    from_table=table["name"],
+                    to_table=fk["referenced_table"],
+                    join_columns=[(fk["column"], fk["referenced_column"])],
+                    relationship_type="many_to_one",
                 )
                 result["relationships"].append(rel_element)
 

--- a/src/graphrag/manager.py
+++ b/src/graphrag/manager.py
@@ -5,24 +5,27 @@ Coordinates embeddings, vector search, graph traversal, and community detection
 to provide intelligent schema navigation and context-aware query generation.
 """
 
-import logging
-from typing import List, Dict, Any, Optional
-from pathlib import Path
 import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
+from .community_detector import CommunityDetector
 from .embedder import SchemaEmbedder
 from .retriever import GraphRetriever
-from .community_detector import CommunityDetector
 
 # Try to use ChromaDB if available, fallback to JSON-based VectorStore
 try:
-    from .vector_store_chromadb import ChromaDBVectorStore, CHROMADB_AVAILABLE
+    from .vector_store_chromadb import CHROMADB_AVAILABLE, ChromaDBVectorStore
+
     if CHROMADB_AVAILABLE:
         logger = logging.getLogger(__name__)
         logger.info("ChromaDB available - using high-performance vector storage")
     else:
         logger = logging.getLogger(__name__)
-        logger.warning("ChromaDB not available - falling back to JSON-based vector storage")
+        logger.warning(
+            "ChromaDB not available - falling back to JSON-based vector storage"
+        )
 except ImportError:
     CHROMADB_AVAILABLE = False
     logger = logging.getLogger(__name__)
@@ -37,7 +40,7 @@ class GraphRAGManager:
         embedding_model: str = "tfidf",
         embedding_dimension: int = 384,
         connection_id: Optional[str] = None,
-        schema_name: Optional[str] = None
+        schema_name: Optional[str] = None,
     ):
         """
         Initialize GraphRAG manager.
@@ -55,11 +58,12 @@ class GraphRAGManager:
             self.vector_store = ChromaDBVectorStore(
                 connection_id=connection_id or "default",
                 schema_name=schema_name or "default",
-                dimension=embedding_dimension
+                dimension=embedding_dimension,
             )
             logger.info("Initialized ChromaDB vector store")
         else:
             from .vector_store import VectorStore
+
             self.vector_store = VectorStore(dimension=embedding_dimension)
             logger.warning("Using JSON-based vector store (ChromaDB not available)")
 
@@ -72,9 +76,7 @@ class GraphRAGManager:
         self._connection_id: Optional[str] = connection_id or "default"
 
     def initialize_from_schema(
-        self,
-        tables_info: List[Dict[str, Any]],
-        schema_name: str = "default"
+        self, tables_info: List[Dict[str, Any]], schema_name: str = "default"
     ):
         """
         Initialize GraphRAG from schema metadata.
@@ -83,7 +85,9 @@ class GraphRAGManager:
             tables_info: List of table metadata dictionaries
             schema_name: Schema identifier
         """
-        logger.info(f"Initializing GraphRAG for schema '{schema_name}' with {len(tables_info)} tables")
+        logger.info(
+            f"Initializing GraphRAG for schema '{schema_name}' with {len(tables_info)} tables"
+        )
 
         self._schema_name = schema_name
 
@@ -113,9 +117,7 @@ class GraphRAGManager:
         logger.info("GraphRAG initialization complete")
 
     def accumulate_schema(
-        self,
-        tables_info: List[Dict[str, Any]],
-        schema_name: str = "default"
+        self, tables_info: List[Dict[str, Any]], schema_name: str = "default"
     ):
         """Add a schema's tables to an already-initialized GraphRAG (accumulative).
 
@@ -162,10 +164,7 @@ class GraphRAGManager:
         )
 
     def search_schema(
-        self,
-        query: str,
-        top_k: int = 5,
-        element_type: Optional[str] = None
+        self, query: str, top_k: int = 5, element_type: Optional[str] = None
     ) -> List[Dict[str, Any]]:
         """
         Search schema using natural language.
@@ -179,13 +178,15 @@ class GraphRAGManager:
             List of matching schema elements with scores
         """
         if not self._initialized:
-            raise RuntimeError("GraphRAG not initialized. Call initialize_from_schema() first.")
+            raise RuntimeError(
+                "GraphRAG not initialized. Call initialize_from_schema() first."
+            )
 
         results = self.vector_store.search_by_text(
             query_text=query,
             embedder=self.embedder,
             top_k=top_k,
-            element_type=element_type
+            element_type=element_type,
         )
 
         return [
@@ -195,9 +196,9 @@ class GraphRAGManager:
                     "id": elem.element_id,
                     "name": elem.name,
                     "description": elem.description,
-                    "metadata": elem.metadata
+                    "metadata": elem.metadata,
                 },
-                "similarity_score": float(score)
+                "similarity_score": float(score),
             }
             for elem, score in results
         ]
@@ -207,7 +208,7 @@ class GraphRAGManager:
         query: str,
         top_k: int = 5,
         include_related: bool = True,
-        max_related_distance: int = 1
+        max_related_distance: int = 1,
     ) -> Dict[str, Any]:
         """
         Find tables relevant to a natural language query.
@@ -233,7 +234,7 @@ class GraphRAGManager:
             "primary_tables": table_results,
             "related_tables": {},
             "communities": {},
-            "suggested_joins": []
+            "suggested_joins": [],
         }
 
         if not primary_tables:
@@ -244,8 +245,7 @@ class GraphRAGManager:
             all_related = {}
             for table in primary_tables:
                 related = self.graph_retriever.get_related_tables(
-                    table,
-                    max_distance=max_related_distance
+                    table, max_distance=max_related_distance
                 )
                 all_related[table] = related
 
@@ -258,27 +258,33 @@ class GraphRAGManager:
                 if comm_id is not None:
                     result["communities"][table] = {
                         "community_id": comm_id,
-                        "tables_in_community": list(self.community_detector.get_community_tables(comm_id))
+                        "tables_in_community": list(
+                            self.community_detector.get_community_tables(comm_id)
+                        ),
                     }
 
         # Step 4: Find join paths between primary tables
         if len(primary_tables) > 1:
             for i, table_a in enumerate(primary_tables[:-1]):
-                for table_b in primary_tables[i+1:]:
+                for table_b in primary_tables[i + 1 :]:
                     join_path = self.graph_retriever.find_join_path(table_a, table_b)
                     if join_path:
-                        result["suggested_joins"].append({
-                            "from": table_a,
-                            "to": table_b,
-                            "path": join_path
-                        })
+                        result["suggested_joins"].append(
+                            {"from": table_a, "to": table_b, "path": join_path}
+                        )
 
         # Step 5: Check for fan-trap risks
-        all_tables = list(set(primary_tables + [
-            t for related in result["related_tables"].values()
-            for tables in related.values()
-            for t in tables
-        ]))
+        all_tables = list(
+            set(
+                primary_tables
+                + [
+                    t
+                    for related in result["related_tables"].values()
+                    for tables in related.values()
+                    for t in tables
+                ]
+            )
+        )
 
         fan_trap_warnings = self.graph_retriever.detect_fan_traps(all_tables)
         if fan_trap_warnings:
@@ -287,10 +293,7 @@ class GraphRAGManager:
         return result
 
     def get_query_context(
-        self,
-        query: str,
-        max_tables: int = 5,
-        max_columns: int = 20
+        self, query: str, max_tables: int = 5, max_columns: int = 20
     ) -> Dict[str, Any]:
         """
         Get optimized context for SQL query generation.
@@ -310,17 +313,12 @@ class GraphRAGManager:
 
         # Find relevant tables
         table_info = self.find_relevant_tables(
-            query,
-            top_k=max_tables,
-            include_related=True,
-            max_related_distance=1
+            query, top_k=max_tables, include_related=True, max_related_distance=1
         )
 
         # Find relevant columns
         column_results = self.search_schema(
-            query,
-            top_k=max_columns,
-            element_type="column"
+            query, top_k=max_columns, element_type="column"
         )
 
         # Build minimal context
@@ -330,7 +328,7 @@ class GraphRAGManager:
             "relevant_columns": [],
             "relationships": table_info.get("suggested_joins", []),
             "fan_trap_warnings": table_info.get("fan_trap_warnings", []),
-            "token_estimate": 0
+            "token_estimate": 0,
         }
 
         # Add primary tables with their metadata
@@ -339,28 +337,33 @@ class GraphRAGManager:
             table_meta = self.graph_retriever.get_table_metadata(table_name)
 
             if table_meta:
-                context["relevant_tables"].append({
-                    "name": table_name,
-                    "relevance_score": table_result["similarity_score"],
-                    "column_count": len(table_meta.get("columns", [])),
-                    "has_foreign_keys": bool(table_meta.get("foreign_keys")),
-                    "comment": table_meta.get("comment")
-                })
+                context["relevant_tables"].append(
+                    {
+                        "name": table_name,
+                        "relevance_score": table_result["similarity_score"],
+                        "column_count": len(table_meta.get("columns", [])),
+                        "has_foreign_keys": bool(table_meta.get("foreign_keys")),
+                        "comment": table_meta.get("comment"),
+                    }
+                )
 
         # Add relevant columns
         for col_result in column_results:
-            context["relevant_columns"].append({
-                "table": col_result["element"]["metadata"]["table"],
-                "column": col_result["element"]["name"],
-                "data_type": col_result["element"]["metadata"]["data_type"],
-                "relevance_score": col_result["similarity_score"]
-            })
+            context["relevant_columns"].append(
+                {
+                    "table": col_result["element"]["metadata"]["table"],
+                    "column": col_result["element"]["name"],
+                    "data_type": col_result["element"]["metadata"]["data_type"],
+                    "relevance_score": col_result["similarity_score"],
+                }
+            )
 
         # Estimate token usage (rough approximation)
         context["token_estimate"] = (
-            len(context["relevant_tables"]) * 200 +  # ~200 tokens per table summary
-            len(context["relevant_columns"]) * 50 +   # ~50 tokens per column
-            len(context["relationships"]) * 100       # ~100 tokens per join
+            len(context["relevant_tables"]) * 200
+            + len(context["relevant_columns"]) * 50  # ~200 tokens per table summary
+            + len(context["relationships"])  # ~50 tokens per column
+            * 100  # ~100 tokens per join
         )
 
         return context
@@ -378,12 +381,14 @@ class GraphRAGManager:
         overview = {
             "schema_name": self._schema_name,
             "vector_store_stats": self.vector_store.get_statistics(),
-            "graph_summary": self.graph_retriever.get_graph_summary()
+            "graph_summary": self.graph_retriever.get_graph_summary(),
         }
 
         if self.community_detector:
             overview["communities"] = self.community_detector.get_all_summaries()
-            overview["domain_suggestions"] = self.community_detector.suggest_domain_names()
+            overview[
+                "domain_suggestions"
+            ] = self.community_detector.suggest_domain_names()
 
         return overview
 
@@ -413,7 +418,7 @@ class GraphRAGManager:
             "tables_info": all_tables_info,
             "visualization": self.graph_retriever.export_graph_for_visualization(),
         }
-        with open(graph_path, 'w') as f:
+        with open(graph_path, "w") as f:
             json.dump(graph_data, f, indent=2)
 
         # Save combined communities
@@ -421,9 +426,9 @@ class GraphRAGManager:
             communities_path = connection_dir / "communities_combined.json"
             communities_data = {
                 "summaries": self.community_detector.get_all_summaries(),
-                "domain_names": self.community_detector.suggest_domain_names()
+                "domain_names": self.community_detector.suggest_domain_names(),
             }
-            with open(communities_path, 'w') as f:
+            with open(communities_path, "w") as f:
                 json.dump(communities_data, f, indent=2)
 
         # Also save per-schema files (backward compat with workspace metadata)
@@ -432,7 +437,9 @@ class GraphRAGManager:
             self.vector_store.save(vector_store_path)
 
             # Per-schema graph subset
-            schema_tables = [t for t in all_tables_info if t.get("schema") == schema_name]
+            schema_tables = [
+                t for t in all_tables_info if t.get("schema") == schema_name
+            ]
             if not schema_tables:
                 schema_tables = all_tables_info  # Fallback for single schema
             per_schema_graph_path = connection_dir / f"graph_{schema_name}.json"
@@ -440,16 +447,16 @@ class GraphRAGManager:
                 "tables_info": schema_tables,
                 "visualization": self.graph_retriever.export_graph_for_visualization(),
             }
-            with open(per_schema_graph_path, 'w') as f:
+            with open(per_schema_graph_path, "w") as f:
                 json.dump(per_schema_data, f, indent=2)
 
             if self.community_detector:
                 communities_path = connection_dir / f"communities_{schema_name}.json"
                 communities_data = {
                     "summaries": self.community_detector.get_all_summaries(),
-                    "domain_names": self.community_detector.suggest_domain_names()
+                    "domain_names": self.community_detector.suggest_domain_names(),
                 }
-                with open(communities_path, 'w') as f:
+                with open(communities_path, "w") as f:
                     json.dump(communities_data, f, indent=2)
 
         logger.info(
@@ -487,7 +494,9 @@ class GraphRAGManager:
             if vector_count > 0:
                 restored_components.append(f"vectors ({vector_count})")
             else:
-                logger.warning("ChromaDB collection is empty — vector search will not work")
+                logger.warning(
+                    "ChromaDB collection is empty — vector search will not work"
+                )
         except Exception as e:
             logger.warning(f"Failed to verify ChromaDB: {e}")
 
@@ -495,11 +504,15 @@ class GraphRAGManager:
         combined_graph_path = connection_dir / "graph_combined.json"
         per_schema_graph_path = connection_dir / f"graph_{schema_name}.json"
 
-        graph_path = combined_graph_path if combined_graph_path.exists() else per_schema_graph_path
+        graph_path = (
+            combined_graph_path
+            if combined_graph_path.exists()
+            else per_schema_graph_path
+        )
 
         if graph_path.exists():
             try:
-                with open(graph_path, 'r') as f:
+                with open(graph_path, "r") as f:
                     graph_data = json.load(f)
 
                 tables_info = graph_data.get("tables_info")
@@ -515,7 +528,9 @@ class GraphRAGManager:
                     elif schema_name not in self._schema_names:
                         self._schema_names.append(schema_name)
                 else:
-                    logger.warning("Graph file missing tables_info — graph not restored")
+                    logger.warning(
+                        "Graph file missing tables_info — graph not restored"
+                    )
             except Exception as e:
                 logger.error(f"Failed to load graph: {e}")
         else:
@@ -524,11 +539,15 @@ class GraphRAGManager:
         # 3. Load communities — prefer combined, fallback to per-schema
         combined_communities_path = connection_dir / "communities_combined.json"
         per_schema_communities_path = connection_dir / f"communities_{schema_name}.json"
-        communities_path = combined_communities_path if combined_communities_path.exists() else per_schema_communities_path
+        communities_path = (
+            combined_communities_path
+            if combined_communities_path.exists()
+            else per_schema_communities_path
+        )
 
         if communities_path.exists():
             try:
-                with open(communities_path, 'r') as f:
+                with open(communities_path, "r") as f:
                     communities_data = json.load(f)
 
                 self.community_detector = CommunityDetector(self.graph_retriever.graph)

--- a/src/graphrag/retriever.py
+++ b/src/graphrag/retriever.py
@@ -6,8 +6,9 @@ of foreign key relationships and semantic similarity.
 """
 
 import logging
-from typing import List, Dict, Any, Optional
 from collections import defaultdict, deque
+from typing import Any, Dict, List, Optional
+
 import networkx as nx
 
 logger = logging.getLogger(__name__)
@@ -33,31 +34,31 @@ class GraphRetriever:
 
         # Add nodes (tables)
         for table in tables_info:
-            table_name = table['name']
+            table_name = table["name"]
             self._tables_info[table_name] = table
 
             self.graph.add_node(
                 table_name,
-                node_type='table',
-                column_count=len(table.get('columns', [])),
-                has_comment=bool(table.get('comment')),
-                comment=table.get('comment', '')
+                node_type="table",
+                column_count=len(table.get("columns", [])),
+                has_comment=bool(table.get("comment")),
+                comment=table.get("comment", ""),
             )
 
         # Add edges (foreign key relationships)
         for table in tables_info:
-            table_name = table['name']
+            table_name = table["name"]
 
-            for fk in table.get('foreign_keys', []):
-                referenced_table = fk['referenced_table']
+            for fk in table.get("foreign_keys", []):
+                referenced_table = fk["referenced_table"]
 
                 if referenced_table in self.graph:
                     self.graph.add_edge(
                         table_name,
                         referenced_table,
-                        edge_type='foreign_key',
-                        column=fk['column'],
-                        referenced_column=fk['referenced_column']
+                        edge_type="foreign_key",
+                        column=fk["column"],
+                        referenced_column=fk["referenced_column"],
                     )
 
         logger.info(
@@ -78,32 +79,32 @@ class GraphRetriever:
         added_edges = 0
 
         for table in tables_info:
-            table_name = table['name']
+            table_name = table["name"]
             self._tables_info[table_name] = table
 
             if table_name not in self.graph:
                 added_nodes += 1
             self.graph.add_node(
                 table_name,
-                node_type='table',
-                column_count=len(table.get('columns', [])),
-                has_comment=bool(table.get('comment')),
-                comment=table.get('comment', '')
+                node_type="table",
+                column_count=len(table.get("columns", [])),
+                has_comment=bool(table.get("comment")),
+                comment=table.get("comment", ""),
             )
 
         for table in tables_info:
-            table_name = table['name']
-            for fk in table.get('foreign_keys', []):
-                referenced_table = fk['referenced_table']
+            table_name = table["name"]
+            for fk in table.get("foreign_keys", []):
+                referenced_table = fk["referenced_table"]
                 if referenced_table in self.graph:
                     if not self.graph.has_edge(table_name, referenced_table):
                         added_edges += 1
                     self.graph.add_edge(
                         table_name,
                         referenced_table,
-                        edge_type='foreign_key',
-                        column=fk['column'],
-                        referenced_column=fk['referenced_column']
+                        edge_type="foreign_key",
+                        column=fk["column"],
+                        referenced_column=fk["referenced_column"],
                     )
 
         logger.info(
@@ -113,10 +114,7 @@ class GraphRetriever:
         )
 
     def find_join_path(
-        self,
-        from_table: str,
-        to_table: str,
-        max_hops: int = 12
+        self, from_table: str, to_table: str, max_hops: int = 12
     ) -> Optional[List[Dict[str, Any]]]:
         """
         Find join path between two tables.
@@ -141,18 +139,14 @@ class GraphRetriever:
 
             try:
                 path_forward = nx.shortest_path(
-                    self.graph,
-                    source=from_table,
-                    target=to_table
+                    self.graph, source=from_table, target=to_table
                 )
             except nx.NetworkXNoPath:
                 pass
 
             try:
                 path_backward = nx.shortest_path(
-                    self.graph,
-                    source=to_table,
-                    target=from_table
+                    self.graph, source=to_table, target=from_table
                 )
             except nx.NetworkXNoPath:
                 pass
@@ -161,9 +155,7 @@ class GraphRetriever:
             try:
                 undirected_graph = self.graph.to_undirected()
                 path_undirected = nx.shortest_path(
-                    undirected_graph,
-                    source=from_table,
-                    target=to_table
+                    undirected_graph, source=from_table, target=to_table
                 )
             except nx.NetworkXNoPath:
                 pass
@@ -184,7 +176,9 @@ class GraphRetriever:
             path = min(candidates, key=len)
 
             if len(path) - 1 > max_hops:
-                logger.warning(f"Path from {from_table} to {to_table} requires {len(path) - 1} hops (max: {max_hops})")
+                logger.warning(
+                    f"Path from {from_table} to {to_table} requires {len(path) - 1} hops (max: {max_hops})"
+                )
                 return None
 
             # Build join specifications
@@ -196,22 +190,26 @@ class GraphRetriever:
                 # Get edge data (FK relationship)
                 if self.graph.has_edge(left_table, right_table):
                     edge_data = self.graph[left_table][right_table]
-                    joins.append({
-                        "from_table": left_table,
-                        "to_table": right_table,
-                        "from_column": edge_data['column'],
-                        "to_column": edge_data['referenced_column'],
-                        "join_type": "INNER"
-                    })
+                    joins.append(
+                        {
+                            "from_table": left_table,
+                            "to_table": right_table,
+                            "from_column": edge_data["column"],
+                            "to_column": edge_data["referenced_column"],
+                            "join_type": "INNER",
+                        }
+                    )
                 elif self.graph.has_edge(right_table, left_table):
                     edge_data = self.graph[right_table][left_table]
-                    joins.append({
-                        "from_table": left_table,
-                        "to_table": right_table,
-                        "from_column": edge_data['referenced_column'],
-                        "to_column": edge_data['column'],
-                        "join_type": "INNER"
-                    })
+                    joins.append(
+                        {
+                            "from_table": left_table,
+                            "to_table": right_table,
+                            "from_column": edge_data["referenced_column"],
+                            "to_column": edge_data["column"],
+                            "join_type": "INNER",
+                        }
+                    )
 
             return joins
 
@@ -220,10 +218,7 @@ class GraphRetriever:
             return None
 
     def get_related_tables(
-        self,
-        table_name: str,
-        max_distance: int = 1,
-        direction: str = "both"
+        self, table_name: str, max_distance: int = 1, direction: str = "both"
     ) -> Dict[str, List[str]]:
         """
         Get tables related to a given table.
@@ -373,12 +368,14 @@ class GraphRetriever:
             outgoing_fks = list(self.graph.successors(table))
 
             if len(outgoing_fks) > 1:
-                warnings.append({
-                    "bridge_table": table,
-                    "referenced_tables": outgoing_fks,
-                    "warning": f"Table '{table}' connects to multiple tables - potential fan-trap",
-                    "recommendation": "Use separate CTEs or UNION approach if aggregating across these relationships"
-                })
+                warnings.append(
+                    {
+                        "bridge_table": table,
+                        "referenced_tables": outgoing_fks,
+                        "warning": f"Table '{table}' connects to multiple tables - potential fan-trap",
+                        "recommendation": "Use separate CTEs or UNION approach if aggregating across these relationships",
+                    }
+                )
 
         return warnings
 
@@ -411,15 +408,24 @@ class GraphRetriever:
 
         # Find reference tables (many incoming FKs)
         in_degrees = dict(self.graph.in_degree())
-        top_references = sorted(in_degrees.items(), key=lambda x: x[1], reverse=True)[:5]
+        top_references = sorted(in_degrees.items(), key=lambda x: x[1], reverse=True)[
+            :5
+        ]
 
         return {
             "total_tables": self.graph.number_of_nodes(),
             "total_relationships": self.graph.number_of_edges(),
-            "top_central_tables": [{"table": t, "centrality": c} for t, c in top_central],
-            "top_hub_tables": [{"table": t, "outgoing_fks": d} for t, d in top_hubs if d > 0],
-            "top_reference_tables": [{"table": t, "incoming_fks": d} for t, d in top_references if d > 0],
-            "avg_connections_per_table": sum(dict(self.graph.degree()).values()) / max(self.graph.number_of_nodes(), 1)
+            "top_central_tables": [
+                {"table": t, "centrality": c} for t, c in top_central
+            ],
+            "top_hub_tables": [
+                {"table": t, "outgoing_fks": d} for t, d in top_hubs if d > 0
+            ],
+            "top_reference_tables": [
+                {"table": t, "incoming_fks": d} for t, d in top_references if d > 0
+            ],
+            "avg_connections_per_table": sum(dict(self.graph.degree()).values())
+            / max(self.graph.number_of_nodes(), 1),
         }
 
     def load_graph(self, tables_info: List[Dict[str, Any]]) -> bool:
@@ -448,23 +454,24 @@ class GraphRetriever:
         """
         nodes = []
         for node in self.graph.nodes(data=True):
-            nodes.append({
-                "id": node[0],
-                "label": node[0],
-                "type": "table",
-                "column_count": node[1].get('column_count', 0)
-            })
+            nodes.append(
+                {
+                    "id": node[0],
+                    "label": node[0],
+                    "type": "table",
+                    "column_count": node[1].get("column_count", 0),
+                }
+            )
 
         edges = []
         for edge in self.graph.edges(data=True):
-            edges.append({
-                "from": edge[0],
-                "to": edge[1],
-                "label": f"{edge[2].get('column')} → {edge[2].get('referenced_column')}",
-                "type": "foreign_key"
-            })
+            edges.append(
+                {
+                    "from": edge[0],
+                    "to": edge[1],
+                    "label": f"{edge[2].get('column')} → {edge[2].get('referenced_column')}",
+                    "type": "foreign_key",
+                }
+            )
 
-        return {
-            "nodes": nodes,
-            "edges": edges
-        }
+        return {"nodes": nodes, "edges": edges}

--- a/src/graphrag/vector_store.py
+++ b/src/graphrag/vector_store.py
@@ -5,12 +5,13 @@ Provides efficient similarity search and nearest neighbor retrieval
 for schema elements using vector embeddings.
 """
 
-import logging
-from typing import List, Dict, Any, Optional, Tuple
-import numpy as np
-from dataclasses import dataclass, asdict
 import json
+import logging
+from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class StoredElement:
     """Represents a stored schema element with its embedding."""
+
     element_type: str
     element_id: str
     name: str
@@ -48,7 +50,7 @@ class VectorStore:
         name: str,
         description: str,
         embedding: np.ndarray,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
     ):
         """
         Add a schema element to the store.
@@ -66,7 +68,7 @@ class VectorStore:
             if embedding.shape[0] < self.dimension:
                 embedding = np.pad(embedding, (0, self.dimension - embedding.shape[0]))
             else:
-                embedding = embedding[:self.dimension]
+                embedding = embedding[: self.dimension]
 
         element = StoredElement(
             element_type=element_type,
@@ -74,7 +76,7 @@ class VectorStore:
             name=name,
             description=description,
             metadata=metadata or {},
-            embedding=embedding.tolist()
+            embedding=embedding.tolist(),
         )
 
         self.elements.append(element)
@@ -94,7 +96,7 @@ class VectorStore:
                 name=elem.name,
                 description=elem.description,
                 embedding=elem.embedding,
-                metadata=elem.metadata
+                metadata=elem.metadata,
             )
 
         logger.info(f"Added {len(elements)} elements to vector store")
@@ -114,7 +116,7 @@ class VectorStore:
         query_embedding: np.ndarray,
         top_k: int = 5,
         element_type: Optional[str] = None,
-        threshold: float = 0.0
+        threshold: float = 0.0,
     ) -> List[Tuple[StoredElement, float]]:
         """
         Search for similar elements.
@@ -137,9 +139,11 @@ class VectorStore:
         # Normalize query
         if query_embedding.shape[0] != self.dimension:
             if query_embedding.shape[0] < self.dimension:
-                query_embedding = np.pad(query_embedding, (0, self.dimension - query_embedding.shape[0]))
+                query_embedding = np.pad(
+                    query_embedding, (0, self.dimension - query_embedding.shape[0])
+                )
             else:
-                query_embedding = query_embedding[:self.dimension]
+                query_embedding = query_embedding[: self.dimension]
 
         query_norm = np.linalg.norm(query_embedding)
         if query_norm > 0:
@@ -154,7 +158,9 @@ class VectorStore:
 
         # Filter by element type if specified
         if element_type:
-            type_mask = np.array([elem.element_type == element_type for elem in self.elements])
+            type_mask = np.array(
+                [elem.element_type == element_type for elem in self.elements]
+            )
             similarities = np.where(type_mask, similarities, -np.inf)
 
         # Filter by threshold
@@ -176,7 +182,7 @@ class VectorStore:
         query_text: str,
         embedder: Any,
         top_k: int = 5,
-        element_type: Optional[str] = None
+        element_type: Optional[str] = None,
     ) -> List[Tuple[StoredElement, float]]:
         """
         Search using natural language query.
@@ -229,13 +235,15 @@ class VectorStore:
         """
         data = {
             "dimension": self.dimension,
-            "elements": [asdict(elem) for elem in self.elements]
+            "elements": [asdict(elem) for elem in self.elements],
         }
 
-        with open(filepath, 'w') as f:
+        with open(filepath, "w") as f:
             json.dump(data, f, indent=2)
 
-        logger.info(f"Saved vector store with {len(self.elements)} elements to {filepath}")
+        logger.info(
+            f"Saved vector store with {len(self.elements)} elements to {filepath}"
+        )
 
     def load(self, filepath: Path):
         """
@@ -244,17 +252,19 @@ class VectorStore:
         Args:
             filepath: Input file path (JSON)
         """
-        with open(filepath, 'r') as f:
+        with open(filepath, "r") as f:
             data = json.load(f)
 
-        self.dimension = data['dimension']
-        self.elements = [StoredElement(**elem) for elem in data['elements']]
+        self.dimension = data["dimension"]
+        self.elements = [StoredElement(**elem) for elem in data["elements"]]
         self._index_built = False
 
         # Rebuild index
         self.build_index()
 
-        logger.info(f"Loaded vector store with {len(self.elements)} elements from {filepath}")
+        logger.info(
+            f"Loaded vector store with {len(self.elements)} elements from {filepath}"
+        )
 
     def get_statistics(self) -> Dict[str, Any]:
         """
@@ -271,7 +281,7 @@ class VectorStore:
             "total_elements": len(self.elements),
             "dimension": self.dimension,
             "index_built": self._index_built,
-            "elements_by_type": type_counts
+            "elements_by_type": type_counts,
         }
 
     def clear(self):

--- a/src/graphrag/vector_store_chromadb.py
+++ b/src/graphrag/vector_store_chromadb.py
@@ -10,18 +10,20 @@ This implementation offers:
 - Automatic indexing (HNSW algorithm)
 """
 
+import json
 import logging
-from typing import List, Dict, Any, Optional, Tuple
-import numpy as np
 from dataclasses import dataclass
 from pathlib import Path
-import json
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
 
 from ..paths import OUTPUT_DIR
 
 try:
     import chromadb
     from chromadb.config import Settings
+
     CHROMADB_AVAILABLE = True
 except ImportError:
     CHROMADB_AVAILABLE = False
@@ -33,6 +35,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class StoredElement:
     """Represents a stored schema element with its embedding."""
+
     element_type: str
     element_id: str
     name: str
@@ -51,7 +54,12 @@ class ChromaDBVectorStore:
         data/                   # Vector data files
     """
 
-    def __init__(self, connection_id: str = "default", schema_name: str = "default", dimension: int = 384):
+    def __init__(
+        self,
+        connection_id: str = "default",
+        schema_name: str = "default",
+        dimension: int = 384,
+    ):
         """
         Initialize ChromaDB vector store.
 
@@ -76,10 +84,7 @@ class ChromaDBVectorStore:
         # Initialize ChromaDB client (embedded mode)
         self.client = chromadb.PersistentClient(
             path=str(db_path),
-            settings=Settings(
-                anonymized_telemetry=False,
-                allow_reset=True
-            )
+            settings=Settings(anonymized_telemetry=False, allow_reset=True),
         )
 
         # Collection name based on schema
@@ -92,10 +97,12 @@ class ChromaDBVectorStore:
                 metadata={
                     "schema_name": schema_name,
                     "connection_id": connection_id,
-                    "dimension": dimension
-                }
+                    "dimension": dimension,
+                },
             )
-            logger.info(f"Initialized ChromaDB collection: {collection_name} at {db_path}")
+            logger.info(
+                f"Initialized ChromaDB collection: {collection_name} at {db_path}"
+            )
         except Exception as e:
             logger.error(f"Failed to initialize ChromaDB collection: {e}")
             raise
@@ -109,7 +116,7 @@ class ChromaDBVectorStore:
         name: str,
         description: str,
         embedding: np.ndarray,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
     ):
         """
         Add a schema element to the store.
@@ -143,14 +150,14 @@ class ChromaDBVectorStore:
             if embedding.shape[0] < self.dimension:
                 embedding = np.pad(embedding, (0, self.dimension - embedding.shape[0]))
             else:
-                embedding = embedding[:self.dimension]
+                embedding = embedding[: self.dimension]
 
         # Add to ChromaDB
         try:
             self.collection.add(
                 ids=[element_id],
                 embeddings=[embedding.tolist()],
-                metadatas=[chroma_metadata]
+                metadatas=[chroma_metadata],
             )
         except Exception as e:
             logger.error(f"Failed to add element {element_id}: {e}")
@@ -179,7 +186,7 @@ class ChromaDBVectorStore:
             }
 
             # Add element metadata
-            if hasattr(elem, 'metadata') and elem.metadata:
+            if hasattr(elem, "metadata") and elem.metadata:
                 for key, value in elem.metadata.items():
                     if isinstance(value, (str, int, float, bool)):
                         chroma_metadata[key] = value
@@ -190,9 +197,11 @@ class ChromaDBVectorStore:
             embedding = elem.embedding
             if embedding.shape[0] != self.dimension:
                 if embedding.shape[0] < self.dimension:
-                    embedding = np.pad(embedding, (0, self.dimension - embedding.shape[0]))
+                    embedding = np.pad(
+                        embedding, (0, self.dimension - embedding.shape[0])
+                    )
                 else:
-                    embedding = embedding[:self.dimension]
+                    embedding = embedding[: self.dimension]
 
             ids.append(elem.element_id)
             embeddings.append(embedding.tolist())
@@ -200,11 +209,7 @@ class ChromaDBVectorStore:
 
         # Batch add to ChromaDB
         try:
-            self.collection.add(
-                ids=ids,
-                embeddings=embeddings,
-                metadatas=metadatas
-            )
+            self.collection.add(ids=ids, embeddings=embeddings, metadatas=metadatas)
             logger.info(f"Added {len(elements)} elements to ChromaDB vector store")
         except Exception as e:
             logger.error(f"Failed to batch add elements: {e}")
@@ -221,7 +226,7 @@ class ChromaDBVectorStore:
         query_embedding: np.ndarray,
         top_k: int = 5,
         element_type: Optional[str] = None,
-        threshold: float = 0.0
+        threshold: float = 0.0,
     ) -> List[Tuple[StoredElement, float]]:
         """
         Search for similar elements using ChromaDB.
@@ -241,9 +246,11 @@ class ChromaDBVectorStore:
         # Normalize query embedding
         if query_embedding.shape[0] != self.dimension:
             if query_embedding.shape[0] < self.dimension:
-                query_embedding = np.pad(query_embedding, (0, self.dimension - query_embedding.shape[0]))
+                query_embedding = np.pad(
+                    query_embedding, (0, self.dimension - query_embedding.shape[0])
+                )
             else:
-                query_embedding = query_embedding[:self.dimension]
+                query_embedding = query_embedding[: self.dimension]
 
         # Prepare metadata filter
         where_filter = None
@@ -256,7 +263,7 @@ class ChromaDBVectorStore:
                 query_embeddings=[query_embedding.tolist()],
                 n_results=top_k,
                 where=where_filter,
-                include=["metadatas", "distances", "embeddings"]
+                include=["metadatas", "distances", "embeddings"],
             )
         except Exception as e:
             logger.error(f"ChromaDB query failed: {e}")
@@ -265,14 +272,14 @@ class ChromaDBVectorStore:
         # Convert results to StoredElement format
         stored_elements = []
 
-        if not results['ids'] or not results['ids'][0]:
+        if not results["ids"] or not results["ids"][0]:
             return []
 
-        for i in range(len(results['ids'][0])):
-            element_id = results['ids'][0][i]
-            metadata = results['metadatas'][0][i]
-            distance = results['distances'][0][i]
-            embedding = results['embeddings'][0][i]
+        for i in range(len(results["ids"][0])):
+            element_id = results["ids"][0][i]
+            metadata = results["metadatas"][0][i]
+            distance = results["distances"][0][i]
+            embedding = results["embeddings"][0][i]
 
             # Convert distance to similarity (ChromaDB uses L2 distance)
             # Similarity = 1 / (1 + distance)
@@ -287,7 +294,9 @@ class ChromaDBVectorStore:
             for key, value in metadata.items():
                 if key not in ["element_type", "name", "description"]:
                     # Try to parse JSON strings back to objects
-                    if isinstance(value, str) and (value.startswith('{') or value.startswith('[')):
+                    if isinstance(value, str) and (
+                        value.startswith("{") or value.startswith("[")
+                    ):
                         try:
                             elem_metadata[key] = json.loads(value)
                         except (json.JSONDecodeError, ValueError):
@@ -301,7 +310,7 @@ class ChromaDBVectorStore:
                 name=metadata.get("name", ""),
                 description=metadata.get("description", ""),
                 metadata=elem_metadata,
-                embedding=embedding
+                embedding=embedding,
             )
 
             stored_elements.append((element, similarity))
@@ -313,7 +322,7 @@ class ChromaDBVectorStore:
         query_text: str,
         embedder: Any,
         top_k: int = 5,
-        element_type: Optional[str] = None
+        element_type: Optional[str] = None,
     ) -> List[Tuple[StoredElement, float]]:
         """
         Search using natural language query.
@@ -342,21 +351,22 @@ class ChromaDBVectorStore:
         """
         try:
             result = self.collection.get(
-                ids=[element_id],
-                include=["metadatas", "embeddings"]
+                ids=[element_id], include=["metadatas", "embeddings"]
             )
 
-            if not result['ids']:
+            if not result["ids"]:
                 return None
 
-            metadata = result['metadatas'][0]
-            embedding = result['embeddings'][0]
+            metadata = result["metadatas"][0]
+            embedding = result["embeddings"][0]
 
             # Reconstruct metadata dict
             elem_metadata = {}
             for key, value in metadata.items():
                 if key not in ["element_type", "name", "description"]:
-                    if isinstance(value, str) and (value.startswith('{') or value.startswith('[')):
+                    if isinstance(value, str) and (
+                        value.startswith("{") or value.startswith("[")
+                    ):
                         try:
                             elem_metadata[key] = json.loads(value)
                         except (json.JSONDecodeError, ValueError):
@@ -370,7 +380,7 @@ class ChromaDBVectorStore:
                 name=metadata.get("name", ""),
                 description=metadata.get("description", ""),
                 metadata=elem_metadata,
-                embedding=embedding
+                embedding=embedding,
             )
         except Exception as e:
             logger.error(f"Failed to get element {element_id}: {e}")
@@ -389,19 +399,21 @@ class ChromaDBVectorStore:
         try:
             results = self.collection.get(
                 where={"element_type": element_type},
-                include=["metadatas", "embeddings"]
+                include=["metadatas", "embeddings"],
             )
 
             elements = []
-            for i in range(len(results['ids'])):
-                element_id = results['ids'][i]
-                metadata = results['metadatas'][i]
-                embedding = results['embeddings'][i]
+            for i in range(len(results["ids"])):
+                element_id = results["ids"][i]
+                metadata = results["metadatas"][i]
+                embedding = results["embeddings"][i]
 
                 elem_metadata = {}
                 for key, value in metadata.items():
                     if key not in ["element_type", "name", "description"]:
-                        if isinstance(value, str) and (value.startswith('{') or value.startswith('[')):
+                        if isinstance(value, str) and (
+                            value.startswith("{") or value.startswith("[")
+                        ):
                             try:
                                 elem_metadata[key] = json.loads(value)
                             except (json.JSONDecodeError, ValueError):
@@ -409,14 +421,16 @@ class ChromaDBVectorStore:
                         else:
                             elem_metadata[key] = value
 
-                elements.append(StoredElement(
-                    element_type=metadata.get("element_type", "unknown"),
-                    element_id=element_id,
-                    name=metadata.get("name", ""),
-                    description=metadata.get("description", ""),
-                    metadata=elem_metadata,
-                    embedding=embedding
-                ))
+                elements.append(
+                    StoredElement(
+                        element_type=metadata.get("element_type", "unknown"),
+                        element_id=element_id,
+                        name=metadata.get("name", ""),
+                        description=metadata.get("description", ""),
+                        metadata=elem_metadata,
+                        embedding=embedding,
+                    )
+                )
 
             return elements
         except Exception as e:
@@ -432,20 +446,20 @@ class ChromaDBVectorStore:
         """
         try:
             # Get all data from ChromaDB
-            results = self.collection.get(
-                include=["metadatas", "embeddings"]
-            )
+            results = self.collection.get(include=["metadatas", "embeddings"])
 
             elements = []
-            for i in range(len(results['ids'])):
-                element_id = results['ids'][i]
-                metadata = results['metadatas'][i]
-                embedding = results['embeddings'][i]
+            for i in range(len(results["ids"])):
+                element_id = results["ids"][i]
+                metadata = results["metadatas"][i]
+                embedding = results["embeddings"][i]
 
                 elem_metadata = {}
                 for key, value in metadata.items():
                     if key not in ["element_type", "name", "description"]:
-                        if isinstance(value, str) and (value.startswith('{') or value.startswith('[')):
+                        if isinstance(value, str) and (
+                            value.startswith("{") or value.startswith("[")
+                        ):
                             try:
                                 elem_metadata[key] = json.loads(value)
                             except (json.JSONDecodeError, ValueError):
@@ -459,7 +473,9 @@ class ChromaDBVectorStore:
                     "name": metadata.get("name", ""),
                     "description": metadata.get("description", ""),
                     "metadata": elem_metadata,
-                    "embedding": embedding.tolist() if hasattr(embedding, 'tolist') else embedding
+                    "embedding": embedding.tolist()
+                    if hasattr(embedding, "tolist")
+                    else embedding,
                 }
                 elements.append(element_dict)
 
@@ -467,17 +483,21 @@ class ChromaDBVectorStore:
                 "dimension": self.dimension,
                 "connection_id": self.connection_id,
                 "schema_name": self.schema_name,
-                "elements": elements
+                "elements": elements,
             }
 
-            with open(filepath, 'w') as f:
+            with open(filepath, "w") as f:
                 json.dump(data, f, indent=2)
 
-            logger.info(f"Exported ChromaDB vector store ({len(elements)} elements) to {filepath}")
+            logger.info(
+                f"Exported ChromaDB vector store ({len(elements)} elements) to {filepath}"
+            )
         except Exception as e:
             logger.error(f"Failed to export vector store: {e}")
             # Don't raise - ChromaDB is already persisted, JSON export is optional
-            logger.warning("ChromaDB is already persisted to disk, JSON export failed but data is safe")
+            logger.warning(
+                "ChromaDB is already persisted to disk, JSON export failed but data is safe"
+            )
 
     def load(self, filepath: Path):
         """
@@ -487,7 +507,7 @@ class ChromaDBVectorStore:
             filepath: Input file path (JSON)
         """
         try:
-            with open(filepath, 'r') as f:
+            with open(filepath, "r") as f:
                 data = json.load(f)
 
             # Clear existing data
@@ -498,7 +518,7 @@ class ChromaDBVectorStore:
             embeddings = []
             metadatas = []
 
-            for elem_dict in data.get('elements', []):
+            for elem_dict in data.get("elements", []):
                 # Prepare metadata
                 chroma_metadata = {
                     "element_type": elem_dict.get("element_type", "unknown"),
@@ -513,19 +533,17 @@ class ChromaDBVectorStore:
                     else:
                         chroma_metadata[key] = json.dumps(value)
 
-                ids.append(elem_dict['element_id'])
-                embeddings.append(elem_dict['embedding'])
+                ids.append(elem_dict["element_id"])
+                embeddings.append(elem_dict["embedding"])
                 metadatas.append(chroma_metadata)
 
             # Batch add
             if ids:
-                self.collection.add(
-                    ids=ids,
-                    embeddings=embeddings,
-                    metadatas=metadatas
-                )
+                self.collection.add(ids=ids, embeddings=embeddings, metadatas=metadatas)
 
-            logger.info(f"Imported ChromaDB vector store ({len(ids)} elements) from {filepath}")
+            logger.info(
+                f"Imported ChromaDB vector store ({len(ids)} elements) from {filepath}"
+            )
         except Exception as e:
             logger.error(f"Failed to import vector store: {e}")
             raise
@@ -544,10 +562,9 @@ class ChromaDBVectorStore:
         try:
             for element_type in ["table", "column", "relationship"]:
                 results = self.collection.get(
-                    where={"element_type": element_type},
-                    include=[]
+                    where={"element_type": element_type}, include=[]
                 )
-                type_counts[element_type] = len(results['ids'])
+                type_counts[element_type] = len(results["ids"])
         except Exception:
             type_counts = {"table": 0, "column": 0, "relationship": 0}
 
@@ -559,7 +576,7 @@ class ChromaDBVectorStore:
             "index_built": self._index_built,
             "elements_by_type": type_counts,
             "storage_backend": "ChromaDB",
-            "storage_path": f"tmp/chromadb/{self.connection_id}"
+            "storage_path": f"tmp/chromadb/{self.connection_id}",
         }
 
     def clear(self):
@@ -568,14 +585,16 @@ class ChromaDBVectorStore:
             # Delete and recreate collection
             self.client.delete_collection(self.collection.name)
 
-            collection_name = f"schema_{self.schema_name}".replace("-", "_").replace(".", "_")
+            collection_name = f"schema_{self.schema_name}".replace("-", "_").replace(
+                ".", "_"
+            )
             self.collection = self.client.get_or_create_collection(
                 name=collection_name,
                 metadata={
                     "schema_name": self.schema_name,
                     "connection_id": self.connection_id,
-                    "dimension": self.dimension
-                }
+                    "dimension": self.dimension,
+                },
             )
             logger.info(f"Cleared ChromaDB vector store: {collection_name}")
         except Exception as e:

--- a/src/handlers/__init__.py
+++ b/src/handlers/__init__.py
@@ -14,14 +14,7 @@ Modules:
     workspace  - Workspace restore from previous sessions
 """
 
-from . import connection
-from . import schema
-from . import ontology
-from . import query
-from . import chart
-from . import rdf
-from . import graphrag
-from . import workspace
+from . import chart, connection, graphrag, ontology, query, rdf, schema, workspace
 
 __all__ = [
     "connection",

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -1,7 +1,7 @@
 """Chart generation handler implementation."""
 
 import logging
-from typing import Optional, Union, List, Dict, Any
+from typing import Any, Dict, List, Optional, Union
 from uuid import uuid4
 
 from fastmcp import Context
@@ -9,7 +9,6 @@ from fastmcp.utilities.types import Image
 
 from ..chart_utils import save_image_to_tmp
 from ..config import config_manager
-
 from ..handler_context import HandlerContext
 
 logger = logging.getLogger(__name__)
@@ -40,11 +39,14 @@ async def generate_chart(
     logic and handles MCP Apps resource registration.
     """
     import json
+
     from ..tools.chart import generate_chart as generate_chart_impl
 
     # Parse data_source if it's a string
     if data_source and isinstance(data_source, str):
-        logger.warning("data_source was sent as string instead of JSON array - attempting to parse")
+        logger.warning(
+            "data_source was sent as string instead of JSON array - attempting to parse"
+        )
         try:
             parsed = json.loads(data_source)
             if isinstance(parsed, list):
@@ -57,7 +59,9 @@ async def generate_chart(
                 parsed = ast.literal_eval(data_source)
                 if isinstance(parsed, list):
                     data_source = parsed
-                    logger.info("Successfully parsed data_source from Python literal string format")
+                    logger.info(
+                        "Successfully parsed data_source from Python literal string format"
+                    )
             except (ValueError, SyntaxError) as e:
                 await ctx.info("Chart generation failed - data_source format error")
                 raise RuntimeError(
@@ -77,7 +81,9 @@ async def generate_chart(
             pass
 
     # Call implementation
-    logger.info(f"generate_chart called with output_format={output_format}, chart_type={chart_type}")
+    logger.info(
+        f"generate_chart called with output_format={output_format}, chart_type={chart_type}"
+    )
     result = generate_chart_impl(
         data_source,
         chart_type,
@@ -122,26 +128,35 @@ async def generate_chart(
             chart_json_uri = f"ui://orionbelt/chart-json/{chart_id}"
             if services.provides("add_resource"):
                 from fastmcp.resources import TextResource
-                services.add_resource(TextResource(
-                    uri=chart_uri,
-                    name=f"Chart: {title or chart_type_display}",
-                    text=html,
-                    mime_type="text/html",
-                ))
-                services.add_resource(TextResource(
-                    uri=chart_json_uri,
-                    name=f"Chart JSON: {title or chart_type_display}",
-                    text=fig.to_json(),
-                    mime_type="application/json",
-                ))
-                logger.info(f"Registered chart resources: {chart_uri}, {chart_json_uri}")
+
+                services.add_resource(
+                    TextResource(
+                        uri=chart_uri,
+                        name=f"Chart: {title or chart_type_display}",
+                        text=html,
+                        mime_type="text/html",
+                    )
+                )
+                services.add_resource(
+                    TextResource(
+                        uri=chart_json_uri,
+                        name=f"Chart JSON: {title or chart_type_display}",
+                        text=fig.to_json(),
+                        mime_type="application/json",
+                    )
+                )
+                logger.info(
+                    f"Registered chart resources: {chart_uri}, {chart_json_uri}"
+                )
 
             # Export a static PNG: saved to disk and returned inline as ImageContent
             image_inline = None
             file_uri = ""
             try:
                 chart_id = str(uuid4())
-                image_bytes = fig.to_image(format="png", width=PNG_WIDTH, height=PNG_HEIGHT)
+                image_bytes = fig.to_image(
+                    format="png", width=PNG_WIDTH, height=PNG_HEIGHT
+                )
                 connection_id = services.get_session_data(ctx).connection_id
                 image_file_path = save_image_to_tmp(
                     image_bytes, chart_id, "png", connection_id=connection_id
@@ -152,15 +167,21 @@ async def generate_chart(
             except Exception as e:
                 logger.debug(f"PNG export failed: {e}")
 
-            await ctx.info(f"Interactive {chart_type_display} chart with {data_points} data points")
-            text_result = f"Chart generated: {chart_uri}{file_uri}\nChart JSON: {chart_json_uri}"
+            await ctx.info(
+                f"Interactive {chart_type_display} chart with {data_points} data points"
+            )
+            text_result = (
+                f"Chart generated: {chart_uri}{file_uri}\nChart JSON: {chart_json_uri}"
+            )
             return_binary = config_manager.get_server_config().chart_return_binary
             if image_inline and return_binary:
                 return [text_result, image_inline]
             return text_result
         else:
             await ctx.info("Chart generation failed")
-            raise RuntimeError("Chart generation failed: unexpected result format for interactive mode")
+            raise RuntimeError(
+                "Chart generation failed: unexpected result format for interactive mode"
+            )
 
     # Handle image output
     if isinstance(result, tuple) and len(result) == 2:

--- a/src/handlers/connection.py
+++ b/src/handlers/connection.py
@@ -3,16 +3,16 @@
 import logging
 import os
 from datetime import datetime
+
 from fastmcp import Context
 
 from ..constants import SUPPORTED_DB_TYPES
 from ..exceptions import ConnectionError, ValidationError
+from ..handler_context import HandlerContext
 from ..lifecycle.metadata import VersionMetadataManager
 from ..paths import OUTPUT_DIR
 from ..workspace import detect_workspace, format_workspace_summary
-from .workspace import _restore_workspace_core, _format_restore_summary
-
-from ..handler_context import HandlerContext
+from .workspace import _format_restore_summary, _restore_workspace_core
 
 logger = logging.getLogger(__name__)
 
@@ -333,7 +333,9 @@ async def list_schemas(ctx: Context, services: "HandlerContext"):
     db_manager = services.get_session_db_manager(ctx)
     schemas = db_manager.get_schemas()
     if schemas:
-        await ctx.info(f"Found {len(schemas)} schemas; next call should be discover_schema")
+        await ctx.info(
+            f"Found {len(schemas)} schemas; next call should be discover_schema"
+        )
     else:
         await ctx.info("No schemas found")
     return schemas if schemas else []

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -4,18 +4,17 @@ import logging
 import os
 import time
 from datetime import datetime
-from typing import Optional, Dict, List, Any
+from typing import Any, Dict, List, Optional
 
 from fastmcp import Context
 
 from ..exceptions import ConnectionError
 from ..graphrag import GraphRAGManager
+from ..handler_context import HandlerContext
+from ..lifecycle.metadata import update_workspace_section
 from ..ontology_generator import OntologyGenerator
 from ..oxigraph_store import OXIGRAPH_AVAILABLE
-from ..lifecycle.metadata import update_workspace_section
-from ..paths import ensure_output_dir, get_connection_dir, OUTPUT_DIR
-
-from ..handler_context import HandlerContext
+from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +74,11 @@ async def _auto_generate_ontology_background(
         ontology_generator = OntologyGenerator(base_uri=base_uri)
         ontology_ttl = ontology_generator.generate_from_schema(tables_info)
 
-        conn_dir = get_connection_dir(session.connection_id) if session.connection_id else ensure_output_dir()
+        conn_dir = (
+            get_connection_dir(session.connection_id)
+            if session.connection_id
+            else ensure_output_dir()
+        )
 
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         ontology_file = conn_dir / f"ontology_{schema_name}_{timestamp}.ttl"
@@ -93,7 +96,9 @@ async def _auto_generate_ontology_background(
                     triple_count = session.oxigraph_store.load_ontology(
                         ontology_ttl, graph_uri, schema_name
                     )
-                    logger.info(f"Stored {triple_count} triples in RDF store (graph: {graph_uri})")
+                    logger.info(
+                        f"Stored {triple_count} triples in RDF store (graph: {graph_uri})"
+                    )
             except Exception as e:
                 logger.warning(f"Failed to store in RDF: {e}")
 
@@ -134,7 +139,9 @@ async def _auto_initialize_graphrag_background(
             )
         else:
             # Additional schema — accumulate into existing graph
-            logger.info(f"Accumulating schema '{schema_name}' into existing GraphRAG...")
+            logger.info(
+                f"Accumulating schema '{schema_name}' into existing GraphRAG..."
+            )
             session.graphrag_manager.accumulate_schema(
                 tables_info=tables_dict, schema_name=schema_name
             )
@@ -184,7 +191,10 @@ async def _auto_initialize_graphrag_background(
             )
 
     except Exception as e:
-        logger.error(f"GraphRAG auto-initialization failed: {type(e).__name__}: {e}", exc_info=True)
+        logger.error(
+            f"GraphRAG auto-initialization failed: {type(e).__name__}: {e}",
+            exc_info=True,
+        )
         session.graphrag_initialized = False
 
 
@@ -217,7 +227,9 @@ async def initialize_graphrag(
     if not tables_info:
         try:
             tables = db_manager.get_tables(effective_schema)
-            logger.info(f"Found {len(tables)} tables in schema '{effective_schema or 'default'}'")
+            logger.info(
+                f"Found {len(tables)} tables in schema '{effective_schema or 'default'}'"
+            )
 
             if effective_schema:
                 db_manager.prefetch_schema_constraints(effective_schema)
@@ -234,7 +246,9 @@ async def initialize_graphrag(
             session.cache_schema_analysis(effective_schema or "", tables_info)
 
         except Exception as e:
-            return services.create_error_response(f"Failed to fetch schema: {str(e)}", "database_error")
+            return services.create_error_response(
+                f"Failed to fetch schema: {str(e)}", "database_error"
+            )
 
     if not tables_info:
         return services.create_error_response(
@@ -340,11 +354,18 @@ async def graphrag_search(
 
         await ctx.info(f"Found {len(results)} results for query: {query}")
 
-        return {"success": True, "query": query, "result_count": len(results), "results": results}
+        return {
+            "success": True,
+            "query": query,
+            "result_count": len(results),
+            "results": results,
+        }
 
     except Exception as e:
         logger.error(f"GraphRAG search failed: {e}", exc_info=True)
-        return services.create_error_response(f"GraphRAG search failed: {str(e)}", "graphrag_error")
+        return services.create_error_response(
+            f"GraphRAG search failed: {str(e)}", "graphrag_error"
+        )
 
 
 async def graphrag_query_context(
@@ -425,7 +446,9 @@ async def graphrag_find_join_path(
             if join["to_table"] not in path:
                 path.append(join["to_table"])
 
-        await ctx.info(f"Found {len(join_path)}-hop path from {from_table} to {to_table}")
+        await ctx.info(
+            f"Found {len(join_path)}-hop path from {from_table} to {to_table}"
+        )
 
         return {
             "success": True,
@@ -486,7 +509,9 @@ async def reachable_from(
 
     except Exception as e:
         logger.error(f"reachable_from failed: {e}", exc_info=True)
-        return services.create_error_response(f"reachable_from failed: {str(e)}", "graphrag_error")
+        return services.create_error_response(
+            f"reachable_from failed: {str(e)}", "graphrag_error"
+        )
 
 
 async def measurable_from(
@@ -532,7 +557,9 @@ async def measurable_from(
 
     except Exception as e:
         logger.error(f"measurable_from failed: {e}", exc_info=True)
-        return services.create_error_response(f"measurable_from failed: {str(e)}", "graphrag_error")
+        return services.create_error_response(
+            f"measurable_from failed: {str(e)}", "graphrag_error"
+        )
 
 
 async def plan_composite_query(
@@ -588,9 +615,7 @@ async def plan_composite_query(
     # Leg-root facts = facts that are NOT reachable from another fact. A fact
     # reachable from another sits on that fact's grain chain (a coarser table),
     # so it is a dimension of it, not an independent leg.
-    leg_roots = [
-        f for f in facts if not any(f in reach[g] for g in facts if g != f)
-    ]
+    leg_roots = [f for f in facts if not any(f in reach[g] for g in facts if g != f)]
     leg_roots = list(dict.fromkeys(leg_roots))
 
     cfl_required = len(leg_roots) >= 2
@@ -674,4 +699,6 @@ async def graphrag_overview(
 
     except Exception as e:
         logger.error(f"GraphRAG overview failed: {e}", exc_info=True)
-        return services.create_error_response(f"GraphRAG overview failed: {str(e)}", "graphrag_error")
+        return services.create_error_response(
+            f"GraphRAG overview failed: {str(e)}", "graphrag_error"
+        )

--- a/src/handlers/ontology_artifacts.py
+++ b/src/handlers/ontology_artifacts.py
@@ -2,14 +2,13 @@
 
 import logging
 import re
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 from fastmcp import Context
 
-from ..paths import ensure_output_dir, get_connection_dir
-from ..oxigraph_store import OXIGRAPH_AVAILABLE
-
 from ..handler_context import HandlerContext
+from ..oxigraph_store import OXIGRAPH_AVAILABLE
+from ..paths import ensure_output_dir, get_connection_dir
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +34,11 @@ async def download_ontology(
                 }
 
         schema_safe = schema_name.replace(" ", "_").replace(".", "_")
-        conn_dir = get_connection_dir(session.connection_id) if session.connection_id else ensure_output_dir()
+        conn_dir = (
+            get_connection_dir(session.connection_id)
+            if session.connection_id
+            else ensure_output_dir()
+        )
 
         if source == "rdf" and OXIGRAPH_AVAILABLE:
             store = services.get_oxigraph_store(ctx)
@@ -70,11 +73,15 @@ async def download_ontology(
                     [
                         line
                         for line in ontology_ttl.split("\n")
-                        if line.strip() and not line.strip().startswith("#") and not line.strip().startswith("@")
+                        if line.strip()
+                        and not line.strip().startswith("#")
+                        and not line.strip().startswith("@")
                     ]
                 )
 
-                logger.info(f"Exported ontology from RDF store <{graph_uri}> to {file_path}")
+                logger.info(
+                    f"Exported ontology from RDF store <{graph_uri}> to {file_path}"
+                )
 
                 return {
                     "success": True,
@@ -101,7 +108,9 @@ async def download_ontology(
             # currently active in the session — schema_name may differ from the
             # current schema (per-schema ontology state).
             schema_state = session.get_schema_state(schema_name)
-            ontology_filename = schema_state.ontology.ontology_file if schema_state else None
+            ontology_filename = (
+                schema_state.ontology.ontology_file if schema_state else None
+            )
             if not ontology_filename:
                 pattern = f"ontology_{schema_safe}*.ttl"
                 matching_files = list(conn_dir.glob(pattern))
@@ -177,7 +186,11 @@ async def download_r2rml(
                 }
 
         schema_safe = schema_name.replace(" ", "_").replace(".", "_")
-        conn_dir = get_connection_dir(session.connection_id) if session.connection_id else ensure_output_dir()
+        conn_dir = (
+            get_connection_dir(session.connection_id)
+            if session.connection_id
+            else ensure_output_dir()
+        )
 
         # Read the *requested* schema's R2RML file, not the current schema's
         # (schema_name may differ from the active schema).

--- a/src/handlers/ontology_generation.py
+++ b/src/handlers/ontology_generation.py
@@ -8,12 +8,11 @@ from typing import Optional
 
 from fastmcp import Context
 
-from ..database_manager import TableInfo, ColumnInfo
-from ..lifecycle.metadata import update_workspace_section, update_workspace_rdf
-from ..paths import ensure_output_dir, get_connection_dir, OUTPUT_DIR
-from ..oxigraph_store import OXIGRAPH_AVAILABLE
-
+from ..database_manager import ColumnInfo, TableInfo
 from ..handler_context import HandlerContext
+from ..lifecycle.metadata import update_workspace_rdf, update_workspace_section
+from ..oxigraph_store import OXIGRAPH_AVAILABLE
+from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +25,7 @@ def _build_minimal_graph_summary(ontology_ttl: str) -> str:
     schema structure without consuming the full serialization.
     """
     from rdflib import Graph, Namespace
-    from rdflib.namespace import RDF, RDFS, OWL
+    from rdflib.namespace import OWL, RDF, RDFS
 
     g = Graph()
     g.parse(data=ontology_ttl, format="turtle")
@@ -141,7 +140,9 @@ async def generate_ontology(
     if schema_info:
         # Use provided schema information
         try:
-            schema_data = json.loads(schema_info) if isinstance(schema_info, str) else schema_info
+            schema_data = (
+                json.loads(schema_info) if isinstance(schema_info, str) else schema_info
+            )
 
             if "tables" in schema_data:
                 for table_data in schema_data["tables"]:
@@ -194,7 +195,9 @@ async def generate_ontology(
             logger.info(
                 f"Using CACHED schema from discover_schema: {len(tables_info)} tables (no re-query needed)"
             )
-            await ctx.info(f"Using cached schema: {len(tables_info)} tables - no database queries needed")
+            await ctx.info(
+                f"Using cached schema: {len(tables_info)} tables - no database queries needed"
+            )
         else:
             schema_name = effective_schema or schema_name
             db_manager = services.get_session_db_manager(ctx)
@@ -207,7 +210,9 @@ async def generate_ontology(
 
             try:
                 tables = db_manager.get_tables(schema_name)
-                logger.info(f"Found {len(tables)} tables in schema '{schema_name or 'default'}': {tables}")
+                logger.info(
+                    f"Found {len(tables)} tables in schema '{schema_name or 'default'}': {tables}"
+                )
 
                 if schema_name:
                     db_manager.prefetch_schema_constraints(schema_name)
@@ -228,7 +233,9 @@ async def generate_ontology(
                 )
 
     if not tables_info:
-        return services.create_error_response("No tables found to generate ontology from", "data_error")
+        return services.create_error_response(
+            "No tables found to generate ontology from", "data_error"
+        )
 
     generator = services.server_state.get_ontology_generator(base_uri=base_uri)
     ontology_ttl = generator.generate_from_schema(tables_info)
@@ -243,7 +250,8 @@ async def generate_ontology(
             if shacl["available"] and not shacl["conforms"]:
                 logger.warning(
                     "SHACL: generated ontology has %d violation(s):\n%s",
-                    shacl["violations"], shacl["report"],
+                    shacl["violations"],
+                    shacl["report"],
                 )
                 await ctx.info(
                     f"SHACL validation: {shacl['violations']} violation(s) in the "
@@ -258,16 +266,24 @@ async def generate_ontology(
     ontology_filename = None
     try:
         session = services.get_session_data(ctx)
-        conn_dir = get_connection_dir(session.connection_id) if session.connection_id else ensure_output_dir()
+        conn_dir = (
+            get_connection_dir(session.connection_id)
+            if session.connection_id
+            else ensure_output_dir()
+        )
 
         schema_safe = (schema_name or "default").replace(" ", "_").replace(".", "_")
-        ontology_filename = services.get_session_safe_filename(ctx, "ontology", schema_safe) + ".ttl"
+        ontology_filename = (
+            services.get_session_safe_filename(ctx, "ontology", schema_safe) + ".ttl"
+        )
         ontology_file_path = conn_dir / ontology_filename
 
         with open(ontology_file_path, "w", encoding="utf-8") as f:
             f.write(ontology_ttl)
 
-        logger.info(f"Generated ontology for schema '{schema_name or 'default'}': {len(tables_info)} tables")
+        logger.info(
+            f"Generated ontology for schema '{schema_name or 'default'}': {len(tables_info)} tables"
+        )
         logger.info(f"Saved ontology to: {ontology_file_path}")
 
         session.ontology_file = ontology_filename
@@ -315,10 +331,16 @@ async def generate_ontology(
                 store = services.get_oxigraph_store(ctx)
                 if store:
                     if not graph_uri:
-                        schema_safe = (schema_name or "default").replace(" ", "_").replace(".", "_")
+                        schema_safe = (
+                            (schema_name or "default")
+                            .replace(" ", "_")
+                            .replace(".", "_")
+                        )
                         graph_uri = f"http://example.com/schema/{schema_safe}"
 
-                    triple_count = store.load_ontology(ontology_ttl, graph_uri, schema_name or "default")
+                    triple_count = store.load_ontology(
+                        ontology_ttl, graph_uri, schema_name or "default"
+                    )
                     logger.info(
                         f"Auto-persisted ontology to Oxigraph: {triple_count} triples in graph <{graph_uri}>"
                     )
@@ -382,7 +404,9 @@ To improve ontology for business users:
 
                     return result
             except Exception as e:
-                logger.warning(f"Auto-persist to Oxigraph failed: {e}, falling back to full TTL return")
+                logger.warning(
+                    f"Auto-persist to Oxigraph failed: {e}, falling back to full TTL return"
+                )
 
         # Fallback: return minimal graph summary instead of full TTL
         result = f"Ontology generated and saved to file: {ontology_filename}\n"
@@ -393,7 +417,9 @@ To improve ontology for business users:
             result += "\n\nSEMANTIC NAME RESOLUTION RECOMMENDED"
             result += f"\nFound {cryptic_count} names that may be abbreviations or cryptic identifiers."
             result += "\n1. Call suggest_semantic_names() - NO parameters needed, ontology is CACHED"
-            result += "\n2. Review the suggestions and provide business-friendly alternatives"
+            result += (
+                "\n2. Review the suggestions and provide business-friendly alternatives"
+            )
             result += "\n3. Call apply_semantic_names() with your suggestions"
 
         return result
@@ -404,4 +430,3 @@ To improve ontology for business users:
             "Ontology file save failed but ontology generated; next call should be suggest_semantic_names to improve cryptic names"
         )
         return _build_minimal_graph_summary(ontology_ttl)
-

--- a/src/handlers/ontology_io.py
+++ b/src/handlers/ontology_io.py
@@ -4,15 +4,14 @@ import logging
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 from fastmcp import Context
 
-from ..paths import PROJECT_ROOT
 from ..constants import OBA_NAMESPACE
-from ..oxigraph_store import OXIGRAPH_AVAILABLE
-
 from ..handler_context import HandlerContext
+from ..oxigraph_store import OXIGRAPH_AVAILABLE
+from ..paths import PROJECT_ROOT
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +23,7 @@ def _check_ontology_db_compatibility(graph, ctx, get_session_db_manager, session
     """
     try:
         from rdflib import Namespace
-        from rdflib.namespace import RDF, OWL
+        from rdflib.namespace import OWL, RDF
 
         db_manager = get_session_db_manager(ctx)
         if not db_manager.has_engine():
@@ -56,18 +55,14 @@ def _check_ontology_db_compatibility(graph, ctx, get_session_db_manager, session
             db_tables_list = db_manager.get_tables(schema_name)
             db_tables = {t.lower(): t for t in db_tables_list}
         except Exception as e:
-            logger.warning(f"Could not fetch database tables for compatibility check: {e}")
+            logger.warning(
+                f"Could not fetch database tables for compatibility check: {e}"
+            )
             return None
 
-        matched = sorted(
-            onto_tables[k] for k in onto_tables if k in db_tables
-        )
-        onto_only = sorted(
-            onto_tables[k] for k in onto_tables if k not in db_tables
-        )
-        db_only = sorted(
-            db_tables[k] for k in db_tables if k not in onto_tables
-        )
+        matched = sorted(onto_tables[k] for k in onto_tables if k in db_tables)
+        onto_only = sorted(onto_tables[k] for k in onto_tables if k not in db_tables)
+        db_only = sorted(db_tables[k] for k in db_tables if k not in onto_tables)
 
         total_onto = len(onto_tables)
         match_count = len(matched)
@@ -133,7 +128,7 @@ async def load_my_ontology(
     """Load an ontology from inline content or the newest .ttl file from the import folder."""
     try:
         from rdflib import Graph
-        from rdflib.namespace import RDF, OWL
+        from rdflib.namespace import OWL, RDF
 
         newest_file = None
         ttl_files = []
@@ -213,7 +208,9 @@ async def load_my_ontology(
         datatype_props = len(list(graph.subjects(RDF.type, OWL.DatatypeProperty)))
         object_props = len(list(graph.subjects(RDF.type, OWL.ObjectProperty)))
 
-        modified_time = datetime.fromtimestamp(file_stat.st_mtime).strftime("%Y-%m-%d %H:%M:%S")
+        modified_time = datetime.fromtimestamp(file_stat.st_mtime).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
 
         session = services.get_session_data(ctx)
         session.loaded_ontology = ontology_content
@@ -246,7 +243,9 @@ async def load_my_ontology(
                         graph_uri = f"http://example.com/schema/{schema_name}"
                     used_graph_uri = graph_uri
 
-                    triple_count = store.load_ontology(ontology_content, graph_uri, schema_name)
+                    triple_count = store.load_ontology(
+                        ontology_content, graph_uri, schema_name
+                    )
                     stored_in_rdf = True
 
                     logger.info(
@@ -257,12 +256,20 @@ async def load_my_ontology(
                     )
                 else:
                     logger.warning("Oxigraph store not available for auto-persist")
-                    await ctx.info(f"Ontology loaded with {classes_count} classes; ready for SQL generation")
+                    await ctx.info(
+                        f"Ontology loaded with {classes_count} classes; ready for SQL generation"
+                    )
             except Exception as e:
-                logger.warning(f"Auto-persist to Oxigraph failed: {e}, ontology still available in session state")
-                await ctx.info(f"Ontology loaded with {classes_count} classes; ready for SQL generation")
+                logger.warning(
+                    f"Auto-persist to Oxigraph failed: {e}, ontology still available in session state"
+                )
+                await ctx.info(
+                    f"Ontology loaded with {classes_count} classes; ready for SQL generation"
+                )
         else:
-            await ctx.info(f"Ontology loaded with {classes_count} classes; ready for SQL generation")
+            await ctx.info(
+                f"Ontology loaded with {classes_count} classes; ready for SQL generation"
+            )
 
         response = {
             "success": True,
@@ -275,7 +282,9 @@ async def load_my_ontology(
             "properties_count": datatype_props,
             "relationships_count": object_props,
             "total_files_found": len(ttl_files),
-            "other_files": [f.name for f in ttl_files[1:5]] if len(ttl_files) > 1 else [],
+            "other_files": [f.name for f in ttl_files[1:5]]
+            if len(ttl_files) > 1
+            else [],
             "stored_in_rdf": stored_in_rdf,
         }
 
@@ -309,7 +318,9 @@ async def load_my_ontology(
                     "3. execute_sql_query (use ontology context for accurate SQL)",
                 ],
             }
-            response["note"] = "This ontology is now active and will be used instead of auto-generated ontologies"
+            response[
+                "note"
+            ] = "This ontology is now active and will be used instead of auto-generated ontologies"
 
         if compatibility:
             response["compatibility"] = compatibility
@@ -323,4 +334,3 @@ async def load_my_ontology(
             "error": f"Failed to load ontology: {str(e)}",
             "error_type": "internal_error",
         }
-

--- a/src/handlers/ontology_semantic.py
+++ b/src/handlers/ontology_semantic.py
@@ -4,20 +4,18 @@ import json
 import logging
 import re
 from datetime import datetime
-from typing import Optional, Dict, Any, Union
+from typing import Any, Dict, Optional, Union
 
 from fastmcp import Context
 
-from ..ontology_generator import OntologyGenerator
-from ..lifecycle.metadata import update_workspace_section
-from ..paths import ensure_output_dir, get_connection_dir, OUTPUT_DIR
-from ..oxigraph_store import OXIGRAPH_AVAILABLE
 from ..config import config_manager
-from ..utils import safe_ctx_info, is_client_disconnect
-
-from .ontology_generation import _build_minimal_graph_summary
-
 from ..handler_context import HandlerContext
+from ..lifecycle.metadata import update_workspace_section
+from ..ontology_generator import OntologyGenerator
+from ..oxigraph_store import OXIGRAPH_AVAILABLE
+from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
+from ..utils import is_client_disconnect, safe_ctx_info
+from .ontology_generation import _build_minimal_graph_summary
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +43,9 @@ async def _maybe_sample_rename_suggestions(
     payload.
     """
     if not config_manager.get_server_config().enable_sampling:
-        logger.info("MCP sampling disabled (ENABLE_SAMPLING=false) — using legacy review path")
+        logger.info(
+            "MCP sampling disabled (ENABLE_SAMPLING=false) — using legacy review path"
+        )
         return None
 
     if not (cryptic_classes or cryptic_props_by_table or cryptic_relationships):
@@ -187,12 +187,13 @@ def _build_rename_prompt(items: list[str]) -> str:
         '"description":"International Bank Account Number for the account.",'
         '"table_name":"acctbal"}],'
         '"relationships":[]}\n\n'
-        "Now produce suggestions for the items below. Items:\n"
-        + "\n".join(items)
+        "Now produce suggestions for the items below. Items:\n" + "\n".join(items)
     )
 
 
-def _normalize_structured_suggestions(parsed: Optional[Dict[str, Any]]) -> Dict[str, list]:
+def _normalize_structured_suggestions(
+    parsed: Optional[Dict[str, Any]]
+) -> Dict[str, list]:
     """Validate and clean a structured suggestions payload.
 
     Drops items missing required fields, strips suggestions that match the
@@ -255,7 +256,9 @@ def _parse_rename_json(text: str) -> Optional[Dict[str, Any]]:
     if stripped.startswith("{") and stripped.endswith("}"):
         candidates.append(stripped)
 
-    fence_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL | re.IGNORECASE)
+    fence_match = re.search(
+        r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL | re.IGNORECASE
+    )
     if fence_match:
         candidates.append(fence_match.group(1))
 
@@ -285,7 +288,11 @@ async def suggest_semantic_names(
         try:
             if ontology_file:
                 session = services.get_session_data(ctx)
-                file_dir = get_connection_dir(session.connection_id) if session.connection_id else ensure_output_dir()
+                file_dir = (
+                    get_connection_dir(session.connection_id)
+                    if session.connection_id
+                    else ensure_output_dir()
+                )
                 ontology_path = file_dir / ontology_file
                 if not ontology_path.exists():
                     return {
@@ -344,7 +351,10 @@ async def suggest_semantic_names(
             cryptic_relationships=cryptic_relationships,
         )
 
-        if sampled_suggestions and any(sampled_suggestions.get(k) for k in ("classes", "properties", "relationships")):
+        if sampled_suggestions and any(
+            sampled_suggestions.get(k)
+            for k in ("classes", "properties", "relationships")
+        ):
             sampled_total = sum(
                 len(sampled_suggestions.get(k) or [])
                 for k in ("classes", "properties", "relationships")
@@ -414,7 +424,11 @@ async def apply_semantic_names(
         session = services.get_session_data(ctx)
         try:
             if ontology_file:
-                conn_dir = get_connection_dir(session.connection_id) if session.connection_id else ensure_output_dir()
+                conn_dir = (
+                    get_connection_dir(session.connection_id)
+                    if session.connection_id
+                    else ensure_output_dir()
+                )
                 ontology_path = conn_dir / ontology_file
                 if not ontology_path.exists():
                     return services.create_error_response(
@@ -455,8 +469,15 @@ async def apply_semantic_names(
         new_ontology_filename = None
         if save_to_file:
             try:
-                conn_dir = get_connection_dir(session.connection_id) if session.connection_id else ensure_output_dir()
-                new_ontology_filename = services.get_session_safe_filename(ctx, "ontology", "semantic") + ".ttl"
+                conn_dir = (
+                    get_connection_dir(session.connection_id)
+                    if session.connection_id
+                    else ensure_output_dir()
+                )
+                new_ontology_filename = (
+                    services.get_session_safe_filename(ctx, "ontology", "semantic")
+                    + ".ttl"
+                )
                 ontology_file_path = conn_dir / new_ontology_filename
 
                 with open(ontology_file_path, "w", encoding="utf-8") as f:
@@ -510,16 +531,22 @@ async def apply_semantic_names(
                 store = services.get_oxigraph_store(ctx)
                 if store:
                     session = services.get_session_data(ctx)
-                    schema_name = getattr(session, "schema_name", "default") or "default"
+                    schema_name = (
+                        getattr(session, "schema_name", "default") or "default"
+                    )
                     schema_safe = schema_name.replace(" ", "_").replace(".", "_")
                     graph_uri = f"http://example.com/schema/{schema_safe}"
-                    triple_count = store.load_ontology(updated_ontology, graph_uri, schema_name)
+                    triple_count = store.load_ontology(
+                        updated_ontology, graph_uri, schema_name
+                    )
                     result += f"\nPersisted to Oxigraph: {triple_count:,} triples in <{graph_uri}>"
                     result += f"\nToken savings: ~{len(updated_ontology) // 4} tokens saved by auto-persisting to RDF store!"
                     result += '\nUse query_sparql() to explore or download_artifact(artifact_type="ontology") to get the TTL file.'
                     persisted = True
             except Exception as e:
-                logger.warning(f"Auto-persist semantic ontology to Oxigraph failed: {e}")
+                logger.warning(
+                    f"Auto-persist semantic ontology to Oxigraph failed: {e}"
+                )
 
         if not persisted:
             # Without Oxigraph, return a minimal graph summary instead of full TTL
@@ -529,5 +556,6 @@ async def apply_semantic_names(
 
     except Exception as e:
         logger.error(f"Error applying semantic names: {e}")
-        return services.create_error_response(f"Failed to apply semantic names: {str(e)}", "internal_error")
-
+        return services.create_error_response(
+            f"Failed to apply semantic names: {str(e)}", "internal_error"
+        )

--- a/src/handlers/query.py
+++ b/src/handlers/query.py
@@ -2,12 +2,11 @@
 
 import logging
 import re
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 from fastmcp import Context
 
 from ..exceptions import ConnectionError, ParameterError, ValidationError
-
 from ..handler_context import HandlerContext
 
 logger = logging.getLogger(__name__)
@@ -45,11 +44,15 @@ def _extract_query_intent(sql: str) -> str:
     aggs = list(set([a.upper() for a in aggs]))
 
     # Extract WHERE conditions
-    where_match = re.search(r"WHERE\s+(.+?)(?:GROUP BY|ORDER BY|LIMIT|$)", sql, re.IGNORECASE)
+    where_match = re.search(
+        r"WHERE\s+(.+?)(?:GROUP BY|ORDER BY|LIMIT|$)", sql, re.IGNORECASE
+    )
     conditions = []
     if where_match:
         where_clause = where_match.group(1)
-        cond_cols = re.findall(r"\b(\w+)\s*(?:=|>|<|LIKE|IN)", where_clause, re.IGNORECASE)
+        cond_cols = re.findall(
+            r"\b(\w+)\s*(?:=|>|<|LIKE|IN)", where_clause, re.IGNORECASE
+        )
         conditions = list(set(cond_cols[:3]))
 
     # Build intent string
@@ -91,7 +94,9 @@ async def validate_sql_syntax(
                     "Use connect_database tool first to enable comprehensive validation",
                     "Basic syntax validation can still be performed, but schema validation requires a connection",
                 ],
-                "warnings": ["Schema-level validation disabled without database connection"],
+                "warnings": [
+                    "Schema-level validation disabled without database connection"
+                ],
                 "database_dialect": "unknown",
             }
 
@@ -100,7 +105,9 @@ async def validate_sql_syntax(
                 "is_valid": False,
                 "error": "SQL query cannot be empty.",
                 "error_type": "parameter_error",
-                "suggestions": ["Provide a valid SELECT statement or schema introspection query"],
+                "suggestions": [
+                    "Provide a valid SELECT statement or schema introspection query"
+                ],
                 "database_dialect": "unknown",
             }
 
@@ -122,8 +129,12 @@ async def validate_sql_syntax(
             if not obqc_result.is_valid:
                 validation_result["is_valid"] = False
                 if not validation_result.get("error"):
-                    validation_result["error"] = "OBQC validation failed - see obqc_issues for details"
-                validation_result["error_type"] = validation_result.get("error_type") or "obqc_error"
+                    validation_result[
+                        "error"
+                    ] = "OBQC validation failed - see obqc_issues for details"
+                validation_result["error_type"] = (
+                    validation_result.get("error_type") or "obqc_error"
+                )
 
             for issue in obqc_result.issues:
                 if issue.severity.value == "warning":
@@ -132,7 +143,9 @@ async def validate_sql_syntax(
                         msg += f" - {issue.suggestion}"
                     validation_result["warnings"].append(msg)
                 elif issue.severity.value == "error" and issue.suggestion:
-                    validation_result["suggestions"].append(f"[OBQC] {issue.suggestion}")
+                    validation_result["suggestions"].append(
+                        f"[OBQC] {issue.suggestion}"
+                    )
 
             if obqc_result.fan_trap_risk:
                 validation_result["warnings"].append(
@@ -142,7 +155,9 @@ async def validate_sql_syntax(
                     "Consider UNION ALL pattern: aggregate each fact table separately, then combine"
                 )
 
-            logger.debug(f"OBQC validation: valid={obqc_result.is_valid}, issues={len(obqc_result.issues)}")
+            logger.debug(
+                f"OBQC validation: valid={obqc_result.is_valid}, issues={len(obqc_result.issues)}"
+            )
         else:
             validation_result["obqc_valid"] = None
             validation_result["obqc_issues"] = []
@@ -156,12 +171,16 @@ async def validate_sql_syntax(
                 f"SQL validation successful: {sql_query[:100]}{'...' if len(sql_query) > 100 else ''}"
             )
             validation_result["next_tool"] = "execute_sql_query"
-            await ctx.info("SQL validation passed; next call should be execute_sql_query")
+            await ctx.info(
+                "SQL validation passed; next call should be execute_sql_query"
+            )
         else:
             logger.info(
                 f"SQL validation failed: {validation_result.get('error', 'Unknown validation error')}"
             )
-            await ctx.info("SQL validation failed; fix the query and try validate_sql_syntax again")
+            await ctx.info(
+                "SQL validation failed; fix the query and try validate_sql_syntax again"
+            )
 
         return validation_result
 
@@ -295,7 +314,9 @@ async def execute_sql_query(
 
                 if context and "relevant_tables" in context:
                     table_count = len(context["relevant_tables"])
-                    logger.info(f"Auto-retrieved context: {table_count} relevant tables")
+                    logger.info(
+                        f"Auto-retrieved context: {table_count} relevant tables"
+                    )
             except Exception as e:
                 logger.debug(f"Context auto-retrieval failed (non-critical): {e}")
 
@@ -319,7 +340,9 @@ async def execute_sql_query(
             else:
                 await ctx.info("SQL query executed successfully but returned no rows")
         else:
-            logger.warning(f"SQL query execution failed: {result.get('error', 'Unknown error')}")
+            logger.warning(
+                f"SQL query execution failed: {result.get('error', 'Unknown error')}"
+            )
             await ctx.info("SQL query execution failed; review error and try again")
 
         return result

--- a/src/handlers/rdf.py
+++ b/src/handlers/rdf.py
@@ -1,21 +1,20 @@
 """Oxigraph RDF store and SPARQL handler implementations."""
 
 import logging
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 from fastmcp import Context
 
 from ..exceptions import (
     DependencyError,
-    StoreNotInitializedError,
     RDFError,
+    StoreNotInitializedError,
     ValidationError,
 )
-from ..oxigraph_store import OXIGRAPH_AVAILABLE
-from ..lifecycle.metadata import update_workspace_section, update_workspace_rdf
-from ..paths import ensure_output_dir, get_connection_dir, OUTPUT_DIR
-
 from ..handler_context import HandlerContext
+from ..lifecycle.metadata import update_workspace_rdf, update_workspace_section
+from ..oxigraph_store import OXIGRAPH_AVAILABLE
+from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +33,9 @@ async def store_ontology_in_rdf(
 
     store = services.get_oxigraph_store(ctx)
     if store is None:
-        return StoreNotInitializedError("Failed to initialize Oxigraph store").to_response()
+        return StoreNotInitializedError(
+            "Failed to initialize Oxigraph store"
+        ).to_response()
 
     session = services.get_session_data(ctx)
     effective_schema = schema_name or session.get_last_analyzed_schema() or "default"
@@ -45,7 +46,11 @@ async def store_ontology_in_rdf(
         ).to_response()
 
     try:
-        conn_dir = get_connection_dir(session.connection_id) if session.connection_id else ensure_output_dir()
+        conn_dir = (
+            get_connection_dir(session.connection_id)
+            if session.connection_id
+            else ensure_output_dir()
+        )
         ontology_path = conn_dir / session.ontology_file
 
         if not ontology_path.exists():
@@ -70,6 +75,7 @@ async def store_ontology_in_rdf(
         if session.connection_id:
             try:
                 from datetime import datetime
+
                 await update_workspace_section(
                     connection_id=session.connection_id,
                     output_dir=OUTPUT_DIR,
@@ -114,6 +120,7 @@ def _detect_sparql_type(sparql_query: str) -> str:
     stripped = sparql_query.strip()
     # Skip PREFIX declarations to find the actual query keyword
     import re
+
     body = re.sub(r"(?i)^\s*(PREFIX\s+\S+\s+<[^>]+>\s*)+", "", stripped).strip()
     upper = body.upper()
     if upper.startswith("ASK"):
@@ -218,7 +225,9 @@ async def add_rdf_knowledge(
             subject=subject, predicate=predicate, object=object_value, metadata=metadata
         )
 
-        await ctx.info(f"Added knowledge triple: <{subject}> <{predicate}> {object_value}")
+        await ctx.info(
+            f"Added knowledge triple: <{subject}> <{predicate}> {object_value}"
+        )
 
         return (
             f"Knowledge added successfully!\n\n"

--- a/src/handlers/schema.py
+++ b/src/handlers/schema.py
@@ -4,15 +4,14 @@ import asyncio
 import json
 import logging
 import os
-from typing import Optional, Dict, List, Any
+from typing import Any, Dict, List, Optional
 
 from fastmcp import Context
 
-from ..lifecycle.metadata import update_workspace_section
-from ..paths import ensure_output_dir, get_connection_dir, OUTPUT_DIR
-from ..r2rml_generator import R2RMLGenerator
-
 from ..handler_context import HandlerContext
+from ..lifecycle.metadata import update_workspace_section
+from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
+from ..r2rml_generator import R2RMLGenerator
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +78,9 @@ async def discover_schema(
         _auto_initialize_graphrag_background: Background init function
     """
     # Log function entry to verify code is being called
-    logger.debug(f"discover_schema() called - schema: '{schema_name}', lightweight: {lightweight}")
+    logger.debug(
+        f"discover_schema() called - schema: '{schema_name}', lightweight: {lightweight}"
+    )
 
     session = services.get_session_data(ctx)
     effective_schema = schema_name or ""
@@ -103,7 +104,9 @@ async def discover_schema(
 
     cached_tables = session.get_cached_schema(effective_schema)
 
-    logger.debug(f"Cache check result - cached_tables: {bool(cached_tables)} (count: {len(cached_tables) if cached_tables else 0})")
+    logger.debug(
+        f"Cache check result - cached_tables: {bool(cached_tables)} (count: {len(cached_tables) if cached_tables else 0})"
+    )
 
     if cached_tables:
         ontology_also_cached = session.ontology_file is not None
@@ -114,12 +117,22 @@ async def discover_schema(
         # Debug logging to diagnose auto-init issues
         logger.debug("GraphRAG auto-init check (CACHED path):")
         logger.debug(f"  AUTO_GRAPHRAG env: '{auto_graphrag}'")
-        logger.debug(f"  cached_tables exists: {bool(cached_tables)} (count: {len(cached_tables) if cached_tables else 0})")
+        logger.debug(
+            f"  cached_tables exists: {bool(cached_tables)} (count: {len(cached_tables) if cached_tables else 0})"
+        )
         logger.info(f"  session.graphrag_initialized: {session.graphrag_initialized}")
-        logger.debug(f"  Will trigger: {auto_graphrag == 'true' and cached_tables and not session.graphrag_initialized}")
+        logger.debug(
+            f"  Will trigger: {auto_graphrag == 'true' and cached_tables and not session.graphrag_initialized}"
+        )
 
-        if auto_graphrag == "true" and cached_tables and not session.graphrag_initialized:
-            logger.info(f"GraphRAG auto-init triggered for cached schema: {effective_schema or 'default'}")
+        if (
+            auto_graphrag == "true"
+            and cached_tables
+            and not session.graphrag_initialized
+        ):
+            logger.info(
+                f"GraphRAG auto-init triggered for cached schema: {effective_schema or 'default'}"
+            )
             task = asyncio.create_task(
                 services.auto_initialize_graphrag_background(
                     schema_name=effective_schema or "default",
@@ -129,7 +142,9 @@ async def discover_schema(
                 )
             )
             session.graphrag._init_task = task
-            logger.info("GraphRAG auto-initialization started in background (from cache)")
+            logger.info(
+                "GraphRAG auto-initialization started in background (from cache)"
+            )
 
         if ontology_also_cached:
             await ctx.info(
@@ -206,7 +221,9 @@ async def discover_schema(
                 logger.warning(f"Failed to analyze table {table_name}: {e}")
 
         session.cache_schema_analysis(schema_name or "", table_info_objects)
-        logger.info(f"Cached {len(table_info_objects)} tables for generate_ontology() reuse")
+        logger.info(
+            f"Cached {len(table_info_objects)} tables for generate_ontology() reuse"
+        )
 
         lightweight_result = {
             "schema": schema_name or "default",
@@ -227,11 +244,17 @@ async def discover_schema(
         # Debug logging to diagnose auto-init issues
         logger.debug("GraphRAG auto-init check (NON-CACHED path):")
         logger.debug(f"  AUTO_GRAPHRAG env: '{auto_graphrag}'")
-        logger.debug(f"  table_info_objects exists: {bool(table_info_objects)} (count: {len(table_info_objects) if table_info_objects else 0})")
-        logger.debug(f"  Will trigger: {auto_graphrag == 'true' and bool(table_info_objects)}")
+        logger.debug(
+            f"  table_info_objects exists: {bool(table_info_objects)} (count: {len(table_info_objects) if table_info_objects else 0})"
+        )
+        logger.debug(
+            f"  Will trigger: {auto_graphrag == 'true' and bool(table_info_objects)}"
+        )
 
         if auto_graphrag == "true" and table_info_objects:
-            logger.info(f"GraphRAG auto-init triggered for schema: {schema_name or 'default'}")
+            logger.info(
+                f"GraphRAG auto-init triggered for schema: {schema_name or 'default'}"
+            )
             task = asyncio.create_task(
                 services.auto_initialize_graphrag_background(
                     schema_name=schema_name or "default",
@@ -292,9 +315,15 @@ async def discover_schema(
     # Save schema analysis to connection-scoped output folder
     schema_filename = None
     try:
-        conn_dir = get_connection_dir(session.connection_id) if session.connection_id else ensure_output_dir()
+        conn_dir = (
+            get_connection_dir(session.connection_id)
+            if session.connection_id
+            else ensure_output_dir()
+        )
         schema_safe = (schema_name or "default").replace(" ", "_").replace(".", "_")
-        schema_filename = services.get_session_safe_filename(ctx, "schema", schema_safe) + ".json"
+        schema_filename = (
+            services.get_session_safe_filename(ctx, "schema", schema_safe) + ".json"
+        )
         schema_file_path = conn_dir / schema_filename
 
         with open(schema_file_path, "w", encoding="utf-8") as f:
@@ -312,10 +341,14 @@ async def discover_schema(
         if t.foreign_keys:
             relationships[t.name] = t.foreign_keys
             if len(t.foreign_keys) > 1:
-                fan_trap_warnings.append({
-                    "table": t.name,
-                    "referenced_tables": [fk["referenced_table"] for fk in t.foreign_keys],
-                })
+                fan_trap_warnings.append(
+                    {
+                        "table": t.name,
+                        "referenced_tables": [
+                            fk["referenced_table"] for fk in t.foreign_keys
+                        ],
+                    }
+                )
 
     schema_result = {
         "schema": schema_name or "default",
@@ -331,7 +364,11 @@ async def discover_schema(
     # Generate R2RML mapping
     if table_info_objects:
         try:
-            conn_dir = get_connection_dir(session.connection_id) if session.connection_id else ensure_output_dir()
+            conn_dir = (
+                get_connection_dir(session.connection_id)
+                if session.connection_id
+                else ensure_output_dir()
+            )
             from ..constants import DEFAULT_R2RML_BASE_IRI
 
             effective_schema = schema_name or "default"
@@ -342,13 +379,17 @@ async def discover_schema(
 
             database_name = db_manager.connection_info.get("database", "database")
 
-            r2rml_generator = R2RMLGenerator(base_iri=base_iri, database_name=database_name)
+            r2rml_generator = R2RMLGenerator(
+                base_iri=base_iri, database_name=database_name
+            )
             r2rml_content = r2rml_generator.generate_from_schema(
                 table_info_objects, schema_name=effective_schema
             )
 
             schema_safe = effective_schema.replace(" ", "_").replace(".", "_")
-            r2rml_filename = services.get_session_safe_filename(ctx, "r2rml", schema_safe) + ".ttl"
+            r2rml_filename = (
+                services.get_session_safe_filename(ctx, "r2rml", schema_safe) + ".ttl"
+            )
             r2rml_file_path = conn_dir / r2rml_filename
 
             with open(r2rml_file_path, "w", encoding="utf-8") as f:
@@ -359,7 +400,9 @@ async def discover_schema(
             schema_result["r2rml_file"] = r2rml_filename
             schema_result["r2rml_base_iri"] = base_iri
 
-            await ctx.info(f"R2RML mapping generated with {len(table_info_objects)} tables")
+            await ctx.info(
+                f"R2RML mapping generated with {len(table_info_objects)} tables"
+            )
         except Exception as e:
             logger.warning(f"Failed to generate R2RML mapping: {e}")
             schema_result["r2rml_error"] = str(e)
@@ -405,11 +448,17 @@ async def discover_schema(
     # Debug logging to diagnose auto-init issues
     logger.debug("GraphRAG auto-init check (FULL MODE path):")
     logger.debug(f"  AUTO_GRAPHRAG env: '{auto_graphrag}'")
-    logger.debug(f"  table_info_objects exists: {bool(table_info_objects)} (count: {len(table_info_objects) if table_info_objects else 0})")
-    logger.debug(f"  Will trigger: {auto_graphrag == 'true' and bool(table_info_objects)}")
+    logger.debug(
+        f"  table_info_objects exists: {bool(table_info_objects)} (count: {len(table_info_objects) if table_info_objects else 0})"
+    )
+    logger.debug(
+        f"  Will trigger: {auto_graphrag == 'true' and bool(table_info_objects)}"
+    )
 
     if auto_graphrag == "true" and table_info_objects:
-        logger.info(f"GraphRAG auto-init triggered for schema: {schema_name or 'default'}")
+        logger.info(
+            f"GraphRAG auto-init triggered for schema: {schema_name or 'default'}"
+        )
         task = asyncio.create_task(
             services.auto_initialize_graphrag_background(
                 schema_name=schema_name or "default",
@@ -427,6 +476,7 @@ async def discover_schema(
     if session.connection_id and schema_filename:
         try:
             from datetime import datetime
+
             await update_workspace_section(
                 connection_id=session.connection_id,
                 output_dir=OUTPUT_DIR,
@@ -503,7 +553,9 @@ async def get_table_details(
         table_info = db_manager.analyze_table(table_name, schema_name)
 
         if not table_info:
-            await ctx.error(f"Table '{table_name}' not found in schema '{schema_name or 'default'}'")
+            await ctx.error(
+                f"Table '{table_name}' not found in schema '{schema_name or 'default'}'"
+            )
             return {
                 "success": False,
                 "error": f"Table '{table_name}' not found",
@@ -534,7 +586,9 @@ async def get_table_details(
             "row_count": table_info.row_count,
         }
 
-        await ctx.info(f"Retrieved details for table '{table_name}': {len(table_info.columns)} columns")
+        await ctx.info(
+            f"Retrieved details for table '{table_name}': {len(table_info.columns)} columns"
+        )
         return table_dict
 
     except Exception as e:

--- a/src/handlers/workspace.py
+++ b/src/handlers/workspace.py
@@ -11,11 +11,10 @@ from fastmcp import Context
 
 from ..database_manager import TableInfo
 from ..graphrag import GraphRAGManager
+from ..handler_context import HandlerContext
 from ..lifecycle.metadata import VersionMetadataManager
 from ..oxigraph_store import OXIGRAPH_AVAILABLE
-from ..paths import OUTPUT_DIR, get_connection_dir, get_models_dir, ensure_output_dir
-
-from ..handler_context import HandlerContext
+from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir, get_models_dir
 
 logger = logging.getLogger(__name__)
 
@@ -251,7 +250,9 @@ def _format_restore_summary(result: Dict[str, Any]) -> str:
             lines.append("- suggest_semantic_names() to enrich the ontology")
     if "Ontology '" in restored_str:
         lines.append("- query_sparql() for semantic queries")
-        lines.append("- execute_sql_query() for data queries (includes OBQC validation)")
+        lines.append(
+            "- execute_sql_query() for data queries (includes OBQC validation)"
+        )
     if "GraphRAG" in restored_str:
         lines.append("- graphrag_search() for semantic schema search")
 
@@ -409,10 +410,13 @@ async def save_semantic_model(
     # Update workspace metadata
     try:
         mgr = VersionMetadataManager(connection_id, OUTPUT_DIR)
-        workspace = mgr.metadata.setdefault("workspace", {
-            "updated_at": datetime.now().isoformat(),
-            "schemas": {},
-        })
+        workspace = mgr.metadata.setdefault(
+            "workspace",
+            {
+                "updated_at": datetime.now().isoformat(),
+                "schemas": {},
+            },
+        )
         models = workspace.setdefault("models", {})
         models[model_name] = {
             "file": model_filename,
@@ -424,7 +428,9 @@ async def save_semantic_model(
     except Exception as e:
         logger.warning(f"Failed to update workspace metadata for model: {e}")
 
-    await ctx.info(f"Saved semantic model '{model_name}' for schema '{effective_schema}'")
+    await ctx.info(
+        f"Saved semantic model '{model_name}' for schema '{effective_schema}'"
+    )
 
     return {
         "success": True,

--- a/src/lifecycle/__init__.py
+++ b/src/lifecycle/__init__.py
@@ -4,14 +4,14 @@ Data Lifecycle Management
 Provides version tracking and cleanup for GraphRAG and RDF ontology data.
 """
 
-from .metadata import (
-    VersionMetadataManager,
-    VersionInfo,
-    RetentionPolicy,
-    update_workspace_section,
-    update_workspace_rdf,
-)
 from .cleanup import DataCleanupManager
+from .metadata import (
+    RetentionPolicy,
+    VersionInfo,
+    VersionMetadataManager,
+    update_workspace_rdf,
+    update_workspace_section,
+)
 
 __all__ = [
     "VersionMetadataManager",

--- a/src/lifecycle/cleanup.py
+++ b/src/lifecycle/cleanup.py
@@ -6,9 +6,9 @@ based on retention policies.
 """
 
 import logging
-from pathlib import Path
-from typing import Dict, Any, Optional
 from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
 
 from .metadata import VersionMetadataManager
 
@@ -34,9 +34,7 @@ class DataCleanupManager:
         self.metadata_mgr = VersionMetadataManager(connection_id, output_dir)
 
     def cleanup_graphrag(
-        self,
-        schema_name: str,
-        dry_run: bool = True
+        self, schema_name: str, dry_run: bool = True
     ) -> Dict[str, Any]:
         """
         Clean up old GraphRAG data based on retention policy.
@@ -49,15 +47,14 @@ class DataCleanupManager:
             Cleanup report
         """
         versions_to_delete = self.metadata_mgr.get_versions_to_cleanup(
-            schema_name,
-            data_type="graphrag"
+            schema_name, data_type="graphrag"
         )
 
         if not versions_to_delete:
             return {
                 "deleted": [],
                 "kept_all": True,
-                "reason": "All versions within retention policy"
+                "reason": "All versions within retention policy",
             }
 
         deleted = []
@@ -71,38 +68,35 @@ class DataCleanupManager:
 
                     # Mark as deleted in metadata
                     self.metadata_mgr.mark_version_deleted(
-                        schema_name,
-                        version.version,
-                        "graphrag"
+                        schema_name, version.version, "graphrag"
                     )
 
-                age_days = (datetime.now() - datetime.fromisoformat(version.created_at)).days
+                age_days = (
+                    datetime.now() - datetime.fromisoformat(version.created_at)
+                ).days
 
-                deleted.append({
-                    "version": version.version,
-                    "age_days": age_days,
-                    "created_at": version.created_at,
-                    "reason": f"Age {age_days} days exceeds max {self.metadata_mgr.get_retention_policy().graphrag_max_age_days} days"
-                })
+                deleted.append(
+                    {
+                        "version": version.version,
+                        "age_days": age_days,
+                        "created_at": version.created_at,
+                        "reason": f"Age {age_days} days exceeds max {self.metadata_mgr.get_retention_policy().graphrag_max_age_days} days",
+                    }
+                )
 
             except Exception as e:
-                logger.error(f"Failed to delete GraphRAG version {version.version}: {e}")
-                errors.append({
-                    "version": version.version,
-                    "error": str(e)
-                })
+                logger.error(
+                    f"Failed to delete GraphRAG version {version.version}: {e}"
+                )
+                errors.append({"version": version.version, "error": str(e)})
 
-        return {
-            "deleted": deleted,
-            "errors": errors,
-            "dry_run": dry_run
-        }
+        return {"deleted": deleted, "errors": errors, "dry_run": dry_run}
 
     def cleanup_ontology(
         self,
         schema_name: str,
         dry_run: bool = True,
-        oxigraph_store: Optional[Any] = None
+        oxigraph_store: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """
         Clean up old RDF ontology data based on retention policy.
@@ -116,15 +110,14 @@ class DataCleanupManager:
             Cleanup report
         """
         versions_to_delete = self.metadata_mgr.get_versions_to_cleanup(
-            schema_name,
-            data_type="ontology"
+            schema_name, data_type="ontology"
         )
 
         if not versions_to_delete:
             return {
                 "deleted": [],
                 "kept_all": True,
-                "reason": "All versions within retention policy"
+                "reason": "All versions within retention policy",
             }
 
         deleted = []
@@ -143,38 +136,37 @@ class DataCleanupManager:
                         try:
                             oxigraph_store.delete_graph(version.ontology_graph_uri)
                         except Exception as e:
-                            logger.warning(f"Failed to delete graph {version.ontology_graph_uri}: {e}")
+                            logger.warning(
+                                f"Failed to delete graph {version.ontology_graph_uri}: {e}"
+                            )
 
                     # Mark as deleted in metadata
                     self.metadata_mgr.mark_version_deleted(
-                        schema_name,
-                        version.version,
-                        "ontology"
+                        schema_name, version.version, "ontology"
                     )
 
-                age_days = (datetime.now() - datetime.fromisoformat(version.created_at)).days
+                age_days = (
+                    datetime.now() - datetime.fromisoformat(version.created_at)
+                ).days
 
-                deleted.append({
-                    "version": version.version,
-                    "age_days": age_days,
-                    "created_at": version.created_at,
-                    "graph_uri": version.ontology_graph_uri,
-                    "ttl_file": version.ontology_ttl_file,
-                    "reason": f"Age {age_days} days exceeds max {self.metadata_mgr.get_retention_policy().ontology_max_age_days} days"
-                })
+                deleted.append(
+                    {
+                        "version": version.version,
+                        "age_days": age_days,
+                        "created_at": version.created_at,
+                        "graph_uri": version.ontology_graph_uri,
+                        "ttl_file": version.ontology_ttl_file,
+                        "reason": f"Age {age_days} days exceeds max {self.metadata_mgr.get_retention_policy().ontology_max_age_days} days",
+                    }
+                )
 
             except Exception as e:
-                logger.error(f"Failed to delete Ontology version {version.version}: {e}")
-                errors.append({
-                    "version": version.version,
-                    "error": str(e)
-                })
+                logger.error(
+                    f"Failed to delete Ontology version {version.version}: {e}"
+                )
+                errors.append({"version": version.version, "error": str(e)})
 
-        return {
-            "deleted": deleted,
-            "errors": errors,
-            "dry_run": dry_run
-        }
+        return {"deleted": deleted, "errors": errors, "dry_run": dry_run}
 
     def _delete_graphrag_files(self, schema_name: str, version: int):
         """
@@ -190,13 +182,15 @@ class DataCleanupManager:
             # ChromaDB collections are managed by ChromaDB itself
             # We'll need to use the ChromaDB client to delete collections
             # For now, just log
-            logger.info(f"ChromaDB collection cleanup for version {version} (managed by ChromaDB)")
+            logger.info(
+                f"ChromaDB collection cleanup for version {version} (managed by ChromaDB)"
+            )
 
         # Check for JSON files (legacy or backup)
         json_patterns = [
             f"vector_store_{schema_name}_v{version}.json",
             f"graph_{schema_name}_v{version}.json",
-            f"communities_{schema_name}_v{version}.json"
+            f"communities_{schema_name}_v{version}.json",
         ]
 
         for pattern in json_patterns:
@@ -204,4 +198,3 @@ class DataCleanupManager:
             if file_path.exists():
                 file_path.unlink()
                 logger.info(f"Deleted {file_path}")
-

--- a/src/lifecycle/metadata.py
+++ b/src/lifecycle/metadata.py
@@ -9,10 +9,10 @@ Also manages workspace state for session restore across reconnections.
 import asyncio
 import json
 import logging
-from pathlib import Path
-from typing import Dict, List, Any, Optional
+from dataclasses import asdict, dataclass
 from datetime import datetime
-from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +23,7 @@ _metadata_locks: Dict[str, asyncio.Lock] = {}
 @dataclass
 class VersionInfo:
     """Information about a specific version."""
+
     version: int
     created_at: str  # ISO format
     schema_hash: str
@@ -49,6 +50,7 @@ class VersionInfo:
 @dataclass
 class RetentionPolicy:
     """Retention policy for cleanup."""
+
     graphrag_keep_versions: int = 3
     graphrag_max_age_days: int = 30
     ontology_keep_versions: int = 5
@@ -85,7 +87,7 @@ class VersionMetadataManager:
         """Load metadata from disk or create new."""
         if self.metadata_file.exists():
             try:
-                with open(self.metadata_file, 'r') as f:
+                with open(self.metadata_file, "r") as f:
                     metadata = json.load(f)
                 logger.debug(f"Loaded metadata for connection {self.connection_id}")
                 return metadata
@@ -102,13 +104,13 @@ class VersionMetadataManager:
             "connection_id": self.connection_id,
             "connection": {},  # Will be filled with connection details
             "schemas": {},
-            "retention_policy": asdict(RetentionPolicy())
+            "retention_policy": asdict(RetentionPolicy()),
         }
 
     def _save_metadata(self):
         """Save metadata to disk."""
         try:
-            with open(self.metadata_file, 'w') as f:
+            with open(self.metadata_file, "w") as f:
                 json.dump(self.metadata, f, indent=2)
             logger.debug(f"Saved metadata for connection {self.connection_id}")
         except Exception as e:
@@ -139,7 +141,7 @@ class VersionMetadataManager:
     def get_versions_to_cleanup(
         self,
         schema_name: str,
-        data_type: str = "all"  # "graphrag", "ontology", or "all"
+        data_type: str = "all",  # "graphrag", "ontology", or "all"
     ) -> List[VersionInfo]:
         """
         Get versions that should be cleaned up based on retention policy.
@@ -168,7 +170,7 @@ class VersionMetadataManager:
                 policy.graphrag_keep_versions,
                 policy.graphrag_max_age_days,
                 policy.min_versions,
-                "graphrag_status"
+                "graphrag_status",
             )
         elif data_type == "ontology":
             return self._get_cleanup_list(
@@ -176,7 +178,7 @@ class VersionMetadataManager:
                 policy.ontology_keep_versions,
                 policy.ontology_max_age_days,
                 policy.min_versions,
-                "ontology_status"
+                "ontology_status",
             )
         else:  # "all"
             # For "all", only delete if BOTH are eligible
@@ -185,14 +187,14 @@ class VersionMetadataManager:
                 policy.graphrag_keep_versions,
                 policy.graphrag_max_age_days,
                 policy.min_versions,
-                "graphrag_status"
+                "graphrag_status",
             )
             ontology_cleanup = self._get_cleanup_list(
                 versions,
                 policy.ontology_keep_versions,
                 policy.ontology_max_age_days,
                 policy.min_versions,
-                "ontology_status"
+                "ontology_status",
             )
 
             # Intersection - only delete if both agree
@@ -208,7 +210,7 @@ class VersionMetadataManager:
         keep_count: int,
         max_age_days: int,
         min_versions: int,
-        status_field: str
+        status_field: str,
     ) -> List[VersionInfo]:
         """
         Get versions to cleanup based on policy.
@@ -260,10 +262,7 @@ class VersionMetadataManager:
         return to_delete
 
     def mark_version_deleted(
-        self,
-        schema_name: str,
-        version: int,
-        data_type: str = "all"
+        self, schema_name: str, version: int, data_type: str = "all"
     ):
         """
         Mark a version as deleted in metadata.

--- a/src/main.py
+++ b/src/main.py
@@ -96,8 +96,25 @@ from .resources import register_resources  # noqa: E402
 register_resources(mcp)
 
 
+from .handler_context import HandlerContext  # noqa: E402
+
+# --- Handler imports (Task 7: C1/S2) ---
+# Imported here to keep the handler layer decoupled from server setup.
+from .handlers import chart as _h_chart  # noqa: E402
+from .handlers import connection as _h_connection  # noqa: E402
+from .handlers import graphrag as _h_graphrag  # noqa: E402
+from .handlers import ontology as _h_ontology  # noqa: E402
+from .handlers import query as _h_query  # noqa: E402
+from .handlers import rdf as _h_rdf  # noqa: E402
+from .handlers import schema as _h_schema  # noqa: E402
+from .handlers import workspace as _h_workspace  # noqa: E402
+
 # --- Session state and per-request helpers (extracted to server_state) ---
-from .server_state import (  # noqa: E402
+# ServerState and _calculate_schema_hash are re-exported for tests that import
+# them from main; F401 is suppressed for this re-export block.
+from .server_state import (  # noqa: E402, F401
+    ServerState,
+    _calculate_schema_hash,
     _clear_session_state,
     _get_connection_fingerprint,
     _server_state,
@@ -109,9 +126,6 @@ from .server_state import (  # noqa: E402
     get_session_safe_filename,
     load_ontology_from_session,
 )
-
-# Re-exported for backward compatibility with tests that import these from main.
-from .server_state import ServerState, _calculate_schema_hash  # noqa: E402,F401
 
 # --- Constrained MCP parameter types (extracted to tool_types) ---
 from .tool_types import (  # noqa: E402
@@ -125,19 +139,6 @@ from .tool_types import (  # noqa: E402
     _ShortText,
     _Uri,
 )
-
-from .handler_context import HandlerContext  # noqa: E402
-
-# --- Handler imports (Task 7: C1/S2) ---
-# Imported here to keep the handler layer decoupled from server setup.
-from .handlers import chart as _h_chart  # noqa: E402
-from .handlers import connection as _h_connection  # noqa: E402
-from .handlers import graphrag as _h_graphrag  # noqa: E402
-from .handlers import ontology as _h_ontology  # noqa: E402
-from .handlers import query as _h_query  # noqa: E402
-from .handlers import rdf as _h_rdf  # noqa: E402
-from .handlers import schema as _h_schema  # noqa: E402
-from .handlers import workspace as _h_workspace  # noqa: E402
 
 
 def _services() -> HandlerContext:
@@ -185,7 +186,8 @@ async def connect_database(ctx: Context, db_type: _DbType) -> str:
         Connection status with auto-restored workspace summary if available
     """
     return await _h_connection.connect_database(
-        ctx, db_type,
+        ctx,
+        db_type,
         services=_services(),
     )
 
@@ -231,7 +233,9 @@ async def discover_schema(
                      If False, return full schema with all column details.
     """
     return await _h_schema.discover_schema(
-        ctx, schema_name, lightweight,
+        ctx,
+        schema_name,
+        lightweight,
         services=_services(),
     )
 
@@ -254,7 +258,9 @@ async def get_table_details(
         schema_name: Schema containing the table (optional, auto-detected)
     """
     return await _h_schema.get_table_details(
-        ctx, table_name, schema_name,
+        ctx,
+        table_name,
+        schema_name,
         services=_services(),
     )
 
@@ -281,7 +287,12 @@ async def generate_ontology(
         Ontology TTL or status message
     """
     return await _h_ontology.generate_ontology(
-        ctx, schema_info, schema_name, base_uri, auto_persist, graph_uri,
+        ctx,
+        schema_info,
+        schema_name,
+        base_uri,
+        auto_persist,
+        graph_uri,
         services=_services(),
     )
 
@@ -305,7 +316,8 @@ async def suggest_semantic_names(
         Dictionary containing extracted names, analysis results, and instructions
     """
     return await _h_ontology.suggest_semantic_names(
-        ctx, ontology_file,
+        ctx,
+        ontology_file,
         services=_services(),
     )
 
@@ -342,7 +354,10 @@ async def apply_semantic_names(
         save_to_file: Whether to save the updated ontology to a file
     """
     return await _h_ontology.apply_semantic_names(
-        ctx, suggestions, ontology_file, save_to_file,
+        ctx,
+        suggestions,
+        ontology_file,
+        save_to_file,
         services=_services(),
     )
 
@@ -372,7 +387,10 @@ async def load_my_ontology(
         Dictionary with ontology information and status
     """
     return await _h_ontology.load_my_ontology(
-        ctx, import_folder, auto_persist, graph_uri,
+        ctx,
+        import_folder,
+        auto_persist,
+        graph_uri,
         ontology_content=ontology_content,
         file_name=file_name,
         services=_services(),
@@ -398,13 +416,13 @@ async def download_artifact(
     """
     if artifact_type == "ontology":
         return await _h_ontology.download_ontology(
-            ctx, schema_name, source,
+            ctx,
+            schema_name,
+            source,
             services=_services(),
         )
     elif artifact_type == "r2rml":
-        return await _h_ontology.download_r2rml(
-            ctx, schema_name, services=_services()
-        )
+        return await _h_ontology.download_r2rml(ctx, schema_name, services=_services())
     else:
         return create_error_response(
             f"Invalid artifact_type: {artifact_type}. Must be 'ontology' or 'r2rml'.",
@@ -429,7 +447,10 @@ async def sample_table_data(
         limit: Maximum number of rows to return (default: 10, max: 100)
     """
     return await _h_schema.sample_table_data(
-        ctx, table_name, schema_name, limit,
+        ctx,
+        table_name,
+        schema_name,
+        limit,
         services=_services(),
     )
 
@@ -463,7 +484,11 @@ async def execute_sql_query(
         query_intent: Optional natural language description of query intent
     """
     return await _h_query.execute_sql_query(
-        ctx, sql_query, limit, checklist_completed, query_intent,
+        ctx,
+        sql_query,
+        limit,
+        checklist_completed,
+        query_intent,
         services=_services(),
     )
 
@@ -471,7 +496,9 @@ async def execute_sql_query(
 @mcp.tool()
 async def generate_chart(
     ctx: Context,
-    data_source: Union[List[Dict[str, Any]], Annotated[str, Field(max_length=5_000_000)]],
+    data_source: Union[
+        List[Dict[str, Any]], Annotated[str, Field(max_length=5_000_000)]
+    ],
     chart_type: Literal["bar", "line", "scatter", "heatmap"],
     x_column: _Identifier,
     y_column: Optional[Union[_Identifier, List[_Identifier]]] = None,
@@ -497,9 +524,17 @@ async def generate_chart(
         output_format: "interactive" (default, responsive MCP Apps widget) or "image" (saves PNG file)
     """
     return await _h_chart.generate_chart(
-        ctx, data_source, chart_type, x_column, y_column,
-        color_column, title, chart_style,
-        sort_by, sort_order, output_format,
+        ctx,
+        data_source,
+        chart_type,
+        x_column,
+        y_column,
+        color_column,
+        title,
+        chart_style,
+        sort_by,
+        sort_order,
+        output_format,
         services=_services(),
     )
 
@@ -541,7 +576,10 @@ async def save_semantic_model(
         schema_name: Database schema this model is based on (auto-detected if omitted)
     """
     return await _h_workspace.save_semantic_model(
-        ctx, model_yaml, model_name, schema_name,
+        ctx,
+        model_yaml,
+        model_name,
+        schema_name,
         services=_services(),
     )
 
@@ -560,7 +598,8 @@ async def get_semantic_model(
         model_name: Name of the model to retrieve
     """
     return await _h_workspace.get_semantic_model(
-        ctx, model_name,
+        ctx,
+        model_name,
         services=_services(),
     )
 
@@ -579,6 +618,7 @@ async def list_semantic_models(ctx: Context) -> Dict[str, Any]:
 
 
 # --- GraphRAG Tools ---
+
 
 @mcp.tool()
 async def graphrag_search(
@@ -603,16 +643,17 @@ async def graphrag_search(
         Dictionary with search results or schema overview
     """
     if overview:
-        return await _h_graphrag.graphrag_overview(
-            ctx, services=_services()
-        )
+        return await _h_graphrag.graphrag_overview(ctx, services=_services())
     if not query:
         return create_error_response(
             "query parameter is required when overview=False",
             "parameter_error",
         )
     return await _h_graphrag.graphrag_search(
-        ctx, query, top_k, element_type,
+        ctx,
+        query,
+        top_k,
+        element_type,
         services=_services(),
     )
 
@@ -635,7 +676,10 @@ async def graphrag_query_context(
         Optimized context with relevant tables, columns, relationships
     """
     return await _h_graphrag.graphrag_query_context(
-        ctx, query, max_tables, max_columns,
+        ctx,
+        query,
+        max_tables,
+        max_columns,
         services=_services(),
     )
 
@@ -658,7 +702,10 @@ async def graphrag_find_join_path(
         Dictionary with join path specifications
     """
     return await _h_graphrag.graphrag_find_join_path(
-        ctx, from_table, to_table, max_hops,
+        ctx,
+        from_table,
+        to_table,
+        max_hops,
         services=_services(),
     )
 
@@ -686,7 +733,9 @@ async def reachable_from(
         Dictionary with reachable (dimension-capable) tables and per-hop breakdown
     """
     return await _h_graphrag.reachable_from(
-        ctx, table, max_hops,
+        ctx,
+        table,
+        max_hops,
         services=_services(),
     )
 
@@ -712,7 +761,9 @@ async def measurable_from(
         Dictionary with measure-capable tables and per-hop breakdown
     """
     return await _h_graphrag.measurable_from(
-        ctx, table, max_hops,
+        ctx,
+        table,
+        max_hops,
         services=_services(),
     )
 
@@ -744,12 +795,15 @@ async def plan_composite_query(
         per-leg dimension/NULL-pad decomposition
     """
     return await _h_graphrag.plan_composite_query(
-        ctx, facts, dimensions,
+        ctx,
+        facts,
+        dimensions,
         services=_services(),
     )
 
 
 # --- Oxigraph RDF Store & SPARQL Tools ---
+
 
 @mcp.tool()
 async def store_ontology_in_rdf(
@@ -767,7 +821,9 @@ async def store_ontology_in_rdf(
         Status message with triple count
     """
     return await _h_rdf.store_ontology_in_rdf(
-        ctx, schema_name, graph_uri,
+        ctx,
+        schema_name,
+        graph_uri,
         services=_services(),
     )
 
@@ -794,7 +850,9 @@ async def query_sparql(
         Query results (bindings for SELECT, boolean for ASK, Turtle string for CONSTRUCT)
     """
     return await _h_rdf.query_sparql(
-        ctx, sparql_query, timeout_seconds,
+        ctx,
+        sparql_query,
+        timeout_seconds,
         services=_services(),
     )
 
@@ -819,12 +877,17 @@ async def add_rdf_knowledge(
         Confirmation message
     """
     return await _h_rdf.add_rdf_knowledge(
-        ctx, subject, predicate, object, metadata,
+        ctx,
+        subject,
+        predicate,
+        object,
+        metadata,
         services=_services(),
     )
 
 
 # --- Cleanup on shutdown ---
+
 
 def cleanup_server():
     """Clean up server resources."""

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -11,10 +11,10 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Set
 
 import sqlglot
+from rdflib import Graph, Namespace, URIRef
+from rdflib.namespace import OWL, RDF, RDFS, XSD
 from sqlglot import exp
 from sqlglot.errors import ParseError
-from rdflib import Graph, Namespace, URIRef
-from rdflib.namespace import RDF, RDFS, OWL, XSD
 
 from .constants import DB_SQLGLOT_DIALECTS, OBA_NAMESPACE
 
@@ -256,9 +256,13 @@ class OBQCValidator:
                     col_schema = ColumnSchema(
                         name=column_name,
                         table_name=table_name,
-                        sql_data_type=self._get_literal(subject, self._oba_ns.sqlDataType)
+                        sql_data_type=self._get_literal(
+                            subject, self._oba_ns.sqlDataType
+                        )
                         or "VARCHAR",
-                        is_nullable=self._get_bool(subject, self._oba_ns.isNullable, True),
+                        is_nullable=self._get_bool(
+                            subject, self._oba_ns.isNullable, True
+                        ),
                         is_primary_key=self._get_bool(
                             subject, self._oba_ns.isPrimaryKey, False
                         ),
@@ -595,7 +599,8 @@ class OBQCValidator:
                         severity=OBQCSeverity.WARNING,
                         message="JOIN condition may not match declared FK relationship",
                         location=f"JOIN {join_table}",
-                        suggestion=suggested or "Verify join matches foreign key constraint",
+                        suggestion=suggested
+                        or "Verify join matches foreign key constraint",
                         related_entities=[join_table] if join_table else [],
                     )
                 )
@@ -713,7 +718,10 @@ class OBQCValidator:
 
         def get_type_category(xsd_uri: str) -> str:
             uri_lower = xsd_uri.lower()
-            if any(t in uri_lower for t in ["integer", "decimal", "float", "double", "byte"]):
+            if any(
+                t in uri_lower
+                for t in ["integer", "decimal", "float", "double", "byte"]
+            ):
                 return "numeric"
             elif "string" in uri_lower:
                 return "string"
@@ -768,7 +776,10 @@ class OBQCValidator:
                         qualified = f"{col_table.lower()}.{col_name.lower()}"
 
                     # Check if it's in GROUP BY
-                    if qualified not in group_by_cols and col_name.lower() not in group_by_cols:
+                    if (
+                        qualified not in group_by_cols
+                        and col_name.lower() not in group_by_cols
+                    ):
                         # Check if it's inside an aggregate function
                         is_aggregated = self._is_inside_aggregate(expr, select)
 
@@ -794,9 +805,7 @@ class OBQCValidator:
                                     )
                                 )
 
-    def _is_inside_aggregate(
-        self, expr: exp.Expression, select: exp.Select
-    ) -> bool:
+    def _is_inside_aggregate(self, expr: exp.Expression, select: exp.Select) -> bool:
         """Check if expression is inside an aggregate function."""
         agg_types = (exp.Sum, exp.Count, exp.Avg, exp.Min, exp.Max)
 
@@ -804,7 +813,9 @@ class OBQCValidator:
             for col in agg.find_all(exp.Column):
                 if isinstance(expr, exp.Column):
                     if col.name == expr.name:
-                        if (col.table is None and expr.table is None) or col.table == expr.table:
+                        if (
+                            col.table is None and expr.table is None
+                        ) or col.table == expr.table:
                             return True
                 elif isinstance(expr, exp.Alias) and isinstance(expr.this, exp.Column):
                     if col.name == expr.this.name:

--- a/src/ontology_generator.py
+++ b/src/ontology_generator.py
@@ -3,16 +3,20 @@
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import List, Dict, Any, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from rdflib import Graph, Literal, Namespace, URIRef
 from rdflib.collection import Collection
-from rdflib.namespace import RDF, RDFS, OWL, XSD
-
+from rdflib.namespace import OWL, RDF, RDFS, XSD
 from wordfreq import word_frequency
 
-from .constants import DEFAULT_BASE_URI, OBA_NAMESPACE, ONTOLOGY_TITLE, ONTOLOGY_DESCRIPTION
-from .database_manager import TableInfo, ColumnInfo
+from .constants import (
+    DEFAULT_BASE_URI,
+    OBA_NAMESPACE,
+    ONTOLOGY_DESCRIPTION,
+    ONTOLOGY_TITLE,
+)
+from .database_manager import ColumnInfo, TableInfo
 
 # Minimum word frequency threshold (in Zipf scale ~1e-6).
 # Words below this are considered non-English / abbreviations.
@@ -25,10 +29,10 @@ _KNOWN_DB_SUFFIXES = {"id", "pk", "fk", "idx", "seq"}
 logger = logging.getLogger(__name__)
 
 
-
 @dataclass
 class InferredRelationship:
     """Represents a relationship inferred from naming patterns."""
+
     source_table: str
     column: str
     target_table: str
@@ -40,6 +44,7 @@ class InferredRelationship:
 @dataclass
 class DenormalizedField:
     """Represents a detected denormalized field."""
+
     table: str
     column: str
     likely_source_table: str
@@ -50,6 +55,7 @@ class DenormalizedField:
 @dataclass
 class OntologyQualityReport:
     """Report on ontology generation quality."""
+
     inferred_relationships: List[InferredRelationship] = field(default_factory=list)
     denormalized_fields: List[DenormalizedField] = field(default_factory=list)
     type_overrides: List[Dict[str, str]] = field(default_factory=list)
@@ -66,7 +72,7 @@ class OntologyQualityReport:
                     "target_table": r.target_table,
                     "target_column": r.target_column,
                     "confidence": r.confidence,
-                    "pattern_matched": r.pattern_matched
+                    "pattern_matched": r.pattern_matched,
                 }
                 for r in self.inferred_relationships
             ],
@@ -75,7 +81,7 @@ class OntologyQualityReport:
                     "table": d.table,
                     "column": d.column,
                     "likely_source_table": d.likely_source_table,
-                    "warning": d.warning
+                    "warning": d.warning,
                 }
                 for d in self.denormalized_fields
             ],
@@ -87,9 +93,10 @@ class OntologyQualityReport:
                 "denormalized_field_count": len(self.denormalized_fields),
                 "type_override_count": len(self.type_overrides),
                 "missing_description_count": len(self.missing_descriptions),
-                "warning_count": len(self.warnings)
-            }
+                "warning_count": len(self.warnings),
+            },
         }
+
 
 class OntologyGenerator:
     """Generates an ontology from a database schema with comprehensive database annotations."""
@@ -97,24 +104,33 @@ class OntologyGenerator:
     # Patterns for inferring FK relationships from column names
     FK_PATTERNS = [
         # Pattern: suppliercountryid → country/countries
-        (r'^(.+?)(?:_)?id$', 'suffix_id'),
+        (r"^(.+?)(?:_)?id$", "suffix_id"),
         # Pattern: id_country → country
-        (r'^id[_]?(.+)$', 'prefix_id'),
+        (r"^id[_]?(.+)$", "prefix_id"),
         # Pattern: fk_country → country
-        (r'^fk[_]?(.+)$', 'prefix_fk'),
+        (r"^fk[_]?(.+)$", "prefix_fk"),
         # Pattern: country_fk → country
-        (r'^(.+?)[_]?fk$', 'suffix_fk'),
+        (r"^(.+?)[_]?fk$", "suffix_fk"),
         # Pattern: customer_sk → customer (TPC-DS style surrogate keys)
-        (r'^(.+?)(?:_)?sk$', 'suffix_sk'),
+        (r"^(.+?)(?:_)?sk$", "suffix_sk"),
         # Pattern: ss_customer_sk → customer (TPC-DS with table prefix)
-        (r'^[a-z]{1,3}_(.+?)(?:_)?sk$', 'tpcds_sk'),
+        (r"^[a-z]{1,3}_(.+?)(?:_)?sk$", "tpcds_sk"),
     ]
 
     # Column name patterns that indicate quantities (should be integers)
-    QUANTITY_PATTERNS = ['quantity', 'qty', 'count', 'cnt', 'number', 'num', 'amount', 'amt']
+    QUANTITY_PATTERNS = [
+        "quantity",
+        "qty",
+        "count",
+        "cnt",
+        "number",
+        "num",
+        "amount",
+        "amt",
+    ]
 
     # Patterns for denormalized text fields
-    DENORM_SUFFIXES = ['name', 'title', 'description', 'desc', 'label']
+    DENORM_SUFFIXES = ["name", "title", "description", "desc", "label"]
 
     def __init__(self, base_uri: str = DEFAULT_BASE_URI):
         self.graph = Graph()
@@ -177,7 +193,7 @@ class OntologyGenerator:
         self,
         tables_info: List[TableInfo],
         include_inferred_relationships: bool = True,
-        annotate_denormalized: bool = True
+        annotate_denormalized: bool = True,
     ) -> str:
         """Generate an ontology from a list of table information with quality enhancements.
 
@@ -224,7 +240,9 @@ class OntologyGenerator:
 
             for denorm in denormalized:
                 self._add_denormalized_field_annotation(denorm)
-                logger.info(f"Annotated denormalized field: {denorm.table}.{denorm.column}")
+                logger.info(
+                    f"Annotated denormalized field: {denorm.table}.{denorm.column}"
+                )
 
         # Generate OWL axioms from relationship structure
         self._add_disjoint_axioms(tables_info)
@@ -265,17 +283,19 @@ class OntologyGenerator:
         # Define table as a class
         self.graph.add((table_uri, RDF.type, OWL.Class))
         self.graph.add((table_uri, RDFS.label, Literal(table_info.name)))
-        
+
         # Add comprehensive database-specific annotations
         self.graph.add((table_uri, self.oba_ns.tableName, Literal(table_info.name)))
         self.graph.add((table_uri, self.oba_ns.schemaName, Literal(table_info.schema)))
-        
+
         if table_info.row_count is not None:
-            self.graph.add((table_uri, self.oba_ns.rowCount, Literal(table_info.row_count)))
-            
+            self.graph.add(
+                (table_uri, self.oba_ns.rowCount, Literal(table_info.row_count))
+            )
+
         if table_info.comment:
             self.graph.add((table_uri, RDFS.comment, Literal(table_info.comment)))
-            
+
         # Add primary key information
         if table_info.primary_keys:
             for pk in table_info.primary_keys:
@@ -289,7 +309,9 @@ class OntologyGenerator:
         for fk in table_info.foreign_keys:
             self._add_relationship_to_ontology(table_uri, fk, table_info.name)
 
-    def _add_column_to_ontology(self, table_uri: URIRef, column: ColumnInfo, table_name: str):
+    def _add_column_to_ontology(
+        self, table_uri: URIRef, column: ColumnInfo, table_name: str
+    ):
         """Add a column as a data property to the ontology with comprehensive database annotations."""
         # Create proper property URI
         prop_name = f"{self._clean_name(table_name)}_{self._clean_name(column.name)}"
@@ -307,8 +329,12 @@ class OntologyGenerator:
         self.graph.add((prop_uri, self.oba_ns.tableName, Literal(table_name)))
         self.graph.add((prop_uri, self.oba_ns.sqlDataType, Literal(column.data_type)))
         self.graph.add((prop_uri, self.oba_ns.isNullable, Literal(column.is_nullable)))
-        self.graph.add((prop_uri, self.oba_ns.isPrimaryKey, Literal(column.is_primary_key)))
-        self.graph.add((prop_uri, self.oba_ns.isForeignKey, Literal(column.is_foreign_key)))
+        self.graph.add(
+            (prop_uri, self.oba_ns.isPrimaryKey, Literal(column.is_primary_key))
+        )
+        self.graph.add(
+            (prop_uri, self.oba_ns.isForeignKey, Literal(column.is_foreign_key))
+        )
 
         # Add SQL query generation hints
         full_column_ref = f"{table_name}.{column.name}"
@@ -325,11 +351,13 @@ class OntologyGenerator:
         if type_override and self.quality_report:
             self.quality_report.type_overrides.append(type_override)
             # Also add annotation to the property
-            self.graph.add((
-                prop_uri,
-                self.oba_ns.typeOverrideReason,
-                Literal(type_override["reason"])
-            ))
+            self.graph.add(
+                (
+                    prop_uri,
+                    self.oba_ns.typeOverrideReason,
+                    Literal(type_override["reason"]),
+                )
+            )
 
         # Note: Primary key and nullability constraints are already captured
         # in the metadata annotations (oba:isPrimaryKey, oba:isNullable).
@@ -339,39 +367,55 @@ class OntologyGenerator:
         if column.comment:
             self.graph.add((prop_uri, RDFS.comment, Literal(column.comment)))
 
-    def _add_relationship_to_ontology(self, table_uri: URIRef, fk: Dict[str, str], table_name: str):
+    def _add_relationship_to_ontology(
+        self, table_uri: URIRef, fk: Dict[str, str], table_name: str
+    ):
         """Add a foreign key relationship as an object property with comprehensive database annotations."""
-        referenced_table = fk.get('referenced_table')
+        referenced_table = fk.get("referenced_table")
         if not referenced_table:
             logger.warning(f"FK from {table_name} missing referenced_table: {fk}")
             return
 
         # Create descriptive relationship name
-        rel_name = f"{self._clean_name(table_name)}_has_{self._clean_name(referenced_table)}"
+        rel_name = (
+            f"{self._clean_name(table_name)}_has_{self._clean_name(referenced_table)}"
+        )
         prop_uri = self.base_uri[rel_name]
         referenced_table_uri = self.base_uri[self._clean_name(referenced_table)]
 
-        referenced_column = fk.get('referenced_column', 'id')
-        fk_column = fk.get('column', '')
-        referenced_schema = fk.get('referenced_schema')
+        referenced_column = fk.get("referenced_column", "id")
+        fk_column = fk.get("column", "")
+        referenced_schema = fk.get("referenced_schema")
 
         self.graph.add((prop_uri, RDF.type, OWL.ObjectProperty))
         # Many-to-one: each source row references at most one target row
         self.graph.add((prop_uri, RDF.type, OWL.FunctionalProperty))
         self.graph.add((prop_uri, RDFS.domain, table_uri))
         self.graph.add((prop_uri, RDFS.range, referenced_table_uri))
-        self.graph.add((prop_uri, RDFS.label, Literal(f"{table_name} has {referenced_table}")))
+        self.graph.add(
+            (prop_uri, RDFS.label, Literal(f"{table_name} has {referenced_table}"))
+        )
 
         # Add comprehensive database-specific annotations for foreign keys
         self.graph.add((prop_uri, self.oba_ns.foreignKeyColumn, Literal(fk_column)))
-        self.graph.add((prop_uri, self.oba_ns.referencedTable, Literal(referenced_table)))
-        self.graph.add((prop_uri, self.oba_ns.referencedColumn, Literal(referenced_column)))
+        self.graph.add(
+            (prop_uri, self.oba_ns.referencedTable, Literal(referenced_table))
+        )
+        self.graph.add(
+            (prop_uri, self.oba_ns.referencedColumn, Literal(referenced_column))
+        )
         if referenced_schema:
-            self.graph.add((prop_uri, self.oba_ns.referencedSchema, Literal(referenced_schema)))
+            self.graph.add(
+                (prop_uri, self.oba_ns.referencedSchema, Literal(referenced_schema))
+            )
 
         # Add SQL join condition
-        join_condition = f"{table_name}.{fk_column} = {referenced_table}.{referenced_column}"
-        self.graph.add((prop_uri, self.oba_ns.sqlJoinCondition, Literal(join_condition)))
+        join_condition = (
+            f"{table_name}.{fk_column} = {referenced_table}.{referenced_column}"
+        )
+        self.graph.add(
+            (prop_uri, self.oba_ns.sqlJoinCondition, Literal(join_condition))
+        )
 
         # Add relationship type annotation
         self.graph.add((prop_uri, self.oba_ns.relationshipType, Literal("many_to_one")))
@@ -387,30 +431,40 @@ class OntologyGenerator:
         self.graph.add((inverse_prop_uri, RDF.type, OWL.ObjectProperty))
         self.graph.add((inverse_prop_uri, RDFS.domain, referenced_table_uri))
         self.graph.add((inverse_prop_uri, RDFS.range, table_uri))
-        self.graph.add((inverse_prop_uri, RDFS.label, Literal(f"{referenced_table} referenced by {table_name}")))
+        self.graph.add(
+            (
+                inverse_prop_uri,
+                RDFS.label,
+                Literal(f"{referenced_table} referenced by {table_name}"),
+            )
+        )
 
         # Add database annotations for inverse relationship
-        self.graph.add((inverse_prop_uri, self.oba_ns.relationshipType, Literal("one_to_many")))
+        self.graph.add(
+            (inverse_prop_uri, self.oba_ns.relationshipType, Literal("one_to_many"))
+        )
 
         # Link them as inverses (both directions for explicit traversal)
         self.graph.add((prop_uri, OWL.inverseOf, inverse_prop_uri))
         self.graph.add((inverse_prop_uri, OWL.inverseOf, prop_uri))
 
-        logger.debug(f"Added declared FK relationship: {table_name}.{fk_column} -> {referenced_table}.{referenced_column}")
+        logger.debug(
+            f"Added declared FK relationship: {table_name}.{fk_column} -> {referenced_table}.{referenced_column}"
+        )
 
     def _clean_name(self, name: str) -> str:
         """Clean a name to make it suitable for URIs."""
         if not name:
-            return 'unnamed'
+            return "unnamed"
 
         # Replace spaces and special characters with underscores
-        cleaned = re.sub(r'[^a-zA-Z0-9_]', '_', name)
+        cleaned = re.sub(r"[^a-zA-Z0-9_]", "_", name)
 
         # Ensure it starts with a letter or underscore
-        if cleaned and not (cleaned[0].isalpha() or cleaned[0] == '_'):
-            cleaned = '_' + cleaned
+        if cleaned and not (cleaned[0].isalpha() or cleaned[0] == "_"):
+            cleaned = "_" + cleaned
 
-        return cleaned or 'unnamed'
+        return cleaned or "unnamed"
 
     def _build_table_lookup(self, tables_info: List[TableInfo]) -> None:
         """Build lookup structures for tables and their primary keys."""
@@ -423,12 +477,12 @@ class OntologyGenerator:
             self._table_lookup[table_lower] = table
 
             # Also store singular/plural variants
-            if table_lower.endswith('s'):
-                self._table_lookup[table_lower.rstrip('s')] = table
-            if table_lower.endswith('es'):
+            if table_lower.endswith("s"):
+                self._table_lookup[table_lower.rstrip("s")] = table
+            if table_lower.endswith("es"):
                 self._table_lookup[table_lower[:-2]] = table
-            if table_lower.endswith('ies'):
-                self._table_lookup[table_lower[:-3] + 'y'] = table
+            if table_lower.endswith("ies"):
+                self._table_lookup[table_lower[:-3] + "y"] = table
 
             # Store primary key columns
             self._pk_columns[table.name] = table.primary_keys
@@ -442,28 +496,28 @@ class OntologyGenerator:
             return self._table_lookup[name_lower]
 
         # Try adding common plural suffixes
-        for suffix in ['s', 'es', 'ies']:
+        for suffix in ["s", "es", "ies"]:
             candidate = name_lower + suffix
             if candidate in self._table_lookup:
                 return self._table_lookup[candidate]
 
         # Try removing plural suffixes
-        if name_lower.endswith('ies') and len(name_lower) > 3:
-            candidate = name_lower[:-3] + 'y'
+        if name_lower.endswith("ies") and len(name_lower) > 3:
+            candidate = name_lower[:-3] + "y"
             if candidate in self._table_lookup:
                 return self._table_lookup[candidate]
-        if name_lower.endswith('es') and len(name_lower) > 2:
+        if name_lower.endswith("es") and len(name_lower) > 2:
             candidate = name_lower[:-2]
             if candidate in self._table_lookup:
                 return self._table_lookup[candidate]
-        if name_lower.endswith('s') and len(name_lower) > 1:
+        if name_lower.endswith("s") and len(name_lower) > 1:
             candidate = name_lower[:-1]
             if candidate in self._table_lookup:
                 return self._table_lookup[candidate]
 
         # Try removing 'y' and adding 'ies'
-        if name_lower.endswith('y'):
-            candidate = name_lower[:-1] + 'ies'
+        if name_lower.endswith("y"):
+            candidate = name_lower[:-1] + "ies"
             if candidate in self._table_lookup:
                 return self._table_lookup[candidate]
 
@@ -489,7 +543,7 @@ class OntologyGenerator:
         # Build set of existing declared FKs to avoid duplicates
         for table in tables_info:
             for fk in table.foreign_keys:
-                existing_fks.add((table.name.lower(), fk['column'].lower()))
+                existing_fks.add((table.name.lower(), fk["column"].lower()))
 
         # Build table name variations for matching (include singular/plural forms)
         table_name_variations: Dict[str, TableInfo] = {}
@@ -498,21 +552,21 @@ class OntologyGenerator:
             table_name_variations[name_lower] = t
 
             # Add singular forms for matching in column names
-            if name_lower.endswith('ies'):
-                table_name_variations[name_lower[:-3] + 'y'] = t
-            elif name_lower.endswith('es') and len(name_lower) > 2:
+            if name_lower.endswith("ies"):
+                table_name_variations[name_lower[:-3] + "y"] = t
+            elif name_lower.endswith("es") and len(name_lower) > 2:
                 table_name_variations[name_lower[:-2]] = t
-            elif name_lower.endswith('s') and len(name_lower) > 1:
+            elif name_lower.endswith("s") and len(name_lower) > 1:
                 table_name_variations[name_lower[:-1]] = t
 
         # Sort by length (longer first) to match most specific names first
         sorted_variations = sorted(
-            table_name_variations.items(),
-            key=lambda x: len(x[0]),
-            reverse=True
+            table_name_variations.items(), key=lambda x: len(x[0]), reverse=True
         )
 
-        logger.debug(f"FK inference: Table name variations: {list(table_name_variations.keys())}")
+        logger.debug(
+            f"FK inference: Table name variations: {list(table_name_variations.keys())}"
+        )
 
         for table in tables_info:
             for col in table.columns:
@@ -528,8 +582,10 @@ class OntologyGenerator:
                 found_match = False
 
                 # Log columns that look like potential FKs
-                if 'id' in col_lower and not col.is_primary_key:
-                    logger.debug(f"FK inference: Checking column {table.name}.{col.name}")
+                if "id" in col_lower and not col.is_primary_key:
+                    logger.debug(
+                        f"FK inference: Checking column {table.name}.{col.name}"
+                    )
 
                 # First try: look for embedded table names (or variations) in the column
                 for target_name, target_table in sorted_variations:
@@ -545,23 +601,25 @@ class OntologyGenerator:
                     if target_name in col_lower:
                         # Check if followed by 'id', '_id', 'sk', '_sk' or empty
                         idx = col_lower.find(target_name)
-                        suffix = col_lower[idx + len(target_name):]
-                        if suffix in ['id', '_id', 'sk', '_sk', '']:
+                        suffix = col_lower[idx + len(target_name) :]
+                        if suffix in ["id", "_id", "sk", "_sk", ""]:
                             target_pk = target_table.primary_keys
-                            target_column = target_pk[0] if target_pk else 'id'
+                            target_column = target_pk[0] if target_pk else "id"
 
                             confidence = self._calculate_fk_confidence(
                                 col, target_table, target_name
                             )
 
-                            inferred.append(InferredRelationship(
-                                source_table=table.name,
-                                column=col.name,
-                                target_table=target_table.name,
-                                target_column=target_column,
-                                confidence=confidence,
-                                pattern_matched='embedded_table_name'
-                            ))
+                            inferred.append(
+                                InferredRelationship(
+                                    source_table=table.name,
+                                    column=col.name,
+                                    target_table=target_table.name,
+                                    target_column=target_column,
+                                    confidence=confidence,
+                                    pattern_matched="embedded_table_name",
+                                )
+                            )
                             found_match = True
                             break
 
@@ -585,21 +643,23 @@ class OntologyGenerator:
                         if target_table and target_table.name != table.name:
                             # Determine the likely target column (usually PK)
                             target_pk = target_table.primary_keys
-                            target_column = target_pk[0] if target_pk else 'id'
+                            target_column = target_pk[0] if target_pk else "id"
 
                             # Determine confidence level
                             confidence = self._calculate_fk_confidence(
                                 col, target_table, potential_table
                             )
 
-                            inferred.append(InferredRelationship(
-                                source_table=table.name,
-                                column=col.name,
-                                target_table=target_table.name,
-                                target_column=target_column,
-                                confidence=confidence,
-                                pattern_matched=pattern_name
-                            ))
+                            inferred.append(
+                                InferredRelationship(
+                                    source_table=table.name,
+                                    column=col.name,
+                                    target_table=target_table.name,
+                                    target_column=target_column,
+                                    confidence=confidence,
+                                    pattern_matched=pattern_name,
+                                )
+                            )
                             break  # Only match first pattern
 
         return inferred
@@ -615,7 +675,7 @@ class OntologyGenerator:
         if target_pk_cols:
             target_pk_type = target_pk_cols[0].data_type.lower()
             col_type = column.data_type.lower()
-            if 'int' in col_type and 'int' in target_pk_type:
+            if "int" in col_type and "int" in target_pk_type:
                 score += 2
             elif col_type == target_pk_type:
                 score += 2
@@ -623,19 +683,19 @@ class OntologyGenerator:
         # Higher confidence if exact table name match (vs plural/singular variation)
         if extracted_name.lower() == target_table.name.lower():
             score += 2
-        elif extracted_name.lower() + 's' == target_table.name.lower():
+        elif extracted_name.lower() + "s" == target_table.name.lower():
             score += 1
 
         # Higher confidence for common FK naming patterns
         col_lower = column.name.lower()
-        if col_lower.endswith('id') or col_lower.endswith('_id'):
+        if col_lower.endswith("id") or col_lower.endswith("_id"):
             score += 1
 
         if score >= 4:
-            return 'high'
+            return "high"
         elif score >= 2:
-            return 'medium'
-        return 'low'
+            return "medium"
+        return "low"
 
     def _detect_denormalized_fields(
         self, tables_info: List[TableInfo]
@@ -660,11 +720,11 @@ class OntologyGenerator:
             table_name_variations[name_lower] = t.name
 
             # Add singular forms
-            if name_lower.endswith('ies'):
-                table_name_variations[name_lower[:-3] + 'y'] = t.name
-            elif name_lower.endswith('es'):
+            if name_lower.endswith("ies"):
+                table_name_variations[name_lower[:-3] + "y"] = t.name
+            elif name_lower.endswith("es"):
                 table_name_variations[name_lower[:-2]] = t.name
-            elif name_lower.endswith('s'):
+            elif name_lower.endswith("s"):
                 table_name_variations[name_lower[:-1]] = t.name
 
         for table in tables_info:
@@ -673,7 +733,9 @@ class OntologyGenerator:
                 col_type = col.data_type.lower()
 
                 # Only consider text/varchar columns
-                if not any(t in col_type for t in ['char', 'text', 'string', 'varchar']):
+                if not any(
+                    t in col_type for t in ["char", "text", "string", "varchar"]
+                ):
                     continue
 
                 # Check if column name contains another table name (or variation)
@@ -693,26 +755,31 @@ class OntologyGenerator:
 
                         # Check if this looks like a denormalized name field
                         # (column contains table ref + optionally a text suffix)
-                        suffix_after_ref = col_lower[col_lower.find(ref_name) + len(ref_name):]
+                        suffix_after_ref = col_lower[
+                            col_lower.find(ref_name) + len(ref_name) :
+                        ]
                         is_denorm_pattern = (
-                            has_denorm_suffix or
-                            col_lower == ref_name or
-                            suffix_after_ref == '' or
-                            suffix_after_ref in ['name', 'title', 'desc', 'description']
+                            has_denorm_suffix
+                            or col_lower == ref_name
+                            or suffix_after_ref == ""
+                            or suffix_after_ref
+                            in ["name", "title", "desc", "description"]
                         )
 
                         if is_denorm_pattern:
-                            denormalized.append(DenormalizedField(
-                                table=table.name,
-                                column=col.name,
-                                likely_source_table=original_table_name,
-                                data_type=col.data_type,
-                                warning=(
-                                    f"Column '{col.name}' appears to store denormalized data "
-                                    f"from '{original_table_name}'. Consider joining to source "
-                                    f"table instead of storing duplicate text."
+                            denormalized.append(
+                                DenormalizedField(
+                                    table=table.name,
+                                    column=col.name,
+                                    likely_source_table=original_table_name,
+                                    data_type=col.data_type,
+                                    warning=(
+                                        f"Column '{col.name}' appears to store denormalized data "
+                                        f"from '{original_table_name}'. Consider joining to source "
+                                        f"table instead of storing duplicate text."
+                                    ),
                                 )
-                            ))
+                            )
                             break  # Found a match, no need to check more variations
 
         return denormalized
@@ -744,26 +811,54 @@ class OntologyGenerator:
         self.graph.add((prop_uri, RDF.type, OWL.FunctionalProperty))
         self.graph.add((prop_uri, RDFS.domain, source_table_uri))
         self.graph.add((prop_uri, RDFS.range, target_table_uri))
-        self.graph.add((prop_uri, RDFS.label, Literal(
-            f"{inferred_rel.source_table} has {inferred_rel.target_table}"
-        )))
+        self.graph.add(
+            (
+                prop_uri,
+                RDFS.label,
+                Literal(f"{inferred_rel.source_table} has {inferred_rel.target_table}"),
+            )
+        )
 
         # Add database-specific annotations
-        self.graph.add((prop_uri, self.oba_ns.foreignKeyColumn, Literal(inferred_rel.column)))
-        self.graph.add((prop_uri, self.oba_ns.referencedTable, Literal(inferred_rel.target_table)))
-        self.graph.add((prop_uri, self.oba_ns.referencedColumn, Literal(inferred_rel.target_column)))
+        self.graph.add(
+            (prop_uri, self.oba_ns.foreignKeyColumn, Literal(inferred_rel.column))
+        )
+        self.graph.add(
+            (prop_uri, self.oba_ns.referencedTable, Literal(inferred_rel.target_table))
+        )
+        self.graph.add(
+            (
+                prop_uri,
+                self.oba_ns.referencedColumn,
+                Literal(inferred_rel.target_column),
+            )
+        )
 
         # Add SQL join condition
         join_condition = (
             f"{inferred_rel.source_table}.{inferred_rel.column} = "
             f"{inferred_rel.target_table}.{inferred_rel.target_column}"
         )
-        self.graph.add((prop_uri, self.oba_ns.sqlJoinCondition, Literal(join_condition)))
+        self.graph.add(
+            (prop_uri, self.oba_ns.sqlJoinCondition, Literal(join_condition))
+        )
 
         # Mark as inferred (not declared FK)
         self.graph.add((prop_uri, self.oba_ns.isInferredRelationship, Literal(True)))
-        self.graph.add((prop_uri, self.oba_ns.inferenceConfidence, Literal(inferred_rel.confidence)))
-        self.graph.add((prop_uri, self.oba_ns.inferencePattern, Literal(inferred_rel.pattern_matched)))
+        self.graph.add(
+            (
+                prop_uri,
+                self.oba_ns.inferenceConfidence,
+                Literal(inferred_rel.confidence),
+            )
+        )
+        self.graph.add(
+            (
+                prop_uri,
+                self.oba_ns.inferencePattern,
+                Literal(inferred_rel.pattern_matched),
+            )
+        )
         self.graph.add((prop_uri, self.oba_ns.relationshipType, Literal("many_to_one")))
 
         # Shared traversable join edge (finer grain -> coarser grain); see
@@ -781,11 +876,21 @@ class OntologyGenerator:
             self.graph.add((inverse_prop_uri, RDF.type, OWL.ObjectProperty))
             self.graph.add((inverse_prop_uri, RDFS.domain, target_table_uri))
             self.graph.add((inverse_prop_uri, RDFS.range, source_table_uri))
-            self.graph.add((inverse_prop_uri, RDFS.label, Literal(
-                f"{inferred_rel.target_table} referenced by {inferred_rel.source_table}"
-            )))
-            self.graph.add((inverse_prop_uri, self.oba_ns.relationshipType, Literal("one_to_many")))
-            self.graph.add((inverse_prop_uri, self.oba_ns.isInferredRelationship, Literal(True)))
+            self.graph.add(
+                (
+                    inverse_prop_uri,
+                    RDFS.label,
+                    Literal(
+                        f"{inferred_rel.target_table} referenced by {inferred_rel.source_table}"
+                    ),
+                )
+            )
+            self.graph.add(
+                (inverse_prop_uri, self.oba_ns.relationshipType, Literal("one_to_many"))
+            )
+            self.graph.add(
+                (inverse_prop_uri, self.oba_ns.isInferredRelationship, Literal(True))
+            )
 
             # Link as inverses (both directions for explicit traversal)
             self.graph.add((prop_uri, OWL.inverseOf, inverse_prop_uri))
@@ -797,21 +902,23 @@ class OntologyGenerator:
         Args:
             denorm: The denormalized field info
         """
-        prop_name = f"{self._clean_name(denorm.table)}_{self._clean_name(denorm.column)}"
+        prop_name = (
+            f"{self._clean_name(denorm.table)}_{self._clean_name(denorm.column)}"
+        )
         prop_uri = self.base_uri[prop_name]
 
         if (prop_uri, RDF.type, OWL.DatatypeProperty) in self.graph:
             self.graph.add((prop_uri, self.oba_ns.isDenormalized, Literal(True)))
-            self.graph.add((
-                prop_uri,
-                self.oba_ns.likelySourceTable,
-                Literal(denorm.likely_source_table)
-            ))
-            self.graph.add((
-                prop_uri,
-                self.oba_ns.denormalizationWarning,
-                Literal(denorm.warning)
-            ))
+            self.graph.add(
+                (
+                    prop_uri,
+                    self.oba_ns.likelySourceTable,
+                    Literal(denorm.likely_source_table),
+                )
+            )
+            self.graph.add(
+                (prop_uri, self.oba_ns.denormalizationWarning, Literal(denorm.warning))
+            )
 
     def _add_disjoint_axioms(self, tables_info: List[TableInfo]) -> None:
         """Add owl:disjointWith axioms between sibling tables that share a dimension.
@@ -842,9 +949,9 @@ class OntologyGenerator:
             if ref_table and domain:
                 source_name = self.graph.value(domain, self.oba_ns.tableName)
                 if source_name:
-                    dimension_to_sources.setdefault(
-                        str(ref_table), set()
-                    ).add(str(source_name))
+                    dimension_to_sources.setdefault(str(ref_table), set()).add(
+                        str(source_name)
+                    )
 
         # Build set of tables that have a direct FK relationship between them.
         # Must mirror dimension_to_sources, which includes inferred relationships:
@@ -877,16 +984,17 @@ class OntologyGenerator:
         for _dim, sources in dimension_to_sources.items():
             source_list = sorted(sources)
             for i, a in enumerate(source_list):
-                for b in source_list[i + 1:]:
+                for b in source_list[i + 1 :]:
                     if (a, b) in fk_pairs or (a, b) in declared:
                         continue
                     uri_a = self.base_uri[self._clean_name(a)]
                     uri_b = self.base_uri[self._clean_name(b)]
                     # Only add if both are actual classes in the graph
-                    if (
-                        (uri_a, RDF.type, OWL.Class) in self.graph
-                        and (uri_b, RDF.type, OWL.Class) in self.graph
-                    ):
+                    if (uri_a, RDF.type, OWL.Class) in self.graph and (
+                        uri_b,
+                        RDF.type,
+                        OWL.Class,
+                    ) in self.graph:
                         self.graph.add((uri_a, OWL.disjointWith, uri_b))
                         declared.add((a, b))
                         declared.add((b, a))
@@ -954,22 +1062,22 @@ class OntologyGenerator:
                 self.graph.add((chain_uri, RDF.type, OWL.ObjectProperty))
                 self.graph.add((chain_uri, RDFS.domain, uri_a))
                 self.graph.add((chain_uri, RDFS.range, uri_c))
-                self.graph.add((chain_uri, RDFS.label, Literal(
-                    f"{a} via {tgt_ab} has {c}"
-                )))
+                self.graph.add(
+                    (chain_uri, RDFS.label, Literal(f"{a} via {tgt_ab} has {c}"))
+                )
 
                 # Build the RDF list for the property chain
                 chain_list = Collection(self.graph, None, [uri_ab, uri_bc])
-                self.graph.add((
-                    chain_uri,
-                    OWL.propertyChainAxiom,
-                    chain_list.uri,
-                ))
+                self.graph.add(
+                    (
+                        chain_uri,
+                        OWL.propertyChainAxiom,
+                        chain_list.uri,
+                    )
+                )
 
                 declared.add((a, c))
-                logger.info(
-                    f"Added owl:propertyChainAxiom: {a} -> {tgt_ab} -> {c}"
-                )
+                logger.info(f"Added owl:propertyChainAxiom: {a} -> {tgt_ab} -> {c}")
 
     def validate_enrichment_completeness(self) -> Dict[str, Any]:
         """Check that all classes and properties have semantic descriptions.
@@ -1025,7 +1133,9 @@ class OntologyGenerator:
             total_rels += 1
             has_comment = any(self.graph.objects(subject, RDFS.comment))
             # Also check for relationship description
-            has_rel_desc = any(self.graph.objects(subject, self.oba_ns.relationshipDescription))
+            has_rel_desc = any(
+                self.graph.objects(subject, self.oba_ns.relationshipDescription)
+            )
             if not has_comment and not has_rel_desc:
                 for label in self.graph.objects(subject, RDFS.label):
                     relationships_without_desc.append(str(label))
@@ -1048,11 +1158,16 @@ class OntologyGenerator:
                 (total_rels - len(relationships_without_desc)) / max(1, total_rels)
             ),
             "overall_coverage": (
-                (total_classes + total_props + total_rels -
-                 len(classes_without_desc) - len(properties_without_desc) -
-                 len(relationships_without_desc)) /
-                max(1, total_classes + total_props + total_rels)
-            )
+                (
+                    total_classes
+                    + total_props
+                    + total_rels
+                    - len(classes_without_desc)
+                    - len(properties_without_desc)
+                    - len(relationships_without_desc)
+                )
+                / max(1, total_classes + total_props + total_rels)
+            ),
         }
 
     def _map_sql_to_xsd(
@@ -1077,14 +1192,17 @@ class OntologyGenerator:
 
         # Semantic override: quantities should be integers even if stored as float/double
         if col_lower and any(p in col_lower for p in self.QUANTITY_PATTERNS):
-            if any(t in sql_type_lower for t in ["float", "double", "decimal", "numeric", "real"]):
+            if any(
+                t in sql_type_lower
+                for t in ["float", "double", "decimal", "numeric", "real"]
+            ):
                 type_override = {
                     "table": table_name,
                     "column": column_name,
                     "original_sql_type": sql_type,
                     "original_xsd_type": "xsd:double",
                     "overridden_xsd_type": "xsd:integer",
-                    "reason": f"Column name '{column_name}' indicates quantity/count (should be integer)"
+                    "reason": f"Column name '{column_name}' indicates quantity/count (should be integer)",
                 }
                 return XSD.integer, type_override
 
@@ -1138,10 +1256,10 @@ class OntologyGenerator:
 
     def apply_semantic_descriptions(self, descriptions: Dict[str, Any]):
         """Apply LLM-generated semantic descriptions to the ontology.
-        
+
         This method allows applying rich, context-aware descriptions generated
         by the LLM through the generate_semantic_descriptions tool.
-        
+
         Args:
             descriptions: Dictionary containing semantic descriptions for:
                 - tables: Business descriptions for each table
@@ -1149,7 +1267,7 @@ class OntologyGenerator:
                 - relationships: Descriptions of foreign key relationships
         """
         logger.info("Applying LLM-generated semantic descriptions to ontology")
-        
+
         # Apply table descriptions
         if "tables" in descriptions:
             for table_name, table_desc in descriptions["tables"].items():
@@ -1159,17 +1277,32 @@ class OntologyGenerator:
                         # Remove existing comment if present
                         self.graph.remove((table_uri, RDFS.comment, None))
                         # Add new rich description as rdfs:comment
-                        self.graph.add((table_uri, RDFS.comment,
-                                      Literal(table_desc["business_description"])))
-                    
+                        self.graph.add(
+                            (
+                                table_uri,
+                                RDFS.comment,
+                                Literal(table_desc["business_description"]),
+                            )
+                        )
+
                     if "table_type" in table_desc:
-                        self.graph.add((table_uri, self.oba_ns.tableType, 
-                                      Literal(table_desc["table_type"])))
-                    
+                        self.graph.add(
+                            (
+                                table_uri,
+                                self.oba_ns.tableType,
+                                Literal(table_desc["table_type"]),
+                            )
+                        )
+
                     if "usage_notes" in table_desc:
-                        self.graph.add((table_uri, self.oba_ns.usageNotes, 
-                                      Literal(table_desc["usage_notes"])))
-        
+                        self.graph.add(
+                            (
+                                table_uri,
+                                self.oba_ns.usageNotes,
+                                Literal(table_desc["usage_notes"]),
+                            )
+                        )
+
         # Apply column descriptions
         if "columns" in descriptions:
             for column_ref, column_desc in descriptions["columns"].items():
@@ -1178,25 +1311,42 @@ class OntologyGenerator:
                     table_name, column_name = column_ref.split(".", 1)
                     prop_name = f"{self._clean_name(table_name)}_{self._clean_name(column_name)}"
                     prop_uri = self.base_uri[prop_name]
-                    
-                    if ((prop_uri, RDF.type, OWL.DatatypeProperty) in self.graph or
-                        (prop_uri, RDF.type, OWL.ObjectProperty) in self.graph):
-                        
+
+                    if (prop_uri, RDF.type, OWL.DatatypeProperty) in self.graph or (
+                        prop_uri,
+                        RDF.type,
+                        OWL.ObjectProperty,
+                    ) in self.graph:
                         if "business_description" in column_desc:
                             # Remove existing comment if present
                             self.graph.remove((prop_uri, RDFS.comment, None))
                             # Add new rich description as rdfs:comment
-                            self.graph.add((prop_uri, RDFS.comment,
-                                          Literal(column_desc["business_description"])))
-                        
+                            self.graph.add(
+                                (
+                                    prop_uri,
+                                    RDFS.comment,
+                                    Literal(column_desc["business_description"]),
+                                )
+                            )
+
                         if "data_characteristics" in column_desc:
-                            self.graph.add((prop_uri, self.oba_ns.dataCharacteristics, 
-                                          Literal(column_desc["data_characteristics"])))
-                        
+                            self.graph.add(
+                                (
+                                    prop_uri,
+                                    self.oba_ns.dataCharacteristics,
+                                    Literal(column_desc["data_characteristics"]),
+                                )
+                            )
+
                         if "business_rules" in column_desc:
-                            self.graph.add((prop_uri, self.oba_ns.businessRules, 
-                                          Literal(column_desc["business_rules"])))
-        
+                            self.graph.add(
+                                (
+                                    prop_uri,
+                                    self.oba_ns.businessRules,
+                                    Literal(column_desc["business_rules"]),
+                                )
+                            )
+
         # Apply relationship descriptions
         if "relationships" in descriptions:
             for rel_key, rel_desc in descriptions["relationships"].items():
@@ -1204,32 +1354,51 @@ class OntologyGenerator:
                 # Expected format: "from_table.column -> to_table.column"
                 if " -> " in rel_key:
                     from_part, to_part = rel_key.split(" -> ")
-                    from_table = from_part.split(".")[0] if "." in from_part else from_part
+                    from_table = (
+                        from_part.split(".")[0] if "." in from_part else from_part
+                    )
                     to_table = to_part.split(".")[0] if "." in to_part else to_part
-                    
+
                     rel_name = f"{self._clean_name(from_table)}_has_{self._clean_name(to_table)}"
                     rel_uri = self.base_uri[rel_name]
-                    
+
                     if (rel_uri, RDF.type, OWL.ObjectProperty) in self.graph:
                         if "description" in rel_desc:
-                            self.graph.add((rel_uri, self.oba_ns.relationshipDescription, 
-                                          Literal(rel_desc["description"])))
-                        
+                            self.graph.add(
+                                (
+                                    rel_uri,
+                                    self.oba_ns.relationshipDescription,
+                                    Literal(rel_desc["description"]),
+                                )
+                            )
+
                         if "cardinality" in rel_desc:
-                            self.graph.add((rel_uri, self.oba_ns.cardinality, 
-                                          Literal(rel_desc["cardinality"])))
-                        
+                            self.graph.add(
+                                (
+                                    rel_uri,
+                                    self.oba_ns.cardinality,
+                                    Literal(rel_desc["cardinality"]),
+                                )
+                            )
+
                         if "business_rule" in rel_desc:
-                            self.graph.add((rel_uri, self.oba_ns.businessRule, 
-                                          Literal(rel_desc["business_rule"])))
-        
+                            self.graph.add(
+                                (
+                                    rel_uri,
+                                    self.oba_ns.businessRule,
+                                    Literal(rel_desc["business_rule"]),
+                                )
+                            )
+
         logger.info("Finished applying semantic descriptions")
-    
+
     def serialize_ontology(self) -> str:
         """Serialize the current ontology to Turtle format."""
         return self.graph.serialize(format="turtle")
 
-    def get_enrichment_data(self, tables_info: List[TableInfo], sample_data: Dict[str, List[Dict[str, Any]]]) -> Dict[str, Any]:
+    def get_enrichment_data(
+        self, tables_info: List[TableInfo], sample_data: Dict[str, List[Dict[str, Any]]]
+    ) -> Dict[str, Any]:
         """Generate enrichment data structure for LLM processing.
 
         Args:
@@ -1246,7 +1415,7 @@ class OntologyGenerator:
                 "table_name": table_info.name,
                 "schema": table_info.schema,
                 "row_count": table_info.row_count,
-                "columns": []
+                "columns": [],
             }
 
             # Add column information
@@ -1256,7 +1425,7 @@ class OntologyGenerator:
                     "data_type": column.data_type,
                     "is_nullable": column.is_nullable,
                     "is_primary_key": column.is_primary_key,
-                    "is_foreign_key": column.is_foreign_key
+                    "is_foreign_key": column.is_foreign_key,
                 }
                 if column.comment:
                     column_data["comment"] = column.comment
@@ -1279,7 +1448,7 @@ class OntologyGenerator:
                     {
                         "original_name": "table_name",
                         "suggested_name": "SemanticName",
-                        "description": "Business description"
+                        "description": "Business description",
                     }
                 ],
                 "properties": [
@@ -1287,7 +1456,7 @@ class OntologyGenerator:
                         "table_name": "table_name",
                         "original_name": "column_name",
                         "suggested_name": "semanticPropertyName",
-                        "description": "Business meaning"
+                        "description": "Business meaning",
                     }
                 ],
                 "relationships": [
@@ -1295,24 +1464,23 @@ class OntologyGenerator:
                         "from_table": "source_table",
                         "to_table": "target_table",
                         "suggested_name": "semanticRelationshipName",
-                        "description": "Relationship meaning"
+                        "description": "Relationship meaning",
                     }
-                ]
+                ],
             },
             "guidelines": [
                 "Use clear, business-oriented terminology",
                 "Provide meaningful descriptions based on table and column names and sample data",
                 "Suggest appropriate semantic names that reflect business concepts",
-                "For relationships, describe the business meaning of the association"
-            ]
+                "For relationships, describe the business meaning of the association",
+            ],
         }
 
-        return {
-            "schema_data": schema_data,
-            "instructions": instructions
-        }
+        return {"schema_data": schema_data, "instructions": instructions}
 
-    def apply_enrichment(self, enrichment_suggestions: Dict[str, List[Dict[str, Any]]]) -> None:
+    def apply_enrichment(
+        self, enrichment_suggestions: Dict[str, List[Dict[str, Any]]]
+    ) -> None:
         """Apply enrichment suggestions to the ontology.
 
         Args:
@@ -1360,7 +1528,9 @@ class OntologyGenerator:
                     continue
 
                 # Find the original property URI
-                prop_name = f"{self._clean_name(table_name)}_{self._clean_name(original_name)}"
+                prop_name = (
+                    f"{self._clean_name(table_name)}_{self._clean_name(original_name)}"
+                )
                 prop_uri = self.base_uri[prop_name]
 
                 # Add suggested name as label if provided
@@ -1385,7 +1555,9 @@ class OntologyGenerator:
                     continue
 
                 # Find the original relationship URI
-                rel_name = f"{self._clean_name(from_table)}_has_{self._clean_name(to_table)}"
+                rel_name = (
+                    f"{self._clean_name(from_table)}_has_{self._clean_name(to_table)}"
+                )
                 rel_uri = self.base_uri[rel_name]
 
                 # Add suggested name as label if provided
@@ -1400,7 +1572,9 @@ class OntologyGenerator:
 
         logger.info("Finished applying enrichment suggestions")
 
-    def enrich_with_llm(self, tables_info: List[TableInfo], sample_data: Dict[str, List[Dict[str, Any]]]) -> str:
+    def enrich_with_llm(
+        self, tables_info: List[TableInfo], sample_data: Dict[str, List[Dict[str, Any]]]
+    ) -> str:
         """Generate basic ontology with optional LLM enrichment.
 
         This is a placeholder method that generates a basic ontology.
@@ -1447,12 +1621,14 @@ class OntologyGenerator:
 
             class_info = {
                 "uri": str(subject),
-                "local_name": str(subject).split("/")[-1] if "/" in str(subject) else str(subject),
+                "local_name": str(subject).split("/")[-1]
+                if "/" in str(subject)
+                else str(subject),
                 "current_label": None,
                 "table_name": None,
                 "schema_name": None,
                 "row_count": None,
-                "comment": None
+                "comment": None,
             }
 
             # Get current label
@@ -1479,14 +1655,16 @@ class OntologyGenerator:
         for subject in self.graph.subjects(RDF.type, OWL.DatatypeProperty):
             prop_info = {
                 "uri": str(subject),
-                "local_name": str(subject).split("/")[-1] if "/" in str(subject) else str(subject),
+                "local_name": str(subject).split("/")[-1]
+                if "/" in str(subject)
+                else str(subject),
                 "current_label": None,
                 "column_name": None,
                 "table_name": None,
                 "sql_data_type": None,
                 "is_primary_key": False,
                 "is_foreign_key": False,
-                "comment": None
+                "comment": None,
             }
 
             # Get current label
@@ -1517,12 +1695,14 @@ class OntologyGenerator:
         for subject in self.graph.subjects(RDF.type, OWL.ObjectProperty):
             rel_info = {
                 "uri": str(subject),
-                "local_name": str(subject).split("/")[-1] if "/" in str(subject) else str(subject),
+                "local_name": str(subject).split("/")[-1]
+                if "/" in str(subject)
+                else str(subject),
                 "current_label": None,
                 "foreign_key_column": None,
                 "referenced_table": None,
                 "relationship_type": None,
-                "comment": None
+                "comment": None,
             }
 
             # Get current label
@@ -1546,30 +1726,49 @@ class OntologyGenerator:
             relationships.append(rel_info)
 
         # Generate analysis hints
-        cryptic_classes = [c for c in classes if c.get("needs_review", {}).get("is_cryptic")]
-        cryptic_props = [p for p in properties if p.get("needs_review", {}).get("is_cryptic")]
-        cryptic_rels = [r for r in relationships if r.get("needs_review", {}).get("is_cryptic")]
+        cryptic_classes = [
+            c for c in classes if c.get("needs_review", {}).get("is_cryptic")
+        ]
+        cryptic_props = [
+            p for p in properties if p.get("needs_review", {}).get("is_cryptic")
+        ]
+        cryptic_rels = [
+            r for r in relationships if r.get("needs_review", {}).get("is_cryptic")
+        ]
 
         if cryptic_classes:
-            analysis_hints.append(f"Found {len(cryptic_classes)} class names that may need improvement")
+            analysis_hints.append(
+                f"Found {len(cryptic_classes)} class names that may need improvement"
+            )
         if cryptic_props:
-            analysis_hints.append(f"Found {len(cryptic_props)} property names that may need improvement")
+            analysis_hints.append(
+                f"Found {len(cryptic_props)} property names that may need improvement"
+            )
         if cryptic_rels:
-            analysis_hints.append(f"Found {len(cryptic_rels)} relationship names that may need improvement")
+            analysis_hints.append(
+                f"Found {len(cryptic_rels)} relationship names that may need improvement"
+            )
 
         # In compact mode, return full metadata only for cryptic items.
         # Non-cryptic items are reduced to name-only entries so LLM clients
         # with limited context windows can still see all names at a glance.
         if compact:
+
             def _compact_class(c: Dict[str, Any]) -> Dict[str, Any]:
                 if c.get("needs_review", {}).get("is_cryptic"):
                     return c
-                return {"local_name": c["local_name"], "table_name": c.get("table_name")}
+                return {
+                    "local_name": c["local_name"],
+                    "table_name": c.get("table_name"),
+                }
 
             def _compact_prop(p: Dict[str, Any]) -> Dict[str, Any]:
                 if p.get("needs_review", {}).get("is_cryptic"):
                     return p
-                return {"local_name": p["local_name"], "table_name": p.get("table_name")}
+                return {
+                    "local_name": p["local_name"],
+                    "table_name": p.get("table_name"),
+                }
 
             def _compact_rel(r: Dict[str, Any]) -> Dict[str, Any]:
                 if r.get("needs_review", {}).get("is_cryptic"):
@@ -1591,8 +1790,8 @@ class OntologyGenerator:
                 "total_relationships": len(relationships),
                 "classes_needing_review": len(cryptic_classes),
                 "properties_needing_review": len(cryptic_props),
-                "relationships_needing_review": len(cryptic_rels)
-            }
+                "relationships_needing_review": len(cryptic_rels),
+            },
         }
 
     @staticmethod
@@ -1678,10 +1877,7 @@ class OntologyGenerator:
         # Split on underscores, then check each token against the corpus.
         parts = [p for p in name.lower().split("_") if p.isalpha()]
         if parts:
-            non_words = [
-                p for p in parts
-                if not self._is_known_word(p)
-            ]
+            non_words = [p for p in parts if not self._is_known_word(p)]
             # If more than half the tokens are not real words → cryptic
             if len(non_words) > len(parts) / 2:
                 is_cryptic = True
@@ -1690,14 +1886,16 @@ class OntologyGenerator:
                 )
             elif non_words:
                 # Some tokens unrecognised — mention but don't auto-flag
-                reasons.append(
-                    f"Possible abbreviations: {', '.join(non_words)}"
-                )
+                reasons.append(f"Possible abbreviations: {', '.join(non_words)}")
 
         return {
             "is_cryptic": is_cryptic,
             "reasons": reasons,
-            "confidence": "high" if len(reasons) >= 2 else "medium" if len(reasons) == 1 else "low",
+            "confidence": "high"
+            if len(reasons) >= 2
+            else "medium"
+            if len(reasons) == 1
+            else "low",
         }
 
     def apply_semantic_names(self, name_suggestions: Dict[str, Any]) -> str:
@@ -1738,7 +1936,9 @@ class OntologyGenerator:
                         self.graph.remove((class_uri, RDFS.label, None))
                         self.graph.add((class_uri, RDFS.label, Literal(suggested)))
                         # Also add a semantic name annotation
-                        self.graph.add((class_uri, self.oba_ns.semanticName, Literal(suggested)))
+                        self.graph.add(
+                            (class_uri, self.oba_ns.semanticName, Literal(suggested))
+                        )
                         changes_made += 1
 
                     if description:
@@ -1761,26 +1961,35 @@ class OntologyGenerator:
 
                 # Find the property URI - might need table context
                 if table_name:
-                    prop_name = f"{self._clean_name(table_name)}_{self._clean_name(original)}"
+                    prop_name = (
+                        f"{self._clean_name(table_name)}_{self._clean_name(original)}"
+                    )
                 else:
                     prop_name = self._clean_name(original)
 
                 prop_uri = self.base_uri[prop_name]
 
                 # Check if this property exists (as data or object property)
-                if ((prop_uri, RDF.type, OWL.DatatypeProperty) in self.graph or
-                    (prop_uri, RDF.type, OWL.ObjectProperty) in self.graph):
-                    proposed_changes.append({
-                        "prop_uri": prop_uri,
-                        "suggested": suggested,
-                        "description": description,
-                        "table_name": table_name,
-                    })
+                if (prop_uri, RDF.type, OWL.DatatypeProperty) in self.graph or (
+                    prop_uri,
+                    RDF.type,
+                    OWL.ObjectProperty,
+                ) in self.graph:
+                    proposed_changes.append(
+                        {
+                            "prop_uri": prop_uri,
+                            "suggested": suggested,
+                            "description": description,
+                            "table_name": table_name,
+                        }
+                    )
 
             # Detect duplicate suggested labels and disambiguate with table context
             if proposed_changes:
                 # Collect existing labels from properties NOT being changed
-                changing_uris = {c["prop_uri"] for c in proposed_changes if c["suggested"]}
+                changing_uris = {
+                    c["prop_uri"] for c in proposed_changes if c["suggested"]
+                }
                 existing_labels: Dict[str, URIRef] = {}
                 for rdf_type in (OWL.DatatypeProperty, OWL.ObjectProperty):
                     for s, _, _ in self.graph.triples((None, RDF.type, rdf_type)):
@@ -1802,25 +2011,43 @@ class OntologyGenerator:
                         for change in changes:
                             if change["table_name"]:
                                 # Prefer the class's rdfs:label (may have been enriched above)
-                                class_uri = self.base_uri[self._clean_name(change["table_name"])]
+                                class_uri = self.base_uri[
+                                    self._clean_name(change["table_name"])
+                                ]
                                 class_label = None
                                 for label in self.graph.objects(class_uri, RDFS.label):
                                     class_label = str(label)
                                     break
                                 qualifier = class_label or change["table_name"]
-                                change["suggested"] = f"{change['suggested']} ({qualifier})"
+                                change[
+                                    "suggested"
+                                ] = f"{change['suggested']} ({qualifier})"
 
             # Second pass: apply all changes
             for change in proposed_changes:
                 if change["suggested"]:
                     self.graph.remove((change["prop_uri"], RDFS.label, None))
-                    self.graph.add((change["prop_uri"], RDFS.label, Literal(change["suggested"])))
-                    self.graph.add((change["prop_uri"], self.oba_ns.semanticName, Literal(change["suggested"])))
+                    self.graph.add(
+                        (change["prop_uri"], RDFS.label, Literal(change["suggested"]))
+                    )
+                    self.graph.add(
+                        (
+                            change["prop_uri"],
+                            self.oba_ns.semanticName,
+                            Literal(change["suggested"]),
+                        )
+                    )
                     changes_made += 1
 
                 if change["description"]:
                     self.graph.remove((change["prop_uri"], RDFS.comment, None))
-                    self.graph.add((change["prop_uri"], RDFS.comment, Literal(change["description"])))
+                    self.graph.add(
+                        (
+                            change["prop_uri"],
+                            RDFS.comment,
+                            Literal(change["description"]),
+                        )
+                    )
 
         # Apply relationship name suggestions
         if "relationships" in name_suggestions:
@@ -1842,7 +2069,9 @@ class OntologyGenerator:
                         self.graph.remove((rel_uri, RDFS.label, None))
                         self.graph.add((rel_uri, RDFS.label, Literal(suggested)))
                         # Also add a semantic name annotation
-                        self.graph.add((rel_uri, self.oba_ns.semanticName, Literal(suggested)))
+                        self.graph.add(
+                            (rel_uri, self.oba_ns.semanticName, Literal(suggested))
+                        )
                         changes_made += 1
 
                     if description:
@@ -1853,6 +2082,3 @@ class OntologyGenerator:
         logger.info(f"Applied {changes_made} semantic name changes to ontology")
 
         return self.graph.serialize(format="turtle")
-
-
-

--- a/src/oxigraph_store.py
+++ b/src/oxigraph_store.py
@@ -7,10 +7,11 @@ Stores ontologies, schema metadata, and accumulated knowledge across sessions.
 
 import logging
 from pathlib import Path
-from typing import List, Dict, Any, Optional
+from typing import Any, Dict, List, Optional
 
 try:
-    from pyoxigraph import Store, NamedNode, Literal, Triple, RdfFormat
+    from pyoxigraph import Literal, NamedNode, RdfFormat, Store, Triple
+
     OXIGRAPH_AVAILABLE = True
 except ImportError:
     OXIGRAPH_AVAILABLE = False
@@ -29,8 +30,7 @@ def _escape_sparql_literal(value: str) -> str:
     Prevents SPARQL injection by escaping special characters.
     """
     return (
-        value
-        .replace("\\", "\\\\")
+        value.replace("\\", "\\\\")
         .replace('"', '\\"')
         .replace("'", "\\'")
         .replace("\n", "\\n")
@@ -75,9 +75,7 @@ class OxigraphStoreManager:
             except OSError:
                 lock_file = store_path / "store" / "LOCK"
                 if lock_file.exists():
-                    logger.warning(
-                        f"Removing stale Oxigraph lock file: {lock_file}"
-                    )
+                    logger.warning(f"Removing stale Oxigraph lock file: {lock_file}")
                     lock_file.unlink()
                     self.store = Store(str(store_path))
                 else:
@@ -90,12 +88,7 @@ class OxigraphStoreManager:
         # Track loaded ontologies
         self._loaded_ontologies: Dict[str, str] = {}  # schema_name -> graph_uri
 
-    def load_ontology(
-        self,
-        ontology_ttl: str,
-        graph_uri: str,
-        schema_name: str
-    ) -> int:
+    def load_ontology(self, ontology_ttl: str, graph_uri: str, schema_name: str) -> int:
         """
         Load ontology into the store.
 
@@ -115,27 +108,27 @@ class OxigraphStoreManager:
             try:
                 # Try with RdfFormat object (pyoxigraph >= 0.4.0)
                 self.store.load(
-                    ontology_ttl.encode('utf-8'),
+                    ontology_ttl.encode("utf-8"),
                     format=RdfFormat.TURTLE,
                     base_iri=graph_uri,
-                    to_graph=NamedNode(graph_uri)
+                    to_graph=NamedNode(graph_uri),
                 )
             except (TypeError, AttributeError):
                 # Fallback for older pyoxigraph versions
                 try:
                     self.store.load(
-                        ontology_ttl.encode('utf-8'),
+                        ontology_ttl.encode("utf-8"),
                         format="text/turtle",
                         base_iri=graph_uri,
-                        to_graph=NamedNode(graph_uri)
+                        to_graph=NamedNode(graph_uri),
                     )
                 except TypeError:
                     # Final fallback for very old versions using mime_type
                     self.store.load(
-                        ontology_ttl.encode('utf-8'),
+                        ontology_ttl.encode("utf-8"),
                         mime_type="text/turtle",
                         base_iri=graph_uri,
-                        to_graph=NamedNode(graph_uri)
+                        to_graph=NamedNode(graph_uri),
                     )
 
             triples_after = len(self.store)
@@ -155,9 +148,7 @@ class OxigraphStoreManager:
             raise
 
     def query_sparql(
-        self,
-        sparql_query: str,
-        timeout_seconds: Optional[int] = 30
+        self, sparql_query: str, timeout_seconds: Optional[int] = 30
     ) -> List[Dict[str, Any]]:
         """
         Execute SPARQL query.
@@ -189,7 +180,7 @@ class OxigraphStoreManager:
                 binding = {}
                 for var, term in solution.items():
                     # Convert RDF terms to strings
-                    if hasattr(term, 'value'):
+                    if hasattr(term, "value"):
                         binding[str(var)] = term.value
                     else:
                         binding[str(var)] = str(term)
@@ -229,17 +220,18 @@ class OxigraphStoreManager:
             result = self.store.query(sparql_query)
             # ASK queries return a boolean, not an iterator
             # pyoxigraph query() returns the boolean value for ASK queries
-            return bool(result) if isinstance(result, bool) else bool(next(iter(result), False))
+            return (
+                bool(result)
+                if isinstance(result, bool)
+                else bool(next(iter(result), False))
+            )
         except StopIteration:
             return False
         except Exception as e:
             logger.error(f"SPARQL ASK query failed: {e}", exc_info=True)
             raise
 
-    def query_sparql_construct(
-        self,
-        sparql_query: str
-    ) -> str:
+    def query_sparql_construct(self, sparql_query: str) -> str:
         """
         Execute SPARQL CONSTRUCT query.
 
@@ -278,7 +270,7 @@ class OxigraphStoreManager:
         predicate: str,
         object: str,
         graph_uri: Optional[str] = None,
-        object_is_literal: bool = False
+        object_is_literal: bool = False,
     ):
         """
         Add a single RDF triple to the store.
@@ -325,7 +317,7 @@ class OxigraphStoreManager:
         predicate: str,
         object: str,
         metadata: Optional[Dict[str, Any]] = None,
-        graph_uri: str = "http://example.com/knowledge"
+        graph_uri: str = "http://example.com/knowledge",
     ):
         """
         Add learned knowledge to the store with metadata.
@@ -354,7 +346,9 @@ class OxigraphStoreManager:
         """
         try:
             # Add main triple
-            self.add_triple(subject, predicate, object, graph_uri, object_is_literal=True)
+            self.add_triple(
+                subject, predicate, object, graph_uri, object_is_literal=True
+            )
 
             # Add metadata triples
             if metadata:
@@ -365,7 +359,7 @@ class OxigraphStoreManager:
                         meta_predicate,
                         str(value),
                         graph_uri,
-                        object_is_literal=True
+                        object_is_literal=True,
                     )
 
             logger.info(f"Added knowledge: {subject} -> {predicate}")
@@ -397,12 +391,9 @@ class OxigraphStoreManager:
                     }}
                 """
                 results = list(self.store.query(query))
-                triple_count = int(results[0]['count'].value) if results else 0
+                triple_count = int(results[0]["count"].value) if results else 0
 
-                return {
-                    "graph_uri": graph_uri,
-                    "triple_count": triple_count
-                }
+                return {"graph_uri": graph_uri, "triple_count": triple_count}
             else:
                 # Overall statistics
                 total_triples = len(self.store)
@@ -419,8 +410,8 @@ class OxigraphStoreManager:
                 return {
                     "total_triples": total_triples,
                     "named_graphs": len(graphs),
-                    "graphs": [str(g['g']) for g in graphs],
-                    "loaded_ontologies": dict(self._loaded_ontologies)
+                    "graphs": [str(g["g"]) for g in graphs],
+                    "loaded_ontologies": dict(self._loaded_ontologies),
                 }
 
         except Exception as e:
@@ -452,12 +443,10 @@ class OxigraphStoreManager:
         """
 
         results = self.query_sparql(query)
-        return [r['tableName'] for r in results]
+        return [r["tableName"] for r in results]
 
     def find_columns_by_type(
-        self,
-        data_type: str,
-        schema_graph: Optional[str] = None
+        self, data_type: str, schema_graph: Optional[str] = None
     ) -> List[Dict[str, str]]:
         """
         Find columns by data type using SPARQL.
@@ -490,19 +479,11 @@ class OxigraphStoreManager:
 
         results = self.query_sparql(query)
         return [
-            {
-                "table": r['tableName'],
-                "column": r['columnName'],
-                "type": r['dataType']
-            }
+            {"table": r["tableName"], "column": r["columnName"], "type": r["dataType"]}
             for r in results
         ]
 
-    def export_graph(
-        self,
-        graph_uri: str,
-        format: str = "turtle"
-    ) -> str:
+    def export_graph(self, graph_uri: str, format: str = "turtle") -> str:
         """
         Export a named graph.
 
@@ -527,6 +508,6 @@ class OxigraphStoreManager:
 
     def close(self):
         """Close the store (flush to disk if persistent)."""
-        if hasattr(self.store, 'close'):
+        if hasattr(self.store, "close"):
             self.store.close()
         logger.info("Closed Oxigraph store")

--- a/src/paths.py
+++ b/src/paths.py
@@ -10,7 +10,6 @@ from typing import Optional
 
 from .constants import DEFAULT_OUTPUT_DIR
 
-
 # Project root: parent of the src/ directory
 PROJECT_ROOT = Path(__file__).parent.parent
 
@@ -97,5 +96,3 @@ def get_charts_dir(connection_id: str) -> Path:
     charts_dir = OUTPUT_DIR / connection_id / "charts"
     charts_dir.mkdir(parents=True, exist_ok=True)
     return charts_dir
-
-

--- a/src/r2rml_generator.py
+++ b/src/r2rml_generator.py
@@ -13,9 +13,9 @@ R2RML mappings enable:
 
 import logging
 import re
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional
 
-from .database_manager import TableInfo, ColumnInfo
+from .database_manager import ColumnInfo, TableInfo
 
 logger = logging.getLogger(__name__)
 
@@ -33,9 +33,7 @@ class R2RMLGenerator:
     """
 
     def __init__(
-        self,
-        base_iri: str = "http://example.com/",
-        database_name: str = "database"
+        self, base_iri: str = "http://example.com/", database_name: str = "database"
     ):
         """Initialize the R2RML generator.
 
@@ -43,13 +41,11 @@ class R2RMLGenerator:
             base_iri: Base IRI for generated RDF resources (must end with /)
             database_name: Name of the database (used in comments)
         """
-        self.base_iri = base_iri if base_iri.endswith('/') else base_iri + '/'
+        self.base_iri = base_iri if base_iri.endswith("/") else base_iri + "/"
         self.database_name = database_name
 
     def generate_from_schema(
-        self,
-        tables_info: List[TableInfo],
-        schema_name: Optional[str] = None
+        self, tables_info: List[TableInfo], schema_name: Optional[str] = None
     ) -> str:
         """Generate R2RML mapping from database schema information.
 
@@ -75,7 +71,9 @@ class R2RMLGenerator:
 
         # Generate TriplesMap for each table
         for table_info in tables_info:
-            lines.extend(self._generate_triples_map(table_info, schema_name, table_lookup))
+            lines.extend(
+                self._generate_triples_map(table_info, schema_name, table_lookup)
+            )
             lines.append("")
 
         return "\n".join(lines)
@@ -93,7 +91,7 @@ class R2RMLGenerator:
         self,
         table_info: TableInfo,
         schema_name: Optional[str],
-        table_lookup: Dict[str, TableInfo]
+        table_lookup: Dict[str, TableInfo],
     ) -> List[str]:
         """Generate a TriplesMap for a single table.
 
@@ -135,21 +133,25 @@ class R2RMLGenerator:
         lines.append("    ] ;")
 
         # Subject map
-        lines.append(f'    rr:subjectMap [ rr:template "{subject_template}" ; rr:class base:{class_name} ] ;')
+        lines.append(
+            f'    rr:subjectMap [ rr:template "{subject_template}" ; rr:class base:{class_name} ] ;'
+        )
 
         # Build FK lookup for this table
         fk_columns = {}
         for fk in table_info.foreign_keys:
-            fk_columns[fk['column']] = fk
+            fk_columns[fk["column"]] = fk
 
         # Predicate-object maps for each column
         for column in table_info.columns:
             fk = fk_columns.get(column.name)
             if fk:
                 # Foreign key column - generate object property with IRI reference
-                lines.extend(self._generate_fk_predicate_object_map(
-                    column, fk, effective_schema, table_lookup
-                ))
+                lines.extend(
+                    self._generate_fk_predicate_object_map(
+                        column, fk, effective_schema, table_lookup
+                    )
+                )
             else:
                 # Regular column - generate data property with literal value
                 lines.extend(self._generate_predicate_object_map(column, table_name))
@@ -163,9 +165,7 @@ class R2RMLGenerator:
         return lines
 
     def _generate_subject_template(
-        self,
-        table_info: TableInfo,
-        schema_name: Optional[str]
+        self, table_info: TableInfo, schema_name: Optional[str]
     ) -> str:
         """Generate subject IRI template based on primary keys.
 
@@ -190,8 +190,12 @@ class R2RMLGenerator:
             # No primary key defined - use all columns as fallback (not ideal)
             # Try to find an 'id' column
             id_col = next(
-                (c.name for c in table_info.columns if c.name.lower() in ['id', 'rowid', '_id']),
-                None
+                (
+                    c.name
+                    for c in table_info.columns
+                    if c.name.lower() in ["id", "rowid", "_id"]
+                ),
+                None,
             )
             if id_col:
                 return f"{self.base_iri}{table_name}/{{{id_col}}}"
@@ -204,9 +208,7 @@ class R2RMLGenerator:
                 return f"{self.base_iri}{table_name}/{{{first_col}}}"
 
     def _generate_predicate_object_map(
-        self,
-        column: ColumnInfo,
-        table_name: str
+        self, column: ColumnInfo, table_name: str
     ) -> List[str]:
         """Generate predicate-object map for a regular column.
 
@@ -236,7 +238,7 @@ class R2RMLGenerator:
         column: ColumnInfo,
         fk: Dict[str, str],
         schema_name: Optional[str],
-        table_lookup: Dict[str, TableInfo]
+        table_lookup: Dict[str, TableInfo],
     ) -> List[str]:
         """Generate predicate-object map for a foreign key column.
 
@@ -254,7 +256,7 @@ class R2RMLGenerator:
         """
         lines = []
         predicate_name = self._safe_identifier(column.name)
-        ref_table = fk['referenced_table']
+        ref_table = fk["referenced_table"]
 
         # Build the referenced IRI template
         # Use the FK column value to construct the referenced resource IRI
@@ -284,7 +286,19 @@ class R2RMLGenerator:
         # Integer types
         if "tinyint" in sql_type:
             return "xsd:byte"
-        if any(t in sql_type for t in ["integer", "int", "int4", "int2", "int8", "serial", "bigint", "smallint"]):
+        if any(
+            t in sql_type
+            for t in [
+                "integer",
+                "int",
+                "int4",
+                "int2",
+                "int8",
+                "serial",
+                "bigint",
+                "smallint",
+            ]
+        ):
             return "xsd:integer"
 
         # Numeric types
@@ -327,10 +341,10 @@ class R2RMLGenerator:
             return "unnamed"
 
         # Replace non-alphanumeric characters with underscores
-        safe = re.sub(r'[^A-Za-z0-9_]', '_', name)
+        safe = re.sub(r"[^A-Za-z0-9_]", "_", name)
 
         # Ensure it starts with a letter or underscore
-        if safe and not (safe[0].isalpha() or safe[0] == '_'):
-            safe = '_' + safe
+        if safe and not (safe[0].isalpha() or safe[0] == "_"):
+            safe = "_" + safe
 
         return safe or "unnamed"

--- a/src/resources.py
+++ b/src/resources.py
@@ -34,9 +34,7 @@ def _read_skill(filename: str) -> str:
     skills_path = get_skills_dir() / filename
     if skills_path.exists():
         return skills_path.read_text()
-    return (
-        f"Skill not found. Please ensure .claude/skills/{filename} exists."
-    )
+    return f"Skill not found. Please ensure .claude/skills/{filename} exists."
 
 
 def _make_skill_loader(filename: str, title: str):

--- a/src/security.py
+++ b/src/security.py
@@ -7,7 +7,7 @@ import os
 import re
 from enum import Enum
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives import hashes
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 class SecurityLevel(Enum):
     """Security levels for different operations."""
+
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"
@@ -31,12 +32,12 @@ class SecureCredentialManager:
     def __init__(self, master_password: Optional[str] = None):
         """Initialize with optional master password for encryption."""
         self._cipher: Optional[Fernet] = None
-        self._salt_file = Path.home() / '.mcp_credential_salt'
+        self._salt_file = Path.home() / ".mcp_credential_salt"
 
         # Try to get master password from environment if not provided
         if not master_password:
             load_dotenv()
-            master_password = os.getenv('MCP_MASTER_PASSWORD')
+            master_password = os.getenv("MCP_MASTER_PASSWORD")
 
         if master_password:
             self._initialize_encryption(master_password)
@@ -60,12 +61,10 @@ class SecureCredentialManager:
         """Get existing salt or create a new one with secure permissions."""
         try:
             if self._salt_file.exists():
-                with open(self._salt_file, 'rb') as f:
+                with open(self._salt_file, "rb") as f:
                     salt = f.read()
                     if len(salt) == 16:  # Validate salt length
-                        logger.debug(
-                            "Using existing salt for credential encryption"
-                        )
+                        logger.debug("Using existing salt for credential encryption")
                         return salt
                     else:
                         logger.warning("Invalid salt file, creating new salt")
@@ -74,7 +73,7 @@ class SecureCredentialManager:
             salt = os.urandom(16)
 
             # Write salt with secure permissions
-            with open(self._salt_file, 'wb') as f:
+            with open(self._salt_file, "wb") as f:
                 f.write(salt)
 
             # Set restrictive permissions (owner read/write only)
@@ -101,7 +100,7 @@ class SecureCredentialManager:
         safe_creds = self._sanitize_credentials(credentials)
         logger.debug(
             "Encrypting credentials for %s connection",
-            safe_creds.get('type', 'unknown')
+            safe_creds.get("type", "unknown"),
         )
 
         json_data = json.dumps(credentials).encode()
@@ -116,24 +115,29 @@ class SecureCredentialManager:
         try:
             decoded_data = base64.urlsafe_b64decode(encrypted_data.encode())
             decrypted_data = self._cipher.decrypt(decoded_data)
-            credentials_dict: Dict[str, Any] = json.loads(
-                decrypted_data.decode()
-            )
+            credentials_dict: Dict[str, Any] = json.loads(decrypted_data.decode())
             return credentials_dict
         except Exception as e:
             logger.error("Failed to decrypt credentials: %s", e)
             raise ValueError("Invalid or corrupted credential data") from e
 
-    def _sanitize_credentials(
-        self, credentials: Dict[str, Any]
-    ) -> Dict[str, Any]:
+    def _sanitize_credentials(self, credentials: Dict[str, Any]) -> Dict[str, Any]:
         """Remove sensitive information for logging."""
         sensitive_keys = {
-            'password', 'passwd', 'pwd', 'secret', 'token', 'key', 'pat', 'api_key'
+            "password",
+            "passwd",
+            "pwd",
+            "secret",
+            "token",
+            "key",
+            "pat",
+            "api_key",
         }
         # Check if key contains any sensitive substrings
         return {
-            k: '***REDACTED***' if any(sens in k.lower() for sens in sensitive_keys) and v else v
+            k: "***REDACTED***"
+            if any(sens in k.lower() for sens in sensitive_keys) and v
+            else v
             for k, v in credentials.items()
         }
 
@@ -144,48 +148,49 @@ class SQLInjectionValidator:
     # Dangerous SQL patterns that should be blocked
     DANGEROUS_PATTERNS = [
         # Multiple statements with DDL/DML
-        r';.*(?:DROP|DELETE|INSERT|UPDATE|CREATE|ALTER|TRUNCATE)',
+        r";.*(?:DROP|DELETE|INSERT|UPDATE|CREATE|ALTER|TRUNCATE)",
         # Classic injection patterns (but NOT blocking UNION/UNION ALL)
-        r'OR\s+1\s*=\s*1',  # Always true conditions
-        r'AND\s+1\s*=\s*1',  # Always true conditions
+        r"OR\s+1\s*=\s*1",  # Always true conditions
+        r"AND\s+1\s*=\s*1",  # Always true conditions
         r"OR\s+'[^']*'\s*=\s*'[^']*'",  # String-based always true
         # SQL comment injection patterns
         r"'[^']*'\s*--",  # String literal followed by SQL comment (injection pattern)
-        r'/\*.*\*/',  # Block comments (can be used to obfuscate or inject)
+        r"/\*.*\*/",  # Block comments (can be used to obfuscate or inject)
         # Multiple semicolons or semicolon with dangerous operations
-        r';\s*;',  # Multiple semicolons
-        r';\s*(?:DROP|DELETE|INSERT|UPDATE|CREATE|ALTER|TRUNCATE)',  # Semicolon followed by DDL/DML
+        r";\s*;",  # Multiple semicolons
+        r";\s*(?:DROP|DELETE|INSERT|UPDATE|CREATE|ALTER|TRUNCATE)",  # Semicolon followed by DDL/DML
         # SQL Server command execution
-        r'xp_cmdshell|sp_executesql|exec\s*\(',
+        r"xp_cmdshell|sp_executesql|exec\s*\(",
         # MySQL file operations
-        r'load_file|into\s+outfile|into\s+dumpfile',
+        r"load_file|into\s+outfile|into\s+dumpfile",
         # PostgreSQL file operations
-        r'pg_read_file|copy.*from|copy.*to',
+        r"pg_read_file|copy.*from|copy.*to",
         # System tables that shouldn't be accessed directly in normal queries
-        r'information_schema\.(?:user_privileges|schema_privileges|table_privileges)',
-        r'pg_catalog\.pg_authid|pg_catalog\.pg_user_mapping',
+        r"information_schema\.(?:user_privileges|schema_privileges|table_privileges)",
+        r"pg_catalog\.pg_authid|pg_catalog\.pg_user_mapping",
         # Dangerous UNION queries attempting to extract sensitive data
-        r'UNION\s+(?:ALL\s+)?SELECT\s+.*(?:password|pwd|secret|token|key|admin)',
+        r"UNION\s+(?:ALL\s+)?SELECT\s+.*(?:password|pwd|secret|token|key|admin)",
     ]
 
     # Safe SQL patterns that are allowed
     # Optional comment prefix: allows -- comments and /* */ comments at start of query
     # Note: After _clean_query(), newlines become spaces, so -- comment ends at next SQL keyword
     # Pattern matches: optional (-- followed by non-SQL text, or /* ... */) followed by whitespace
-    _OPT_COMMENT = r'^(?:--[^;]*?\s+)?'
+    _OPT_COMMENT = r"^(?:--[^;]*?\s+)?"
 
     SAFE_PATTERNS = [
         # Basic SELECT queries with JOINs (with optional leading comments)
-        _OPT_COMMENT + r'SELECT\s+.+\s+FROM\s+.+$',
+        _OPT_COMMENT + r"SELECT\s+.+\s+FROM\s+.+$",
         # CTEs (WITH clauses) - now more permissive for complex queries
-        _OPT_COMMENT + r'WITH\s+.+\s+SELECT\s+.+$',
+        _OPT_COMMENT + r"WITH\s+.+\s+SELECT\s+.+$",
         # Metadata queries
         _OPT_COMMENT + r'DESCRIBE\s+[\w\."]+$',
         _OPT_COMMENT + r'DESC\s+[\w\."]+$',
-        _OPT_COMMENT + r'SHOW\s+(?:TABLES|COLUMNS|DATABASES|SCHEMAS)(?:\s+FROM\s+[\w\."]+)?$',
-        _OPT_COMMENT + r'EXPLAIN\s+.+$',
+        _OPT_COMMENT
+        + r'SHOW\s+(?:TABLES|COLUMNS|DATABASES|SCHEMAS)(?:\s+FROM\s+[\w\."]+)?$',
+        _OPT_COMMENT + r"EXPLAIN\s+.+$",
         # UNION queries (both UNION and UNION ALL) - Note: Will still be blocked if dangerous patterns match
-        r'.+\s+UNION\s+(?:ALL\s+)?SELECT\s+.+',
+        r".+\s+UNION\s+(?:ALL\s+)?SELECT\s+.+",
     ]
 
     def __init__(self) -> None:
@@ -205,7 +210,7 @@ class SQLInjectionValidator:
                 "is_safe": False,
                 "risk_level": SecurityLevel.HIGH.value,
                 "issues": ["Empty query"],
-                "sanitized_query": ""
+                "sanitized_query": "",
             }
 
         # Clean up query for analysis
@@ -217,8 +222,7 @@ class SQLInjectionValidator:
         for pattern in self.compiled_dangerous:
             if pattern.search(cleaned_query):
                 issues.append(
-                    f"Potentially dangerous SQL pattern detected: "
-                    f"{pattern.pattern}"
+                    f"Potentially dangerous SQL pattern detected: " f"{pattern.pattern}"
                 )
                 risk_level = SecurityLevel.CRITICAL
 
@@ -228,7 +232,7 @@ class SQLInjectionValidator:
         # detection is the parser-based analyze_sql_statement() gate; this is a
         # coarse first filter.
         literal_stripped = re.sub(r"'(?:[^']|'')*'", "''", cleaned_query)
-        statements = [s.strip() for s in literal_stripped.split(';') if s.strip()]
+        statements = [s.strip() for s in literal_stripped.split(";") if s.strip()]
         if len(statements) > 1:
             issues.append("Multiple SQL statements not allowed")
             risk_level = SecurityLevel.CRITICAL
@@ -249,7 +253,7 @@ class SQLInjectionValidator:
             "is_safe": is_safe,
             "risk_level": risk_level.value,
             "issues": issues,
-            "sanitized_query": self._sanitize_query_for_logging(cleaned_query)
+            "sanitized_query": self._sanitize_query_for_logging(cleaned_query),
         }
 
     def _clean_query(self, sql_query: str) -> str:
@@ -258,13 +262,11 @@ class SQLInjectionValidator:
         cleaned = sql_query.strip()
 
         # Normalize whitespace
-        cleaned = re.sub(r'\s+', ' ', cleaned)
+        cleaned = re.sub(r"\s+", " ", cleaned)
 
         return cleaned
 
-    def _sanitize_query_for_logging(
-        self, sql_query: str, max_length: int = 200
-    ) -> str:
+    def _sanitize_query_for_logging(self, sql_query: str, max_length: int = 200) -> str:
         """Sanitize SQL query for safe logging."""
         # Remove potential sensitive data patterns
         sanitized = re.sub(r"'[^']*'", "'***'", sql_query)  # String literals
@@ -282,7 +284,7 @@ class IdentifierValidator:
     """Validates database identifiers to prevent injection."""
 
     # Valid identifier pattern (letters, numbers, underscores only - no hyphens)
-    VALID_IDENTIFIER = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*$')
+    VALID_IDENTIFIER = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
     @classmethod
     def validate_identifier(cls, identifier: str) -> bool:
@@ -302,7 +304,7 @@ class IdentifierValidator:
         if not identifier:
             return False
 
-        parts = identifier.split('.')
+        parts = identifier.split(".")
         if len(parts) > 3:  # database.schema.table max
             return False
 
@@ -315,11 +317,11 @@ class IdentifierValidator:
             return ""
 
         # Remove invalid characters (including hyphens)
-        sanitized = re.sub(r'[^a-zA-Z0-9_]', '_', identifier)
+        sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", identifier)
 
         # Ensure starts with letter or underscore
-        if sanitized and not sanitized[0].isalpha() and sanitized[0] != '_':
-            sanitized = '_' + sanitized
+        if sanitized and not sanitized[0].isalpha() and sanitized[0] != "_":
+            sanitized = "_" + sanitized
 
         # Limit length
         return sanitized[:128]
@@ -328,19 +330,26 @@ class IdentifierValidator:
 def audit_log_security_event(
     event_type: str,
     details: Dict[str, Any],
-    risk_level: SecurityLevel = SecurityLevel.MEDIUM
+    risk_level: SecurityLevel = SecurityLevel.MEDIUM,
 ) -> None:
     """Log security-related events for auditing."""
     # Sanitize details before logging
     safe_details = {}
     sensitive_keys = {
-        'password', 'passwd', 'pwd', 'secret', 'token', 'key', 'pat', 'api_key'
+        "password",
+        "passwd",
+        "pwd",
+        "secret",
+        "token",
+        "key",
+        "pat",
+        "api_key",
     }
 
     for key, value in details.items():
         # Check if key contains any sensitive substring
         if any(sens in key.lower() for sens in sensitive_keys):
-            safe_details[key] = '***REDACTED***'
+            safe_details[key] = "***REDACTED***"
         else:
             safe_details[key] = value
 
@@ -352,8 +361,14 @@ def audit_log_security_event(
 
 #: AST node types that mutate data or schema — never allowed for analytics SQL.
 _WRITE_EXPRESSIONS = (
-    "Insert", "Update", "Delete", "Merge",
-    "Create", "Drop", "Alter", "TruncateTable",
+    "Insert",
+    "Update",
+    "Delete",
+    "Merge",
+    "Create",
+    "Drop",
+    "Alter",
+    "TruncateTable",
 )
 
 
@@ -391,7 +406,9 @@ def analyze_sql_statement(sql_query: str, dialect: str = "postgres") -> Dict[str
     }
 
     try:
-        statements = [s for s in sqlglot.parse(sql_query, dialect=dialect) if s is not None]
+        statements = [
+            s for s in sqlglot.parse(sql_query, dialect=dialect) if s is not None
+        ]
     except Exception as e:  # sqlglot.errors.ParseError and friends
         result["error"] = f"SQL parse error: {e}"
         return result
@@ -406,7 +423,9 @@ def analyze_sql_statement(sql_query: str, dialect: str = "postgres") -> Dict[str
         return result
 
     stmt = statements[0]
-    write_types = tuple(getattr(exp, name) for name in _WRITE_EXPRESSIONS if hasattr(exp, name))
+    write_types = tuple(
+        getattr(exp, name) for name in _WRITE_EXPRESSIONS if hasattr(exp, name)
+    )
 
     # Detect write/DDL nodes anywhere in the tree (including nested in CTEs).
     writes = sorted({type(n).__name__ for n in stmt.find_all(*write_types)})
@@ -417,7 +436,9 @@ def analyze_sql_statement(sql_query: str, dialect: str = "postgres") -> Dict[str
         return result
 
     if isinstance(stmt, (exp.Select, exp.Union)):
-        result["query_type"] = "CTE_SELECT" if stmt.find(exp.With) is not None else "SELECT"
+        result["query_type"] = (
+            "CTE_SELECT" if stmt.find(exp.With) is not None else "SELECT"
+        )
         result["is_read_only"] = True
     elif isinstance(stmt, (exp.Describe, exp.Show, exp.Command)):
         # EXPLAIN parses to Command in sqlglot; DESCRIBE/SHOW are metadata.
@@ -427,7 +448,9 @@ def analyze_sql_statement(sql_query: str, dialect: str = "postgres") -> Dict[str
         result["error"] = "Only SELECT, CTE, and metadata queries are allowed"
         return result
 
-    result["affected_tables"] = sorted({t.name for t in stmt.find_all(exp.Table) if t.name})
+    result["affected_tables"] = sorted(
+        {t.name for t in stmt.find_all(exp.Table) if t.name}
+    )
     return result
 
 

--- a/src/serialization.py
+++ b/src/serialization.py
@@ -46,7 +46,9 @@ def serialize_row(row: Sequence[Any], columns: List[str]) -> Dict[str, Any]:
     return row_dict
 
 
-def serialize_rows(rows: Sequence[Sequence[Any]], columns: List[str]) -> List[Dict[str, Any]]:
+def serialize_rows(
+    rows: Sequence[Sequence[Any]], columns: List[str]
+) -> List[Dict[str, Any]]:
     """Serialize multiple database rows into JSON-compatible dicts.
 
     Args:

--- a/src/server_state.py
+++ b/src/server_state.py
@@ -72,7 +72,11 @@ def _calculate_schema_hash(tables_info: List[Any]) -> str:
         sorted_columns = sorted(table.columns, key=lambda c: c.name)
         for col in sorted_columns:
             table_data["columns"].append(
-                {"name": col.name, "data_type": col.data_type, "nullable": col.is_nullable}
+                {
+                    "name": col.name,
+                    "data_type": col.data_type,
+                    "nullable": col.is_nullable,
+                }
             )
 
         if table.foreign_keys:
@@ -92,7 +96,9 @@ def _calculate_schema_hash(tables_info: List[Any]) -> str:
     return hashlib.sha256(json_str.encode()).hexdigest()
 
 
-def _clear_session_state(session: SessionData, reason: str = "connection change") -> None:
+def _clear_session_state(
+    session: SessionData, reason: str = "connection change"
+) -> None:
     """Clear all session state caches and indexes."""
     logger.info(f"Clearing session state ({reason})")
 
@@ -146,12 +152,16 @@ class ServerState:
                 try:
                     session.db_manager.disconnect()
                 except Exception as e:
-                    logger.warning(f"Error disconnecting db for session {session_id}: {e}")
+                    logger.warning(
+                        f"Error disconnecting db for session {session_id}: {e}"
+                    )
             if session.rdf_store.oxigraph_store:
                 try:
                     session.rdf_store.oxigraph_store.close()
                 except Exception as e:
-                    logger.warning(f"Error closing Oxigraph for session {session_id}: {e}")
+                    logger.warning(
+                        f"Error closing Oxigraph for session {session_id}: {e}"
+                    )
             del self._sessions[session_id]
             logger.debug(f"Cleaned up session: {session_id}")
 
@@ -273,11 +283,17 @@ def get_session_obqc_validator(ctx: Context) -> Optional[OBQCValidator]:
         ontology_generator = OntologyGenerator(base_uri)
 
         if has_generated_ontology:
-            conn_dir = get_connection_dir(session.connection_id) if session.connection_id else ensure_output_dir()
+            conn_dir = (
+                get_connection_dir(session.connection_id)
+                if session.connection_id
+                else ensure_output_dir()
+            )
             ontology_path = conn_dir / session.ontology_file
             if ontology_path.exists():
                 ontology_generator.load_from_file(str(ontology_path))
-                logger.debug(f"OBQC loaded ontology from session file: {session.ontology_file}")
+                logger.debug(
+                    f"OBQC loaded ontology from session file: {session.ontology_file}"
+                )
         elif has_loaded_ontology:
             ontology_generator.load_from_string(session.loaded_ontology)
             logger.debug(
@@ -309,9 +325,15 @@ def load_ontology_from_session(ctx: Context) -> tuple[OntologyGenerator, str]:
     session = get_session_data(ctx)
     filename = session.ontology_file
     if not filename:
-        raise ValueError("No ontology file in session state. Run generate_ontology first.")
+        raise ValueError(
+            "No ontology file in session state. Run generate_ontology first."
+        )
 
-    conn_dir = get_connection_dir(session.connection_id) if session.connection_id else ensure_output_dir()
+    conn_dir = (
+        get_connection_dir(session.connection_id)
+        if session.connection_id
+        else ensure_output_dir()
+    )
     ontology_path = conn_dir / filename
 
     if not ontology_path.exists():
@@ -325,6 +347,7 @@ def load_ontology_from_session(ctx: Context) -> tuple[OntologyGenerator, str]:
 
 class ErrorResponse(BaseModel):
     """Standardized error response format."""
+
     error: str
     error_type: str = "unknown"
     details: Optional[str] = None
@@ -360,9 +383,13 @@ def get_oxigraph_store(ctx: Context) -> Optional[OxigraphStoreManager]:
             session.oxigraph_initialized = True
 
             if session.connection_id:
-                logger.info(f"Initialized connection-scoped Oxigraph store at: {store_path}")
+                logger.info(
+                    f"Initialized connection-scoped Oxigraph store at: {store_path}"
+                )
             else:
-                logger.info(f"Initialized Oxigraph store at: {store_path} (legacy mode)")
+                logger.info(
+                    f"Initialized Oxigraph store at: {store_path} (legacy mode)"
+                )
 
         except Exception as e:
             logger.error(f"Failed to initialize Oxigraph store: {e}")

--- a/src/session.py
+++ b/src/session.py
@@ -11,7 +11,7 @@ Each MCP session gets its own SessionData instance containing:
 import asyncio
 import logging
 from datetime import datetime
-from typing import Optional, Dict, List, Any
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,9 @@ class OntologyState:
         self.r2rml_file: Optional[str] = None
         self.loaded_ontology: Optional[str] = None  # TTL content
         self.loaded_ontology_path: Optional[str] = None  # File path
-        self.obqc_validator: Optional[Any] = None  # OBQCValidator (avoid circular import)
+        self.obqc_validator: Optional[
+            Any
+        ] = None  # OBQCValidator (avoid circular import)
         self.ontology_enriched: bool = False  # True after semantic names applied
 
 
@@ -41,7 +43,9 @@ class SchemaCache:
     """Cached schema analysis results (multi-schema capable)."""
 
     def __init__(self):
-        self._cached_schema: Optional[Dict[str, List[Any]]] = None  # schema_name -> List[TableInfo]
+        self._cached_schema: Optional[
+            Dict[str, List[Any]]
+        ] = None  # schema_name -> List[TableInfo]
         self._last_analyzed_schema: Optional[str] = None
 
     def cache_schema_analysis(self, schema_name: str, tables_info: List[Any]) -> None:
@@ -51,7 +55,9 @@ class SchemaCache:
         cache_key = schema_name or "_default_"
         self._cached_schema[cache_key] = tables_info
         self._last_analyzed_schema = schema_name
-        logger.debug(f"Cached schema analysis for '{cache_key}': {len(tables_info)} tables")
+        logger.debug(
+            f"Cached schema analysis for '{cache_key}': {len(tables_info)} tables"
+        )
 
     def get_cached_schema(self, schema_name: str) -> Optional[List[Any]]:
         """Get cached schema analysis results if available."""
@@ -174,7 +180,9 @@ class SessionData:
         logger.debug(f"Current schema set to '{key}'")
         return self._schema_states[key]
 
-    def get_schema_state(self, schema_name: Optional[str] = None) -> Optional["SchemaState"]:
+    def get_schema_state(
+        self, schema_name: Optional[str] = None
+    ) -> Optional["SchemaState"]:
         """Get SchemaState for a specific or the current schema.
 
         Args:
@@ -189,7 +197,9 @@ class SessionData:
         key = key or "default"
         return self._schema_states.get(key)
 
-    def get_or_create_schema_state(self, schema_name: Optional[str] = None) -> "SchemaState":
+    def get_or_create_schema_state(
+        self, schema_name: Optional[str] = None
+    ) -> "SchemaState":
         """Get or create SchemaState for a specific or the current schema.
 
         If schema_name is None and no current schema is set, uses "default".

--- a/src/shacl_validator.py
+++ b/src/shacl_validator.py
@@ -81,7 +81,9 @@ def validate_ontology(ontology_ttl: str) -> Dict[str, Any]:
             meta_shacl=False,
         )
 
-        violations = 0 if conforms else max(results_text.count("Constraint Violation"), 1)
+        violations = (
+            0 if conforms else max(results_text.count("Constraint Violation"), 1)
+        )
         return {
             "available": True,
             "conforms": bool(conforms),

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -8,5 +8,5 @@ All other tool modules have been removed; their logic lives in ``src/handlers/``
 from .chart import generate_chart
 
 __all__ = [
-    'generate_chart',
+    "generate_chart",
 ]

--- a/src/tools/chart.py
+++ b/src/tools/chart.py
@@ -2,7 +2,7 @@
 
 import logging
 from datetime import datetime
-from typing import Dict, List, Any, Optional, Union, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ..chart_utils import create_plotly_chart
 
@@ -21,7 +21,7 @@ def generate_chart(
     height: int = 600,
     sort_by: Optional[str] = None,
     sort_order: Optional[str] = None,
-    output_format: str = "image"
+    output_format: str = "image",
 ) -> Union[Tuple[bytes, str], Dict[str, Any]]:
     """Generate chart and return either Plotly data or image bytes.
 
@@ -66,7 +66,9 @@ def generate_chart(
             missing_libs.append("plotly")
 
         if missing_libs:
-            return {"error": f"❌ Missing required visualization libraries: {', '.join(missing_libs)}. Install with: pip install {' '.join(missing_libs)}"}
+            return {
+                "error": f"❌ Missing required visualization libraries: {', '.join(missing_libs)}. Install with: pip install {' '.join(missing_libs)}"
+            }
 
         # Validate input data
         if not data_source:
@@ -79,7 +81,9 @@ def generate_chart(
 
         # Validate required columns
         if x_column not in df.columns:
-            return {"error": f"❌ X-axis column '{x_column}' not found in data. Available columns: {list(df.columns)}"}
+            return {
+                "error": f"❌ X-axis column '{x_column}' not found in data. Available columns: {list(df.columns)}"
+            }
 
         # Auto-detect time series data and switch to line chart
         def is_time_based_column(column_data):
@@ -94,17 +98,26 @@ def generate_chart(
                 return False
 
             # Check for common time-based patterns
-            if column_data.dtype == 'object' or column_data.dtype == 'string':
+            if column_data.dtype == "object" or column_data.dtype == "string":
                 for val in sample:
                     val_str = str(val).lower()
                     # Check for common date/time patterns
                     time_indicators = [
-                        'date', 'time', 'year', 'month', 'day', 'hour',
-                        'timestamp', 'period', 'quarter', 'week'
+                        "date",
+                        "time",
+                        "year",
+                        "month",
+                        "day",
+                        "hour",
+                        "timestamp",
+                        "period",
+                        "quarter",
+                        "week",
                     ]
                     # Check if value contains date separators or time indicators
-                    if any(sep in str(val) for sep in ['-', '/', ':', 'T']) or \
-                       any(ind in val_str for ind in time_indicators):
+                    if any(sep in str(val) for sep in ["-", "/", ":", "T"]) or any(
+                        ind in val_str for ind in time_indicators
+                    ):
                         try:
                             # Try to parse as datetime
                             pd.to_datetime(val)
@@ -118,7 +131,9 @@ def generate_chart(
         if x_column in df.columns and is_time_based_column(df[x_column]):
             if chart_type == "bar":
                 chart_type = "line"
-                logger.info(f"Auto-switched from bar to line chart due to time-based x-axis: {x_column}")
+                logger.info(
+                    f"Auto-switched from bar to line chart due to time-based x-axis: {x_column}"
+                )
 
             # Auto-set sorting for time series if not specified
             if sort_by is None:
@@ -130,23 +145,29 @@ def generate_chart(
         if chart_type in ["bar", "line", "scatter"] and y_column:
             if isinstance(y_column, list):
                 if chart_type not in ["bar", "line"]:
-                    return {"error": f"❌ Multiple y_columns only supported for bar and line charts, not {chart_type}"}
+                    return {
+                        "error": f"❌ Multiple y_columns only supported for bar and line charts, not {chart_type}"
+                    }
                 missing_cols = [col for col in y_column if col not in df.columns]
                 if missing_cols:
-                    return {"error": f"❌ Y-axis columns {missing_cols} not found in data. Available columns: {list(df.columns)}"}
+                    return {
+                        "error": f"❌ Y-axis columns {missing_cols} not found in data. Available columns: {list(df.columns)}"
+                    }
             else:
                 # Single measure
                 if y_column not in df.columns:
-                    return {"error": f"❌ Y-axis column '{y_column}' not found in data. Available columns: {list(df.columns)}"}
+                    return {
+                        "error": f"❌ Y-axis column '{y_column}' not found in data. Available columns: {list(df.columns)}"
+                    }
 
         # Generate title if not provided
         if not title:
             if chart_type == "bar":
                 if isinstance(y_column, list):
-                    y_label = ', '.join(y_column)
+                    y_label = ", ".join(y_column)
                     title = f"{y_label} by {x_column}"
                 else:
-                    y_label = y_column if isinstance(y_column, str) else 'Count'
+                    y_label = y_column if isinstance(y_column, str) else "Count"
                     title = f"{y_label} by {x_column}"
                 if chart_style == "stacked" and color_column:
                     title += f" (stacked by {color_column})"
@@ -158,41 +179,77 @@ def generate_chart(
             elif chart_type == "scatter":
                 title = f"{y_column} vs {x_column}"
             elif chart_type == "heatmap":
-                title = f"Heatmap of {x_column}" + (f" and {y_column}" if y_column else "")
+                title = f"Heatmap of {x_column}" + (
+                    f" and {y_column}" if y_column else ""
+                )
             else:
                 title = f"Chart of {x_column}"
 
         # Create chart ID for file naming and logging
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        safe_title = "".join(c for c in title.replace(" ", "_") if c.isalnum() or c in "_-")
+        safe_title = "".join(
+            c for c in title.replace(" ", "_") if c.isalnum() or c in "_-"
+        )
         chart_id = f"{chart_type}_{safe_title}_{timestamp}"
 
         # Handle interactive output format (return Plotly figure object)
         if output_format == "interactive":
             try:
-                fig = create_plotly_chart(df, chart_type, x_column, y_column, color_column, title, chart_style, width, height, sort_by, sort_order)
+                fig = create_plotly_chart(
+                    df,
+                    chart_type,
+                    x_column,
+                    y_column,
+                    color_column,
+                    title,
+                    chart_style,
+                    width,
+                    height,
+                    sort_by,
+                    sort_order,
+                )
 
-                logger.info(f"Created interactive {chart_type} chart with {len(df)} data points")
+                logger.info(
+                    f"Created interactive {chart_type} chart with {len(df)} data points"
+                )
                 return {
                     "figure": fig,
                     "metadata": {
                         "chart_id": chart_id,
                         "chart_type": chart_type,
                         "data_points": len(df),
-                    }
+                    },
                 }
 
             except ImportError as e:
                 logger.warning(f"Plotly not available for interactive mode: {e}")
-                return {"error": "Plotly required for interactive charts. Install with: pip install plotly"}
+                return {
+                    "error": "Plotly required for interactive charts. Install with: pip install plotly"
+                }
 
         # Handle image output format (return PNG bytes using Plotly + kaleido)
         try:
-            fig = create_plotly_chart(df, chart_type, x_column, y_column, color_column, title, chart_style, width, height, sort_by, sort_order)
-            image_bytes = fig.to_image(format='png', width=width, height=height, scale=2)
+            fig = create_plotly_chart(
+                df,
+                chart_type,
+                x_column,
+                y_column,
+                color_column,
+                title,
+                chart_style,
+                width,
+                height,
+                sort_by,
+                sort_order,
+            )
+            image_bytes = fig.to_image(
+                format="png", width=width, height=height, scale=2
+            )
         except Exception as e:
             if "kaleido" in str(e).lower():
-                return {"error": "❌ kaleido required for PNG export. Install with: pip install kaleido"}
+                return {
+                    "error": "❌ kaleido required for PNG export. Install with: pip install kaleido"
+                }
             raise
 
         logger.info(f"Created {chart_type} chart image with {len(df)} data points")

--- a/src/utils.py
+++ b/src/utils.py
@@ -31,7 +31,7 @@ def is_client_disconnect(exc: BaseException) -> bool:
     crashed task group.
     """
     try:
-        from anyio import ClosedResourceError, BrokenResourceError, EndOfStream
+        from anyio import BrokenResourceError, ClosedResourceError, EndOfStream
     except ImportError:
         return False
     return isinstance(exc, (ClosedResourceError, BrokenResourceError, EndOfStream))
@@ -60,7 +60,7 @@ def setup_logging(log_level: str = "INFO", structured: bool = False) -> logging.
     else:
         # Simple format for development and startup
         formatter = logging.Formatter(
-            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
         )
 
     # Get root logger
@@ -94,14 +94,23 @@ def sanitize_for_logging(data: Any) -> Any:
     if isinstance(data, dict):
         sanitized = {}
         sensitive_keys = {
-            'password', 'passwd', 'pwd', 'secret', 'api_key', 'apikey',
-            'token', 'auth', 'authorization', 'credentials', 'private_key'
+            "password",
+            "passwd",
+            "pwd",
+            "secret",
+            "api_key",
+            "apikey",
+            "token",
+            "auth",
+            "authorization",
+            "credentials",
+            "private_key",
         }
 
         for key, value in data.items():
             # Check if key name suggests sensitive data
             if any(sensitive in key.lower() for sensitive in sensitive_keys):
-                sanitized[key] = '***REDACTED***'
+                sanitized[key] = "***REDACTED***"
             elif isinstance(value, (dict, list)):
                 # Recursively sanitize nested structures
                 sanitized[key] = sanitize_for_logging(value)
@@ -132,7 +141,7 @@ def validate_uri(uri: str) -> bool:
     try:
         parsed = urlparse(uri)
         # Check scheme is http or https and has a netloc (domain)
-        return parsed.scheme in ('http', 'https') and bool(parsed.netloc)
+        return parsed.scheme in ("http", "https") and bool(parsed.netloc)
     except Exception:
         return False
 
@@ -150,7 +159,7 @@ def format_bytes(num_bytes: int) -> str:
     if num_bytes == 0:
         return "0 B"
 
-    units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
+    units = ["B", "KB", "MB", "GB", "TB", "PB"]
     unit_index = 0
     size = float(num_bytes)
 

--- a/src/workspace.py
+++ b/src/workspace.py
@@ -5,7 +5,7 @@ and format summaries for user-facing messages.
 """
 
 import logging
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 
 from .lifecycle.metadata import VersionMetadataManager
 from .paths import OUTPUT_DIR, get_connection_dir
@@ -67,7 +67,9 @@ def detect_workspace(connection_id: str) -> Optional[Dict[str, Any]]:
                     schema_status["ontology"] = {
                         "available": True,
                         "enriched": ontology_section.get("enriched", False),
-                        "persisted_to_rdf": ontology_section.get("persisted_to_rdf", False),
+                        "persisted_to_rdf": ontology_section.get(
+                            "persisted_to_rdf", False
+                        ),
                         "generated_at": ontology_section.get("generated_at"),
                     }
                 else:
@@ -137,7 +139,9 @@ def format_workspace_summary(workspace: Dict[str, Any]) -> str:
 
         schema_info = schema_data.get("schema", {})
         if schema_info.get("available"):
-            lines.append(f"    - Schema analysis: {schema_info.get('table_count', '?')} tables")
+            lines.append(
+                f"    - Schema analysis: {schema_info.get('table_count', '?')} tables"
+            )
         else:
             lines.append("    - Schema analysis: not available")
 
@@ -162,7 +166,11 @@ def format_workspace_summary(workspace: Dict[str, Any]) -> str:
         lines.append(f"  RDF store: {graph_count} graph(s)")
 
     lines.append("")
-    lines.append("NOTE: Auto-restore was not available. Workspace artifacts exist on disk.")
-    lines.append("Call discover_schema() to re-analyze, or reconnect to trigger auto-restore.")
+    lines.append(
+        "NOTE: Auto-restore was not available. Workspace artifacts exist on disk."
+    )
+    lines.append(
+        "Call discover_schema() to re-analyze, or reconnect to trigger auto-restore."
+    )
 
     return "\n".join(lines)

--- a/tests/test_artifact_schema_isolation.py
+++ b/tests/test_artifact_schema_isolation.py
@@ -37,9 +37,7 @@ async def test_download_ontology_uses_requested_schema_not_current():
     conn_dir = ensure_output_dir()
     (conn_dir / "ontology_A.ttl").write_text("@prefix a: <x> .\n# A", encoding="utf-8")
 
-    result = await download_ontology(
-        MagicMock(), "A", "file", _services(session)
-    )
+    result = await download_ontology(MagicMock(), "A", "file", _services(session))
 
     assert result["success"] is True
     # Must read A's file even though current schema is B.
@@ -49,7 +47,9 @@ async def test_download_ontology_uses_requested_schema_not_current():
 async def test_download_r2rml_uses_requested_schema_not_current():
     session = _two_schema_session()
     conn_dir = ensure_output_dir()
-    (conn_dir / "r2rml_A.ttl").write_text('rr:baseIRI "http://a/" .\n', encoding="utf-8")
+    (conn_dir / "r2rml_A.ttl").write_text(
+        'rr:baseIRI "http://a/" .\n', encoding="utf-8"
+    )
 
     result = await download_r2rml(MagicMock(), "A", _services(session))
 

--- a/tests/test_cfl_decomposition.py
+++ b/tests/test_cfl_decomposition.py
@@ -3,13 +3,18 @@
 from types import SimpleNamespace
 
 from src.graphrag.retriever import GraphRetriever
-from src.handlers import graphrag as h
 from src.handler_context import HandlerContext
+from src.handlers import graphrag as h
 
 
 def _tbl(name, fks=None):
-    return {"name": name, "schema": "public", "columns": [], "primary_keys": ["id"],
-            "foreign_keys": fks or []}
+    return {
+        "name": name,
+        "schema": "public",
+        "columns": [],
+        "primary_keys": ["id"],
+        "foreign_keys": fks or [],
+    }
 
 
 def _session():
@@ -17,16 +22,41 @@ def _session():
     tables = [
         _tbl("customers"),
         _tbl("products"),
-        _tbl("orders", [
-            {"column": "customer_id", "referenced_table": "customers", "referenced_column": "id"},
-        ]),
-        _tbl("order_items", [
-            {"column": "order_id", "referenced_table": "orders", "referenced_column": "id"},
-            {"column": "product_id", "referenced_table": "products", "referenced_column": "id"},
-        ]),
-        _tbl("returns", [
-            {"column": "customer_id", "referenced_table": "customers", "referenced_column": "id"},
-        ]),
+        _tbl(
+            "orders",
+            [
+                {
+                    "column": "customer_id",
+                    "referenced_table": "customers",
+                    "referenced_column": "id",
+                },
+            ],
+        ),
+        _tbl(
+            "order_items",
+            [
+                {
+                    "column": "order_id",
+                    "referenced_table": "orders",
+                    "referenced_column": "id",
+                },
+                {
+                    "column": "product_id",
+                    "referenced_table": "products",
+                    "referenced_column": "id",
+                },
+            ],
+        ),
+        _tbl(
+            "returns",
+            [
+                {
+                    "column": "customer_id",
+                    "referenced_table": "customers",
+                    "referenced_column": "id",
+                },
+            ],
+        ),
     ]
     retriever = GraphRetriever()
     retriever.build_graph(tables)
@@ -46,7 +76,9 @@ def _err(message, code):
 async def _call(facts, dimensions=None, session=None):
     sess = session or _session()
     return await h.plan_composite_query(
-        _Ctx(), facts, dimensions,
+        _Ctx(),
+        facts,
+        dimensions,
         services=HandlerContext(
             get_session_data=lambda _ctx: sess,
             create_error_response=_err,

--- a/tests/test_code_review_fixes.py
+++ b/tests/test_code_review_fixes.py
@@ -7,13 +7,13 @@ Covers:
 4. Dremio PAT auth in the main connect_database handler
 """
 
-import unittest
-from unittest.mock import Mock, patch, AsyncMock
 import os
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
 
-from src.session import SessionData
-from src.handler_context import HandlerContext
 from src.database_manager import DatabaseManager
+from src.handler_context import HandlerContext
+from src.session import SessionData
 
 
 class TestClearSessionStateResetsValidator(unittest.TestCase):
@@ -84,7 +84,10 @@ class TestReconnectAllBackends(unittest.TestCase):
         with patch.object(self.db_manager, "connect_bigquery", return_value=True) as m:
             self.db_manager._reconnect()
             m.assert_called_once_with(
-                "my-project", "my_dataset", "/path/to/creds.json", None,
+                "my-project",
+                "my_dataset",
+                "/path/to/creds.json",
+                None,
             )
 
     def test_reconnect_duckdb(self):
@@ -107,11 +110,16 @@ class TestReconnectAllBackends(unittest.TestCase):
             "catalog": "main",
             "schema": "default",
         }
-        with patch.object(self.db_manager, "connect_databricks", return_value=True) as m:
+        with patch.object(
+            self.db_manager, "connect_databricks", return_value=True
+        ) as m:
             self.db_manager._reconnect()
             m.assert_called_once_with(
-                "host.databricks.com", "/sql/1.0/warehouses/abc",
-                "dapi123", "main", "default",
+                "host.databricks.com",
+                "/sql/1.0/warehouses/abc",
+                "dapi123",
+                "main",
+                "default",
             )
 
     def test_reconnect_mysql(self):
@@ -127,7 +135,12 @@ class TestReconnectAllBackends(unittest.TestCase):
         with patch.object(self.db_manager, "connect_mysql", return_value=True) as m:
             self.db_manager._reconnect()
             m.assert_called_once_with(
-                "localhost", 3306, "testdb", "root", "secret", "utf8mb4",
+                "localhost",
+                3306,
+                "testdb",
+                "root",
+                "secret",
+                "utf8mb4",
             )
 
     def test_reconnect_unsupported_type_raises(self):
@@ -192,7 +205,8 @@ class TestDremioPATHandler(unittest.IsolatedAsyncioTestCase):
             )
 
         mock_db_manager.connect_dremio.assert_called_once_with(
-            uri="https://dremio.example.com", pat="my-secret-pat",
+            uri="https://dremio.example.com",
+            pat="my-secret-pat",
         )
 
     async def test_dremio_falls_back_to_legacy(self):
@@ -221,8 +235,9 @@ class TestDremioPATHandler(unittest.IsolatedAsyncioTestCase):
             "DREMIO_PASSWORD": "pass123",
         }
         # Ensure PAT vars are absent
-        cleaned = {k: v for k, v in os.environ.items()
-                   if k not in ("DREMIO_URI", "DREMIO_PAT")}
+        cleaned = {
+            k: v for k, v in os.environ.items() if k not in ("DREMIO_URI", "DREMIO_PAT")
+        }
         cleaned.update(env)
         with patch.dict(os.environ, cleaned, clear=True):
             await connect_database(

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -1,10 +1,11 @@
 """Tests for the DatabaseManager class with enhanced coverage."""
 
 import unittest
-from unittest.mock import Mock, patch, MagicMock, AsyncMock
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
 from sqlalchemy.exc import SQLAlchemyError
 
-from src.database_manager import DatabaseManager, TableInfo, ColumnInfo
+from src.database_manager import ColumnInfo, DatabaseManager, TableInfo
 
 
 class TestDatabaseManager(unittest.TestCase):
@@ -22,7 +23,7 @@ class TestDatabaseManager(unittest.TestCase):
         self.assertEqual(self.db_manager._connection_pool_size, 5)
         self.assertEqual(self.db_manager._max_overflow, 10)
 
-    @patch('src.drivers.postgresql.create_engine')
+    @patch("src.drivers.postgresql.create_engine")
     def test_connect_postgresql_success(self, mock_create_engine):
         """Test successful PostgreSQL connection."""
         mock_engine = Mock()
@@ -41,7 +42,7 @@ class TestDatabaseManager(unittest.TestCase):
             port=5432,
             database="testdb",
             username="testuser",
-            password="testpass"
+            password="testpass",
         )
 
         self.assertTrue(result)
@@ -50,7 +51,7 @@ class TestDatabaseManager(unittest.TestCase):
         self.assertEqual(self.db_manager.connection_info["host"], "localhost")
         self.assertEqual(self.db_manager.connection_info["database"], "testdb")
 
-    @patch('src.drivers.postgresql.create_engine')
+    @patch("src.drivers.postgresql.create_engine")
     def test_connect_postgresql_failure(self, mock_create_engine):
         """Test PostgreSQL connection failure."""
         mock_create_engine.side_effect = SQLAlchemyError("Connection failed")
@@ -60,7 +61,7 @@ class TestDatabaseManager(unittest.TestCase):
             port=5432,
             database="testdb",
             username="testuser",
-            password="wrongpass"
+            password="wrongpass",
         )
 
         self.assertFalse(result)
@@ -73,12 +74,12 @@ class TestDatabaseManager(unittest.TestCase):
             port=5432,
             database="testdb",
             username="testuser",
-            password="testpass"
+            password="testpass",
         )
 
         self.assertFalse(result)
 
-    @patch('src.drivers.snowflake.create_engine')
+    @patch("src.drivers.snowflake.create_engine")
     def test_connect_snowflake_success(self, mock_create_engine):
         """Test successful Snowflake connection."""
         mock_engine = Mock()
@@ -98,7 +99,7 @@ class TestDatabaseManager(unittest.TestCase):
             password="testpass",
             warehouse="COMPUTE_WH",
             database="TESTDB",
-            schema="PUBLIC"
+            schema="PUBLIC",
         )
 
         self.assertTrue(result)
@@ -121,7 +122,7 @@ class TestDatabaseManager(unittest.TestCase):
         self.assertFalse(self.db_manager._validate_identifier("table name"))
         self.assertFalse(self.db_manager._validate_identifier("a" * 64))  # Too long
 
-    @patch('src.drivers.postgresql.inspect')
+    @patch("src.drivers.postgresql.inspect")
     def test_analyze_table_success(self, mock_inspect):
         """Test successful table analysis."""
         # Setup mocks
@@ -132,21 +133,19 @@ class TestDatabaseManager(unittest.TestCase):
         mock_inspector.has_table.return_value = True
         mock_inspector.get_columns.return_value = [
             {
-                'name': 'id',
-                'type': 'INTEGER',
-                'nullable': False,
-                'comment': 'Primary key'
+                "name": "id",
+                "type": "INTEGER",
+                "nullable": False,
+                "comment": "Primary key",
             },
             {
-                'name': 'name',
-                'type': 'VARCHAR(255)',
-                'nullable': False,
-                'comment': 'User name'
-            }
+                "name": "name",
+                "type": "VARCHAR(255)",
+                "nullable": False,
+                "comment": "User name",
+            },
         ]
-        mock_inspector.get_pk_constraint.return_value = {
-            'constrained_columns': ['id']
-        }
+        mock_inspector.get_pk_constraint.return_value = {"constrained_columns": ["id"]}
         mock_inspector.get_foreign_keys.return_value = []
 
         # Mock connection as context manager
@@ -156,6 +155,7 @@ class TestDatabaseManager(unittest.TestCase):
 
         # Set up the driver directly
         from src.drivers.postgresql import PostgreSQLDriver
+
         driver = PostgreSQLDriver()
         driver.engine = mock_engine
         self.db_manager._driver = driver
@@ -163,14 +163,14 @@ class TestDatabaseManager(unittest.TestCase):
         self.db_manager.connection_info = {"type": "postgresql"}
 
         # Mock _test_connection to return True so _ensure_connection doesn't fail
-        with patch.object(self.db_manager, '_test_connection', return_value=True):
+        with patch.object(self.db_manager, "_test_connection", return_value=True):
             result = self.db_manager.analyze_table("test_table", "public")
 
         self.assertIsInstance(result, TableInfo)
         self.assertEqual(result.name, "test_table")
         self.assertEqual(result.schema, "public")
         self.assertEqual(len(result.columns), 2)
-        self.assertEqual(result.primary_keys, ['id'])
+        self.assertEqual(result.primary_keys, ["id"])
         # row_count is no longer fetched during analyze_table (use sample_table_data tool instead)
         self.assertIsNone(result.row_count)
 
@@ -179,7 +179,7 @@ class TestDatabaseManager(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.db_manager.analyze_table("test_table")
 
-    @patch('src.drivers.postgresql.inspect')
+    @patch("src.drivers.postgresql.inspect")
     def test_analyze_table_not_found(self, mock_inspect):
         """Test analysis of non-existent table."""
         mock_engine = Mock()
@@ -197,6 +197,7 @@ class TestDatabaseManager(unittest.TestCase):
 
         # Set up driver
         from src.drivers.postgresql import PostgreSQLDriver
+
         driver = PostgreSQLDriver()
         driver.engine = mock_engine
         self.db_manager._driver = driver
@@ -204,7 +205,7 @@ class TestDatabaseManager(unittest.TestCase):
         self.db_manager.connection_info = {"type": "postgresql"}
 
         # Mock _test_connection to return True so _ensure_connection doesn't fail
-        with patch.object(self.db_manager, '_test_connection', return_value=True):
+        with patch.object(self.db_manager, "_test_connection", return_value=True):
             result = self.db_manager.analyze_table("nonexistent_table")
 
         self.assertIsNone(result)
@@ -233,13 +234,14 @@ class TestDatabaseManager(unittest.TestCase):
         self.db_manager.connection_info = {"type": "postgresql"}
 
         from src.drivers.postgresql import PostgreSQLDriver
+
         driver = PostgreSQLDriver()
 
         # Test with negative limit - should use default
         mock_engine = Mock()
         mock_conn = MagicMock()
         mock_result = Mock()
-        mock_result.keys = Mock(return_value=['id', 'name'])
+        mock_result.keys = Mock(return_value=["id", "name"])
         mock_result.fetchall = Mock(return_value=[])
         mock_conn.execute = Mock(return_value=mock_result)
         mock_engine.connect.return_value.__enter__ = Mock(return_value=mock_conn)
@@ -255,7 +257,7 @@ class TestDatabaseManager(unittest.TestCase):
         mock_engine2 = Mock()
         mock_conn2 = MagicMock()
         mock_result2 = Mock()
-        mock_result2.keys = Mock(return_value=['id', 'name'])
+        mock_result2.keys = Mock(return_value=["id", "name"])
         mock_result2.fetchall = Mock(return_value=[])
         mock_conn2.execute = Mock(return_value=mock_result2)
         mock_engine2.connect.return_value.__enter__ = Mock(return_value=mock_conn2)
@@ -269,7 +271,7 @@ class TestDatabaseManager(unittest.TestCase):
         # Check the SQL query contains LIMIT 1000
         call_args = mock_conn2.execute.call_args
         # The second argument should be the params dict
-        self.assertEqual(call_args[0][1]['limit'], 1000)
+        self.assertEqual(call_args[0][1]["limit"], 1000)
 
     def test_disconnect(self):
         """Test database disconnection."""
@@ -316,13 +318,17 @@ class TestDatabaseManager(unittest.TestCase):
         quoted = self.db_manager._quote_dremio_identifier('My.Schema."Table"')
         self.assertEqual(quoted, '"My"."Schema"."""Table"""')
 
-    @patch('src.dremio_client.create_dremio_client')
+    @patch("src.dremio_client.create_dremio_client")
     def test_dremio_health_check_pat(self, mock_create_client):
         """Test Dremio health check for PAT connections."""
-        self.db_manager._dremio_rest_connection = {"uri": "https://dremio.example", "pat": "pat"}
+        self.db_manager._dremio_rest_connection = {
+            "uri": "https://dremio.example",
+            "pat": "pat",
+        }
 
         # Set up driver
         from src.drivers.dremio import DremioDriver
+
         driver = DremioDriver()
         driver._rest_connection = {"uri": "https://dremio.example", "pat": "pat"}
         self.db_manager._driver = driver
@@ -335,13 +341,17 @@ class TestDatabaseManager(unittest.TestCase):
 
         self.assertTrue(self.db_manager._test_dremio_connection())
 
-    @patch('src.dremio_client.create_dremio_client')
+    @patch("src.dremio_client.create_dremio_client")
     def test_is_connected_uses_dremio_health_check(self, mock_create_client):
         """Test is_connected for Dremio REST connections."""
-        self.db_manager._dremio_rest_connection = {"uri": "https://dremio.example", "pat": "pat"}
+        self.db_manager._dremio_rest_connection = {
+            "uri": "https://dremio.example",
+            "pat": "pat",
+        }
 
         # Set up driver
         from src.drivers.dremio import DremioDriver
+
         driver = DremioDriver()
         driver._rest_connection = {"uri": "https://dremio.example", "pat": "pat"}
         self.db_manager._driver = driver
@@ -359,12 +369,16 @@ class TestDatabaseManager(unittest.TestCase):
         self.db_manager._last_connection_params = {
             "type": "dremio",
             "uri": "https://dremio.example",
-            "pat": "pat"
+            "pat": "pat",
         }
 
-        with patch.object(self.db_manager, "connect_dremio", return_value=True) as mock_connect:
+        with patch.object(
+            self.db_manager, "connect_dremio", return_value=True
+        ) as mock_connect:
             self.db_manager._reconnect()
-            mock_connect.assert_called_once_with(uri="https://dremio.example", pat="pat")
+            mock_connect.assert_called_once_with(
+                uri="https://dremio.example", pat="pat"
+            )
 
 
 class TestClickHouseConnection(unittest.TestCase):
@@ -374,7 +388,7 @@ class TestClickHouseConnection(unittest.TestCase):
         """Set up test fixtures."""
         self.db_manager = DatabaseManager()
 
-    @patch('src.drivers.clickhouse.create_engine')
+    @patch("src.drivers.clickhouse.create_engine")
     def test_connect_clickhouse_success(self, mock_create_engine):
         """Test successful ClickHouse connection."""
         mock_engine = Mock()
@@ -392,7 +406,7 @@ class TestClickHouseConnection(unittest.TestCase):
             port=8123,
             database="testdb",
             username="default",
-            password=""
+            password="",
         )
 
         self.assertTrue(result)
@@ -406,7 +420,7 @@ class TestClickHouseConnection(unittest.TestCase):
         connection_string = call_args[0][0]
         self.assertIn("clickhouse+http://", connection_string)
 
-    @patch('src.drivers.clickhouse.create_engine')
+    @patch("src.drivers.clickhouse.create_engine")
     def test_connect_clickhouse_failure(self, mock_create_engine):
         """Test ClickHouse connection failure."""
         mock_create_engine.side_effect = SQLAlchemyError("Connection failed")
@@ -416,7 +430,7 @@ class TestClickHouseConnection(unittest.TestCase):
             port=8123,
             database="testdb",
             username="default",
-            password=""
+            password="",
         )
 
         self.assertFalse(result)
@@ -425,14 +439,12 @@ class TestClickHouseConnection(unittest.TestCase):
     def test_connect_clickhouse_missing_params(self):
         """Test ClickHouse connection with missing parameters."""
         result = self.db_manager.connect_clickhouse(
-            host="",  # Missing host
-            port=8123,
-            database="testdb"
+            host="", port=8123, database="testdb"  # Missing host
         )
 
         self.assertFalse(result)
 
-    @patch('src.drivers.clickhouse.create_engine')
+    @patch("src.drivers.clickhouse.create_engine")
     def test_connect_clickhouse_native_protocol(self, mock_create_engine):
         """Test ClickHouse connection with native protocol."""
         mock_engine = Mock()
@@ -451,7 +463,7 @@ class TestClickHouseConnection(unittest.TestCase):
             database="testdb",
             username="default",
             password="",
-            protocol="native"
+            protocol="native",
         )
 
         self.assertTrue(result)
@@ -460,7 +472,7 @@ class TestClickHouseConnection(unittest.TestCase):
         connection_string = call_args[0][0]
         self.assertIn("clickhouse+native://", connection_string)
 
-    @patch('src.drivers.clickhouse.create_engine')
+    @patch("src.drivers.clickhouse.create_engine")
     def test_connect_clickhouse_secure(self, mock_create_engine):
         """Test ClickHouse connection with HTTPS."""
         mock_engine = Mock()
@@ -479,7 +491,7 @@ class TestClickHouseConnection(unittest.TestCase):
             database="testdb",
             username="default",
             password="secret",
-            secure=True
+            secure=True,
         )
 
         self.assertTrue(result)
@@ -501,7 +513,7 @@ class TestTableInfoDataClass(unittest.TestCase):
             is_foreign_key=True,
             foreign_key_table="ref_table",
             foreign_key_column="ref_id",
-            comment="Test column"
+            comment="Test column",
         )
 
         self.assertEqual(col_info.name, "test_column")
@@ -521,7 +533,7 @@ class TestTableInfoDataClass(unittest.TestCase):
                 data_type="INTEGER",
                 is_nullable=False,
                 is_primary_key=True,
-                is_foreign_key=False
+                is_foreign_key=False,
             )
         ]
 
@@ -532,7 +544,7 @@ class TestTableInfoDataClass(unittest.TestCase):
             primary_keys=["id"],
             foreign_keys=[],
             comment="Test table",
-            row_count=100
+            row_count=100,
         )
 
         self.assertEqual(table_info.name, "test_table")
@@ -544,5 +556,5 @@ class TestTableInfoDataClass(unittest.TestCase):
         self.assertEqual(table_info.row_count, 100)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_graphrag_integration.py
+++ b/tests/test_graphrag_integration.py
@@ -5,23 +5,24 @@ Comprehensive tests for GraphRAG integration.
 Tests all components: embedder, vector store, retriever, community detector, and manager.
 """
 
-import pytest
-from pathlib import Path
 import sys
+from pathlib import Path
+
 import numpy as np
+import pytest
 
 # Add src to path
 src_path = Path(__file__).parent.parent / "src"
 sys.path.insert(0, str(src_path))
 
-from graphrag.embedder import SchemaEmbedder  # noqa: E402
-from graphrag.vector_store import VectorStore  # noqa: E402
-from graphrag.retriever import GraphRetriever  # noqa: E402
 from graphrag.community_detector import CommunityDetector  # noqa: E402
+from graphrag.embedder import SchemaEmbedder  # noqa: E402
 from graphrag.manager import GraphRAGManager  # noqa: E402
-
+from graphrag.retriever import GraphRetriever  # noqa: E402
+from graphrag.vector_store import VectorStore  # noqa: E402
 
 # --- Fixtures ---
+
 
 @pytest.fixture
 def sample_tables():
@@ -39,7 +40,7 @@ def sample_tables():
                     "is_foreign_key": False,
                     "foreign_key_table": None,
                     "foreign_key_column": None,
-                    "comment": "Primary key"
+                    "comment": "Primary key",
                 },
                 {
                     "name": "name",
@@ -49,13 +50,13 @@ def sample_tables():
                     "is_foreign_key": False,
                     "foreign_key_table": None,
                     "foreign_key_column": None,
-                    "comment": "Customer name"
-                }
+                    "comment": "Customer name",
+                },
             ],
             "primary_keys": ["customer_id"],
             "foreign_keys": [],
             "comment": "Customer master data",
-            "row_count": 1000
+            "row_count": 1000,
         },
         {
             "name": "orders",
@@ -69,7 +70,7 @@ def sample_tables():
                     "is_foreign_key": False,
                     "foreign_key_table": None,
                     "foreign_key_column": None,
-                    "comment": None
+                    "comment": None,
                 },
                 {
                     "name": "customer_id",
@@ -79,19 +80,19 @@ def sample_tables():
                     "is_foreign_key": True,
                     "foreign_key_table": "customers",
                     "foreign_key_column": "customer_id",
-                    "comment": None
-                }
+                    "comment": None,
+                },
             ],
             "primary_keys": ["order_id"],
             "foreign_keys": [
                 {
                     "column": "customer_id",
                     "referenced_table": "customers",
-                    "referenced_column": "customer_id"
+                    "referenced_column": "customer_id",
                 }
             ],
             "comment": "Order transactions",
-            "row_count": 5000
+            "row_count": 5000,
         },
         {
             "name": "order_items",
@@ -105,7 +106,7 @@ def sample_tables():
                     "is_foreign_key": False,
                     "foreign_key_table": None,
                     "foreign_key_column": None,
-                    "comment": None
+                    "comment": None,
                 },
                 {
                     "name": "order_id",
@@ -115,24 +116,25 @@ def sample_tables():
                     "is_foreign_key": True,
                     "foreign_key_table": "orders",
                     "foreign_key_column": "order_id",
-                    "comment": None
-                }
+                    "comment": None,
+                },
             ],
             "primary_keys": ["item_id"],
             "foreign_keys": [
                 {
                     "column": "order_id",
                     "referenced_table": "orders",
-                    "referenced_column": "order_id"
+                    "referenced_column": "order_id",
                 }
             ],
             "comment": "Order line items",
-            "row_count": 15000
-        }
+            "row_count": 15000,
+        },
     ]
 
 
 # --- SchemaEmbedder Tests ---
+
 
 class TestSchemaEmbedder:
     """Test suite for SchemaEmbedder."""
@@ -141,7 +143,7 @@ class TestSchemaEmbedder:
         """Test TF-IDF embedder initialization."""
         embedder = SchemaEmbedder(embedding_model="tfidf")
         assert embedder.embedding_model == "tfidf"
-        assert hasattr(embedder, 'vectorizer')
+        assert hasattr(embedder, "vectorizer")
 
     def test_create_table_embedding(self, sample_tables):
         """Test creating embedding for a table."""
@@ -152,14 +154,16 @@ class TestSchemaEmbedder:
             table_name=table["name"],
             columns=table["columns"],
             comment=table["comment"],
-            foreign_keys=table["foreign_keys"]
+            foreign_keys=table["foreign_keys"],
         )
 
         assert element.element_type == "table"
         assert element.element_id == "customers"
         assert element.name == "customers"
         assert element.embedding is not None
-        assert len(element.embedding) <= 384  # Max dimension; actual varies with vocabulary
+        assert (
+            len(element.embedding) <= 384
+        )  # Max dimension; actual varies with vocabulary
 
     def test_create_column_embedding(self):
         """Test creating embedding for a column."""
@@ -171,7 +175,7 @@ class TestSchemaEmbedder:
             data_type="INTEGER",
             is_primary_key=True,
             is_foreign_key=False,
-            comment="Primary key"
+            comment="Primary key",
         )
 
         assert element.element_type == "column"
@@ -187,7 +191,7 @@ class TestSchemaEmbedder:
             from_table="orders",
             to_table="customers",
             join_columns=[("customer_id", "customer_id")],
-            relationship_type="many_to_one"
+            relationship_type="many_to_one",
         )
 
         assert element.element_type == "relationship"
@@ -214,10 +218,13 @@ class TestSchemaEmbedder:
         assert "relationships" in result
         assert len(result["tables"]) == 3
         assert len(result["columns"]) > 0
-        assert len(result["relationships"]) == 2  # orders->customers, order_items->orders
+        assert (
+            len(result["relationships"]) == 2
+        )  # orders->customers, order_items->orders
 
 
 # --- VectorStore Tests ---
+
 
 class TestVectorStore:
     """Test suite for VectorStore."""
@@ -240,7 +247,7 @@ class TestVectorStore:
             name="customers",
             description="Customer data",
             embedding=embedding,
-            metadata={"column_count": 10}
+            metadata={"column_count": 10},
         )
 
         assert len(store.elements) == 1
@@ -257,7 +264,7 @@ class TestVectorStore:
                 element_id=f"table_{i}",
                 name=f"table_{i}",
                 description=f"Table {i}",
-                embedding=embedding
+                embedding=embedding,
             )
 
         store.build_index()
@@ -303,6 +310,7 @@ class TestVectorStore:
 
 # --- GraphRetriever Tests ---
 
+
 class TestGraphRetriever:
     """Test suite for GraphRetriever."""
 
@@ -318,7 +326,9 @@ class TestGraphRetriever:
         retriever.build_graph(sample_tables)
 
         assert retriever.graph.number_of_nodes() == 3
-        assert retriever.graph.number_of_edges() == 2  # orders->customers, order_items->orders
+        assert (
+            retriever.graph.number_of_edges() == 2
+        )  # orders->customers, order_items->orders
 
     def test_find_join_path_direct(self, sample_tables):
         """Test finding direct join path."""
@@ -347,15 +357,17 @@ class TestGraphRetriever:
         retriever = GraphRetriever()
 
         # Add isolated table
-        tables = sample_tables + [{
-            "name": "isolated_table",
-            "schema": "public",
-            "columns": [],
-            "foreign_keys": [],
-            "primary_keys": [],
-            "comment": None,
-            "row_count": 0
-        }]
+        tables = sample_tables + [
+            {
+                "name": "isolated_table",
+                "schema": "public",
+                "columns": [],
+                "foreign_keys": [],
+                "primary_keys": [],
+                "comment": None,
+                "row_count": 0,
+            }
+        ]
 
         retriever.build_graph(tables)
 
@@ -377,19 +389,23 @@ class TestGraphRetriever:
         retriever = GraphRetriever()
 
         # Create schema with fan-trap
-        fan_trap_tables = sample_tables + [{
-            "name": "payments",
-            "schema": "public",
-            "columns": [],
-            "primary_keys": [],
-            "foreign_keys": [{
-                "column": "order_id",
-                "referenced_table": "orders",
-                "referenced_column": "order_id"
-            }],
-            "comment": None,
-            "row_count": 0
-        }]
+        fan_trap_tables = sample_tables + [
+            {
+                "name": "payments",
+                "schema": "public",
+                "columns": [],
+                "primary_keys": [],
+                "foreign_keys": [
+                    {
+                        "column": "order_id",
+                        "referenced_table": "orders",
+                        "referenced_column": "order_id",
+                    }
+                ],
+                "comment": None,
+                "row_count": 0,
+            }
+        ]
 
         retriever.build_graph(fan_trap_tables)
 
@@ -403,6 +419,7 @@ class TestGraphRetriever:
 
 
 # --- CommunityDetector Tests ---
+
 
 class TestCommunityDetector:
     """Test suite for CommunityDetector."""
@@ -444,6 +461,7 @@ class TestCommunityDetector:
 
 
 # --- GraphRAGManager Tests ---
+
 
 class TestGraphRAGManager:
     """Test suite for GraphRAGManager."""
@@ -515,6 +533,7 @@ class TestGraphRAGManager:
 
 # --- Integration Tests ---
 
+
 class TestGraphRAGIntegration:
     """End-to-end integration tests."""
 
@@ -545,7 +564,9 @@ class TestGraphRAGIntegration:
         manager = GraphRAGManager(embedding_model="tfidf")
         manager.initialize_from_schema(sample_tables, schema_name="public")
 
-        context = manager.get_query_context("customer orders", max_tables=2, max_columns=10)
+        context = manager.get_query_context(
+            "customer orders", max_tables=2, max_columns=10
+        )
 
         # Should be significantly less than full schema
         token_estimate = context["token_estimate"]

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -1,15 +1,11 @@
 """Tests for OBQC (Ontology-Based Query Check) validator."""
 
 import unittest
-from rdflib import Graph, Namespace, Literal
-from rdflib.namespace import RDF, RDFS, OWL, XSD
 
-from src.obqc_validator import (
-    OBQCValidator,
-    OBQCIssue,
-    OBQCIssueType,
-    OBQCSeverity,
-)
+from rdflib import Graph, Literal, Namespace
+from rdflib.namespace import OWL, RDF, RDFS, XSD
+
+from src.obqc_validator import OBQCIssue, OBQCIssueType, OBQCSeverity, OBQCValidator
 
 
 def create_sample_ontology_graph() -> tuple[Graph, str]:
@@ -217,9 +213,7 @@ class TestOBQCValidator(unittest.TestCase):
 
     def test_valid_select_with_where(self):
         """Test validation of SELECT with WHERE clause."""
-        result = self.validator.validate(
-            "SELECT id, name FROM users WHERE id = 1"
-        )
+        result = self.validator.validate("SELECT id, name FROM users WHERE id = 1")
         self.assertTrue(result.is_valid)
 
     def test_table_not_found(self):
@@ -231,9 +225,7 @@ class TestOBQCValidator(unittest.TestCase):
 
     def test_column_not_found(self):
         """Test detection of non-existent column."""
-        result = self.validator.validate(
-            "SELECT users.nonexistent_column FROM users"
-        )
+        result = self.validator.validate("SELECT users.nonexistent_column FROM users")
         self.assertFalse(result.is_valid)
         issue_types = [i.issue_type for i in result.issues]
         self.assertIn(OBQCIssueType.COLUMN_NOT_FOUND, issue_types)
@@ -279,9 +271,7 @@ class TestOBQCValidator(unittest.TestCase):
     def test_type_mismatch_warning(self):
         """Test detection of type mismatch in comparison."""
         # Comparing integer id with string literal
-        result = self.validator.validate(
-            "SELECT * FROM users WHERE users.id = 'abc'"
-        )
+        result = self.validator.validate("SELECT * FROM users WHERE users.id = 'abc'")
         # Should warn about type mismatch
         warning_issues = [
             i for i in result.issues if i.issue_type == OBQCIssueType.TYPE_MISMATCH
@@ -342,21 +332,15 @@ class TestOBQCValidator(unittest.TestCase):
     def test_dialect_support(self):
         """Test different SQL dialects."""
         # PostgreSQL
-        result = self.validator.validate(
-            "SELECT * FROM users", dialect="postgresql"
-        )
+        result = self.validator.validate("SELECT * FROM users", dialect="postgresql")
         self.assertTrue(result.is_valid)
 
         # Snowflake
-        result = self.validator.validate(
-            "SELECT * FROM users", dialect="snowflake"
-        )
+        result = self.validator.validate("SELECT * FROM users", dialect="snowflake")
         self.assertTrue(result.is_valid)
 
         # Dremio (uses trino dialect)
-        result = self.validator.validate(
-            "SELECT * FROM users", dialect="dremio"
-        )
+        result = self.validator.validate("SELECT * FROM users", dialect="dremio")
         self.assertTrue(result.is_valid)
 
 
@@ -383,8 +367,7 @@ class TestOBQCFanTrapDetection(unittest.TestCase):
         # Should detect fan-trap risk
         self.assertTrue(result.fan_trap_risk)
         fan_trap_issues = [
-            i for i in result.issues
-            if i.issue_type == OBQCIssueType.FAN_TRAP_DETECTED
+            i for i in result.issues if i.issue_type == OBQCIssueType.FAN_TRAP_DETECTED
         ]
         self.assertTrue(len(fan_trap_issues) > 0)
 
@@ -414,35 +397,71 @@ class TestOBQCAxiomDrivenFanTrap(unittest.TestCase):
     """Phase 2: fan-trap detection grounded in owl:disjointWith axioms."""
 
     def setUp(self):
+        from src.database_manager import ColumnInfo, TableInfo
         from src.ontology_generator import OntologyGenerator
-        from src.database_manager import TableInfo, ColumnInfo
 
         def fact(name, fk_to):
             return TableInfo(
-                name=name, schema="public",
+                name=name,
+                schema="public",
                 columns=[
-                    ColumnInfo(name="id", data_type="INTEGER", is_nullable=False,
-                               is_primary_key=True, is_foreign_key=False),
-                    ColumnInfo(name="customer_id", data_type="INTEGER", is_nullable=False,
-                               is_primary_key=False, is_foreign_key=True,
-                               foreign_key_table=fk_to, foreign_key_column="id"),
-                    ColumnInfo(name="amount", data_type="DECIMAL(12,2)", is_nullable=False,
-                               is_primary_key=False, is_foreign_key=False),
+                    ColumnInfo(
+                        name="id",
+                        data_type="INTEGER",
+                        is_nullable=False,
+                        is_primary_key=True,
+                        is_foreign_key=False,
+                    ),
+                    ColumnInfo(
+                        name="customer_id",
+                        data_type="INTEGER",
+                        is_nullable=False,
+                        is_primary_key=False,
+                        is_foreign_key=True,
+                        foreign_key_table=fk_to,
+                        foreign_key_column="id",
+                    ),
+                    ColumnInfo(
+                        name="amount",
+                        data_type="DECIMAL(12,2)",
+                        is_nullable=False,
+                        is_primary_key=False,
+                        is_foreign_key=False,
+                    ),
                 ],
                 primary_keys=["id"],
-                foreign_keys=[{"column": "customer_id", "referenced_table": fk_to, "referenced_column": "id"}],
+                foreign_keys=[
+                    {
+                        "column": "customer_id",
+                        "referenced_table": fk_to,
+                        "referenced_column": "id",
+                    }
+                ],
                 row_count=1000,
             )
 
         customers = TableInfo(
-            name="customers", schema="public",
+            name="customers",
+            schema="public",
             columns=[
-                ColumnInfo(name="id", data_type="INTEGER", is_nullable=False,
-                           is_primary_key=True, is_foreign_key=False),
-                ColumnInfo(name="name", data_type="VARCHAR(200)", is_nullable=False,
-                           is_primary_key=False, is_foreign_key=False),
+                ColumnInfo(
+                    name="id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_foreign_key=False,
+                ),
+                ColumnInfo(
+                    name="name",
+                    data_type="VARCHAR(200)",
+                    is_nullable=False,
+                    is_primary_key=False,
+                    is_foreign_key=False,
+                ),
             ],
-            primary_keys=["id"], foreign_keys=[], row_count=500,
+            primary_keys=["id"],
+            foreign_keys=[],
+            row_count=500,
         )
 
         base_uri = "http://test.com/ontology/"
@@ -469,7 +488,9 @@ class TestOBQCAxiomDrivenFanTrap(unittest.TestCase):
             "GROUP BY customers.name"
         )
         self.assertTrue(result.fan_trap_risk)
-        fan = [i for i in result.issues if i.issue_type == OBQCIssueType.FAN_TRAP_DETECTED]
+        fan = [
+            i for i in result.issues if i.issue_type == OBQCIssueType.FAN_TRAP_DETECTED
+        ]
         self.assertEqual(len(fan), 1)
         # cites the actual disjoint pair and recommends a composite (UNION ALL)
         self.assertEqual(set(fan[0].related_entities), {"orders", "returns"})
@@ -490,7 +511,9 @@ class TestOBQCDialectParity(unittest.TestCase):
     def test_dialect_map_covers_all_supported_databases(self):
         from src.constants import SUPPORTED_DB_TYPES
 
-        missing = [db for db in SUPPORTED_DB_TYPES if db not in OBQCValidator.DIALECT_MAP]
+        missing = [
+            db for db in SUPPORTED_DB_TYPES if db not in OBQCValidator.DIALECT_MAP
+        ]
         self.assertEqual(
             missing, [], f"databases missing from OBQC DIALECT_MAP: {missing}"
         )
@@ -514,7 +537,7 @@ class TestOBQCIssue(unittest.TestCase):
             message="Table 'foo' not found",
             location="FROM clause",
             suggestion="Check table name spelling",
-            related_entities=["foo"]
+            related_entities=["foo"],
         )
 
         self.assertEqual(issue.issue_type, OBQCIssueType.TABLE_NOT_FOUND)

--- a/tests/test_ontology_generator.py
+++ b/tests/test_ontology_generator.py
@@ -1,19 +1,20 @@
 """Tests for the OntologyGenerator class with comprehensive coverage."""
 
 import unittest
-from rdflib.namespace import XSD, RDFS
 
+from rdflib.namespace import RDFS, XSD
+
+from src.database_manager import ColumnInfo, TableInfo
 from src.ontology_generator import OntologyGenerator
-from src.database_manager import TableInfo, ColumnInfo
 
 
 class TestOntologyGenerator(unittest.TestCase):
     """Comprehensive test suite for OntologyGenerator functionality."""
-    
+
     def setUp(self):
         """Set up test fixtures."""
         self.generator = OntologyGenerator("http://test.com/ontology/")
-        
+
         # Create sample table with various column types
         self.sample_table = TableInfo(
             name="users",
@@ -25,7 +26,7 @@ class TestOntologyGenerator(unittest.TestCase):
                     is_nullable=False,
                     is_primary_key=True,
                     is_foreign_key=False,
-                    comment="User ID"
+                    comment="User ID",
                 ),
                 ColumnInfo(
                     name="username",
@@ -33,7 +34,7 @@ class TestOntologyGenerator(unittest.TestCase):
                     is_nullable=False,
                     is_primary_key=False,
                     is_foreign_key=False,
-                    comment="Username"
+                    comment="Username",
                 ),
                 ColumnInfo(
                     name="email",
@@ -41,7 +42,7 @@ class TestOntologyGenerator(unittest.TestCase):
                     is_nullable=True,
                     is_primary_key=False,
                     is_foreign_key=False,
-                    comment="Email address"
+                    comment="Email address",
                 ),
                 ColumnInfo(
                     name="created_at",
@@ -49,7 +50,7 @@ class TestOntologyGenerator(unittest.TestCase):
                     is_nullable=False,
                     is_primary_key=False,
                     is_foreign_key=False,
-                    comment="Creation timestamp"
+                    comment="Creation timestamp",
                 ),
                 ColumnInfo(
                     name="is_active",
@@ -57,7 +58,7 @@ class TestOntologyGenerator(unittest.TestCase):
                     is_nullable=False,
                     is_primary_key=False,
                     is_foreign_key=False,
-                    comment="Active status"
+                    comment="Active status",
                 ),
                 ColumnInfo(
                     name="balance",
@@ -65,15 +66,15 @@ class TestOntologyGenerator(unittest.TestCase):
                     is_nullable=True,
                     is_primary_key=False,
                     is_foreign_key=False,
-                    comment="Account balance"
-                )
+                    comment="Account balance",
+                ),
             ],
             primary_keys=["id"],
             foreign_keys=[],
             comment="Users table",
-            row_count=1000
+            row_count=1000,
         )
-        
+
         # Create table with foreign key
         self.orders_table = TableInfo(
             name="orders",
@@ -84,7 +85,7 @@ class TestOntologyGenerator(unittest.TestCase):
                     data_type="INTEGER",
                     is_nullable=False,
                     is_primary_key=True,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
                     name="user_id",
@@ -93,45 +94,47 @@ class TestOntologyGenerator(unittest.TestCase):
                     is_primary_key=False,
                     is_foreign_key=True,
                     foreign_key_table="users",
-                    foreign_key_column="id"
+                    foreign_key_column="id",
                 ),
                 ColumnInfo(
                     name="total",
                     data_type="DECIMAL(12,2)",
                     is_nullable=False,
                     is_primary_key=False,
-                    is_foreign_key=False
-                )
+                    is_foreign_key=False,
+                ),
             ],
             primary_keys=["id"],
             foreign_keys=[
                 {
                     "column": "user_id",
                     "referenced_table": "users",
-                    "referenced_column": "id"
+                    "referenced_column": "id",
                 }
             ],
-            row_count=5000
+            row_count=5000,
         )
-    
+
     def test_initialization(self):
         """Test OntologyGenerator initialization."""
         self.assertEqual(str(self.generator.base_uri), "http://test.com/ontology/")
         self.assertIsNotNone(self.generator.graph)
-        
+
         # Check namespace bindings
         namespaces = dict(self.generator.graph.namespaces())
-        self.assertIn('ns', namespaces)
-        self.assertIn('rdf', namespaces)
-        self.assertIn('rdfs', namespaces)
-        self.assertIn('owl', namespaces)
-        self.assertIn('xsd', namespaces)
-    
+        self.assertIn("ns", namespaces)
+        self.assertIn("rdf", namespaces)
+        self.assertIn("rdfs", namespaces)
+        self.assertIn("owl", namespaces)
+        self.assertIn("xsd", namespaces)
+
     def test_initialization_with_default_uri(self):
         """Test initialization with default URI."""
         default_generator = OntologyGenerator()
-        self.assertTrue(str(default_generator.base_uri).startswith("http://example.com/ontology/"))
-    
+        self.assertTrue(
+            str(default_generator.base_uri).startswith("http://example.com/ontology/")
+        )
+
     def test_clean_name_comprehensive(self):
         """Test name cleaning with comprehensive cases."""
         test_cases = [
@@ -147,15 +150,18 @@ class TestOntologyGenerator(unittest.TestCase):
             ("MixedCaseTable", "MixedCaseTable"),
             ("table123", "table123"),
             ("order-items", "order_items"),
-            ("user_account_info", "user_account_info")
+            ("user_account_info", "user_account_info"),
         ]
-        
+
         for input_name, expected in test_cases:
             with self.subTest(input_name=input_name):
                 result = self.generator._clean_name(input_name)
-                self.assertEqual(result, expected, 
-                    f"Expected {expected}, got {result} for input {input_name}")
-    
+                self.assertEqual(
+                    result,
+                    expected,
+                    f"Expected {expected}, got {result} for input {input_name}",
+                )
+
     def test_map_sql_to_xsd_comprehensive(self):
         """Test SQL to XSD type mapping with comprehensive coverage."""
         test_cases = [
@@ -166,7 +172,6 @@ class TestOntologyGenerator(unittest.TestCase):
             ("SMALLINT", XSD.integer),
             ("SERIAL", XSD.integer),
             ("TINYINT", XSD.byte),
-            
             # String types
             ("VARCHAR(255)", XSD.string),
             ("CHAR(10)", XSD.string),
@@ -174,13 +179,11 @@ class TestOntologyGenerator(unittest.TestCase):
             ("CLOB", XSD.string),
             ("BLOB", XSD.string),
             ("STRING", XSD.string),
-            
             # Temporal types
             ("TIMESTAMP", XSD.dateTime),
             ("DATETIME", XSD.dateTime),
             ("DATE", XSD.date),
             ("TIME", XSD.time),
-            
             # Numeric types
             ("FLOAT", XSD.float),
             ("REAL", XSD.float),
@@ -189,75 +192,73 @@ class TestOntologyGenerator(unittest.TestCase):
             ("DECIMAL(10,2)", XSD.decimal),
             ("NUMERIC(8,2)", XSD.decimal),
             ("MONEY", XSD.decimal),
-            
             # Boolean types
             ("BOOLEAN", XSD.boolean),
             ("BOOL", XSD.boolean),
             ("BIT", XSD.boolean),
-            
             # Binary types
             ("BINARY", XSD.base64Binary),
             ("VARBINARY", XSD.base64Binary),
             ("BYTEA", XSD.base64Binary),
-            
             # UUID types
             ("UUID", XSD.string),
-            
             # JSON types
             ("JSON", XSD.string),
             ("JSONB", XSD.string),
-            
             # Unknown type should default to string
-            ("UNKNOWN_TYPE", XSD.string)
+            ("UNKNOWN_TYPE", XSD.string),
         ]
-        
+
         for sql_type, expected_xsd in test_cases:
             with self.subTest(sql_type=sql_type):
                 result, override = self.generator._map_sql_to_xsd(sql_type)
-                self.assertEqual(result, expected_xsd,
-                    f"Expected {expected_xsd}, got {result} for SQL type {sql_type}")
-    
+                self.assertEqual(
+                    result,
+                    expected_xsd,
+                    f"Expected {expected_xsd}, got {result} for SQL type {sql_type}",
+                )
+
     def test_generate_basic_ontology_structure(self):
         """Test generation of basic ontology structure."""
         result = self.generator.generate_from_schema([self.sample_table])
-        
+
         # Check that result is a valid Turtle string
         self.assertIsInstance(result, str)
-        
+
         # Check for required prefixes
         self.assertIn("@prefix", result)
         self.assertIn("ns:", result)
         self.assertIn("owl:", result)
         self.assertIn("rdfs:", result)
         self.assertIn("xsd:", result)
-        
+
         # Check for ontology declaration
         self.assertIn("owl:Ontology", result)
-        
+
         # Check for class declaration
         self.assertIn("owl:Class", result)
-        
+
         # Check for property declarations
         self.assertIn("owl:DatatypeProperty", result)
-        
+
         # Check for table name in ontology
         self.assertIn("users", result)
-    
+
     def test_generate_ontology_with_relationships(self):
         """Test ontology generation with foreign key relationships."""
         tables = [self.sample_table, self.orders_table]
         result = self.generator.generate_from_schema(tables)
-        
+
         # Check for object properties (relationships)
         self.assertIn("owl:ObjectProperty", result)
-        
+
         # Check for both tables
         self.assertIn("users", result)
         self.assertIn("orders", result)
-        
+
         # Check for relationship properties
         self.assertIn("has", result)  # Should contain relationship naming
-    
+
     def test_add_table_with_various_constraints(self):
         """Test adding table with various column constraints."""
         # Create table with different constraint types
@@ -270,27 +271,27 @@ class TestOntologyGenerator(unittest.TestCase):
                     data_type="INTEGER",
                     is_nullable=False,
                     is_primary_key=True,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
                     name="name",
                     data_type="VARCHAR(100)",
                     is_nullable=False,  # Required field
                     is_primary_key=False,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
                     name="description",
                     data_type="TEXT",
                     is_nullable=True,  # Optional field
                     is_primary_key=False,
-                    is_foreign_key=False
-                )
+                    is_foreign_key=False,
+                ),
             ],
             primary_keys=["id"],
-            foreign_keys=[]
+            foreign_keys=[],
         )
-        
+
         result = self.generator.generate_from_schema([constrained_table])
 
         # Check that tables are top-level classes (not subclasses of restrictions)
@@ -301,92 +302,90 @@ class TestOntologyGenerator(unittest.TestCase):
         self.assertIn("oba:isPrimaryKey true", result)  # Primary key annotation
         self.assertIn("oba:isNullable false", result)  # Required field annotation
         self.assertIn("oba:isNullable true", result)  # Optional field annotation
-    
+
     def test_get_enrichment_data(self):
         """Test generation of enrichment data structure."""
         sample_data = {
             "users": [
                 {"id": 1, "username": "john_doe", "email": "john@example.com"},
-                {"id": 2, "username": "jane_smith", "email": "jane@example.com"}
+                {"id": 2, "username": "jane_smith", "email": "jane@example.com"},
             ]
         }
-        
+
         enrichment_data = self.generator.get_enrichment_data(
-            [self.sample_table], 
-            sample_data
+            [self.sample_table], sample_data
         )
-        
+
         # Check structure
         self.assertIn("schema_data", enrichment_data)
         self.assertIn("instructions", enrichment_data)
-        
+
         schema_data = enrichment_data["schema_data"]
         self.assertEqual(len(schema_data), 1)
-        
+
         table_data = schema_data[0]
         self.assertEqual(table_data["table_name"], "users")
         self.assertEqual(len(table_data["columns"]), 6)  # All columns from sample_table
         self.assertIn("sample_data", table_data)
         self.assertEqual(len(table_data["sample_data"]), 2)
-        
+
         # Check instructions
         instructions = enrichment_data["instructions"]
         self.assertIn("task", instructions)
         self.assertIn("expected_format", instructions)
         self.assertIn("guidelines", instructions)
-    
+
     def test_get_enrichment_data_no_samples(self):
         """Test enrichment data generation without sample data."""
         enrichment_data = self.generator.get_enrichment_data([self.sample_table], {})
-        
+
         schema_data = enrichment_data["schema_data"]
         table_data = schema_data[0]
         self.assertNotIn("sample_data", table_data)
-    
+
     def test_get_enrichment_data_limited_samples(self):
         """Test enrichment data with limited sample data."""
         large_sample_data = {
             "users": [{"id": i, "username": f"user_{i}"} for i in range(10)]
         }
-        
+
         enrichment_data = self.generator.get_enrichment_data(
-            [self.sample_table], 
-            large_sample_data
+            [self.sample_table], large_sample_data
         )
-        
+
         # Should be limited to first 3 samples
         table_data = enrichment_data["schema_data"][0]
         self.assertEqual(len(table_data["sample_data"]), 3)
-    
+
     def test_apply_enrichment_classes(self):
         """Test applying class enrichment suggestions."""
         # Generate base ontology first
         self.generator.generate_from_schema([self.sample_table])
-        
+
         enrichment_suggestions = {
             "classes": [
                 {
                     "original_name": "users",
                     "suggested_name": "UserAccount",
-                    "description": "User account entity representing registered users"
+                    "description": "User account entity representing registered users",
                 }
             ],
             "properties": [],
-            "relationships": []
+            "relationships": [],
         }
-        
+
         self.generator.apply_enrichment(enrichment_suggestions)
         result = self.generator.serialize_ontology()
-        
+
         # Check that enrichment was applied
         self.assertIn("UserAccount", result)
         self.assertIn("User account entity", result)
-    
+
     def test_apply_enrichment_properties(self):
         """Test applying property enrichment suggestions."""
         # Generate base ontology first
         self.generator.generate_from_schema([self.sample_table])
-        
+
         enrichment_suggestions = {
             "classes": [],
             "properties": [
@@ -394,24 +393,24 @@ class TestOntologyGenerator(unittest.TestCase):
                     "table_name": "users",
                     "original_name": "username",
                     "suggested_name": "accountName",
-                    "description": "Unique account identifier for user login"
+                    "description": "Unique account identifier for user login",
                 }
             ],
-            "relationships": []
+            "relationships": [],
         }
-        
+
         self.generator.apply_enrichment(enrichment_suggestions)
         result = self.generator.serialize_ontology()
-        
+
         # Check that property enrichment was applied
         self.assertIn("accountName", result)
         self.assertIn("Unique account identifier", result)
-    
+
     def test_apply_enrichment_relationships(self):
         """Test applying relationship enrichment suggestions."""
         # Generate ontology with relationships first
         self.generator.generate_from_schema([self.sample_table, self.orders_table])
-        
+
         enrichment_suggestions = {
             "classes": [],
             "properties": [],
@@ -420,31 +419,32 @@ class TestOntologyGenerator(unittest.TestCase):
                     "from_table": "orders",
                     "to_table": "users",
                     "suggested_name": "belongsToUser",
-                    "description": "Associates an order with the user who placed it"
+                    "description": "Associates an order with the user who placed it",
                 }
-            ]
+            ],
         }
-        
+
         self.generator.apply_enrichment(enrichment_suggestions)
         result = self.generator.serialize_ontology()
-        
+
         # Check that relationship enrichment was applied
         self.assertIn("belongsToUser", result)
         self.assertIn("Associates an order", result)
-    
+
     def test_serialize_ontology(self):
         """Test ontology serialization."""
         # Generate a basic ontology
         self.generator.generate_from_schema([self.sample_table])
-        
+
         # Test serialization
         result = self.generator.serialize_ontology()
-        
+
         self.assertIsInstance(result, str)
         self.assertIn("@prefix", result)
-        
+
         # Should be valid Turtle format
         from rdflib import Graph
+
         test_graph = Graph()
         try:
             test_graph.parse(data=result, format="turtle")
@@ -452,17 +452,17 @@ class TestOntologyGenerator(unittest.TestCase):
             self.assertTrue(True)
         except Exception as e:
             self.fail(f"Generated ontology is not valid Turtle: {e}")
-    
+
     def test_enrich_with_llm_placeholder(self):
         """Test LLM enrichment placeholder functionality."""
         sample_data = {"users": [{"id": 1, "username": "test"}]}
-        
+
         result = self.generator.enrich_with_llm([self.sample_table], sample_data)
-        
+
         # Should return basic ontology (LLM enrichment is handled by MCP tools)
         self.assertIsInstance(result, str)
         self.assertIn("@prefix", result)
-    
+
     def test_multiple_tables_ontology(self):
         """Test ontology generation with multiple related tables."""
         # Create a third table for more complex relationships
@@ -475,28 +475,28 @@ class TestOntologyGenerator(unittest.TestCase):
                     data_type="INTEGER",
                     is_nullable=False,
                     is_primary_key=True,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
                     name="name",
                     data_type="VARCHAR(100)",
                     is_nullable=False,
                     is_primary_key=False,
-                    is_foreign_key=False
-                )
+                    is_foreign_key=False,
+                ),
             ],
             primary_keys=["id"],
-            foreign_keys=[]
+            foreign_keys=[],
         )
-        
+
         tables = [self.sample_table, self.orders_table, products_table]
         result = self.generator.generate_from_schema(tables)
-        
+
         # Check all tables are represented
         self.assertIn("users", result)
         self.assertIn("orders", result)
         self.assertIn("products", result)
-        
+
         # Should have multiple classes
         class_count = result.count("owl:Class")
         self.assertGreaterEqual(class_count, 3)
@@ -513,10 +513,20 @@ class TestApplySemanticNamesDuplicateLabels(unittest.TestCase):
             name="sales",
             schema="public",
             columns=[
-                ColumnInfo(name="id", data_type="INTEGER", is_nullable=False,
-                           is_primary_key=True, is_foreign_key=False),
-                ColumnInfo(name="notes", data_type="TEXT", is_nullable=True,
-                           is_primary_key=False, is_foreign_key=False),
+                ColumnInfo(
+                    name="id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_foreign_key=False,
+                ),
+                ColumnInfo(
+                    name="notes",
+                    data_type="TEXT",
+                    is_nullable=True,
+                    is_primary_key=False,
+                    is_foreign_key=False,
+                ),
             ],
             primary_keys=["id"],
             foreign_keys=[],
@@ -525,10 +535,20 @@ class TestApplySemanticNamesDuplicateLabels(unittest.TestCase):
             name="purchases",
             schema="public",
             columns=[
-                ColumnInfo(name="id", data_type="INTEGER", is_nullable=False,
-                           is_primary_key=True, is_foreign_key=False),
-                ColumnInfo(name="notes", data_type="TEXT", is_nullable=True,
-                           is_primary_key=False, is_foreign_key=False),
+                ColumnInfo(
+                    name="id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_foreign_key=False,
+                ),
+                ColumnInfo(
+                    name="notes",
+                    data_type="TEXT",
+                    is_nullable=True,
+                    is_primary_key=False,
+                    is_foreign_key=False,
+                ),
             ],
             primary_keys=["id"],
             foreign_keys=[],
@@ -538,10 +558,20 @@ class TestApplySemanticNamesDuplicateLabels(unittest.TestCase):
             name="banks",
             schema="public",
             columns=[
-                ColumnInfo(name="id", data_type="INTEGER", is_nullable=False,
-                           is_primary_key=True, is_foreign_key=False),
-                ColumnInfo(name="bankname", data_type="VARCHAR(100)", is_nullable=False,
-                           is_primary_key=False, is_foreign_key=False),
+                ColumnInfo(
+                    name="id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_foreign_key=False,
+                ),
+                ColumnInfo(
+                    name="bankname",
+                    data_type="VARCHAR(100)",
+                    is_nullable=False,
+                    is_primary_key=False,
+                    is_foreign_key=False,
+                ),
             ],
             primary_keys=["id"],
             foreign_keys=[],
@@ -556,10 +586,18 @@ class TestApplySemanticNamesDuplicateLabels(unittest.TestCase):
 
         suggestions = {
             "properties": [
-                {"original_name": "notes", "table_name": "sales",
-                 "suggested_name": "Notes", "description": "Sales notes"},
-                {"original_name": "notes", "table_name": "purchases",
-                 "suggested_name": "Notes", "description": "Purchase notes"},
+                {
+                    "original_name": "notes",
+                    "table_name": "sales",
+                    "suggested_name": "Notes",
+                    "description": "Sales notes",
+                },
+                {
+                    "original_name": "notes",
+                    "table_name": "purchases",
+                    "suggested_name": "Notes",
+                    "description": "Purchase notes",
+                },
             ]
         }
 
@@ -570,7 +608,8 @@ class TestApplySemanticNamesDuplicateLabels(unittest.TestCase):
         self.assertIn("Notes (purchases)", result)
         # Plain "Notes" without qualifier should NOT be a standalone label
         notes_labels = [
-            str(o) for s, p, o in self.generator.graph.triples((None, RDFS.label, None))
+            str(o)
+            for s, p, o in self.generator.graph.triples((None, RDFS.label, None))
             if str(o) == "Notes"
         ]
         self.assertEqual(notes_labels, [], "Bare 'Notes' label should not exist")
@@ -581,10 +620,16 @@ class TestApplySemanticNamesDuplicateLabels(unittest.TestCase):
 
         suggestions = {
             "properties": [
-                {"original_name": "notes", "table_name": "sales",
-                 "suggested_name": "Sales Notes"},
-                {"original_name": "bankname", "table_name": "banks",
-                 "suggested_name": "Bank Name"},
+                {
+                    "original_name": "notes",
+                    "table_name": "sales",
+                    "suggested_name": "Sales Notes",
+                },
+                {
+                    "original_name": "bankname",
+                    "table_name": "banks",
+                    "suggested_name": "Bank Name",
+                },
             ]
         }
 
@@ -606,11 +651,17 @@ class TestApplySemanticNamesDuplicateLabels(unittest.TestCase):
                 {"original_name": "purchases", "suggested_name": "Purchase Orders"},
             ],
             "properties": [
-                {"original_name": "notes", "table_name": "sales",
-                 "suggested_name": "Notes"},
-                {"original_name": "notes", "table_name": "purchases",
-                 "suggested_name": "Notes"},
-            ]
+                {
+                    "original_name": "notes",
+                    "table_name": "sales",
+                    "suggested_name": "Notes",
+                },
+                {
+                    "original_name": "notes",
+                    "table_name": "purchases",
+                    "suggested_name": "Notes",
+                },
+            ],
         }
 
         result = self.generator.apply_semantic_names(suggestions)
@@ -625,6 +676,7 @@ class TestApplySemanticNamesDuplicateLabels(unittest.TestCase):
 
         # First, set "Bank Name" on banks_bankname (not via suggestions, direct set)
         from rdflib import Literal
+
         bankname_uri = self.generator.base_uri["banks_bankname"]
         self.generator.graph.remove((bankname_uri, RDFS.label, None))
         self.generator.graph.add((bankname_uri, RDFS.label, Literal("Bank Name")))
@@ -632,8 +684,11 @@ class TestApplySemanticNamesDuplicateLabels(unittest.TestCase):
         # Now suggest "Bank Name" for sales_notes — conflicts with existing
         suggestions = {
             "properties": [
-                {"original_name": "notes", "table_name": "sales",
-                 "suggested_name": "Bank Name"},
+                {
+                    "original_name": "notes",
+                    "table_name": "sales",
+                    "suggested_name": "Bank Name",
+                },
             ]
         }
 
@@ -648,10 +703,16 @@ class TestApplySemanticNamesDuplicateLabels(unittest.TestCase):
 
         suggestions = {
             "properties": [
-                {"original_name": "notes", "table_name": "sales",
-                 "suggested_name": "notes"},
-                {"original_name": "notes", "table_name": "purchases",
-                 "suggested_name": "Notes"},
+                {
+                    "original_name": "notes",
+                    "table_name": "sales",
+                    "suggested_name": "notes",
+                },
+                {
+                    "original_name": "notes",
+                    "table_name": "purchases",
+                    "suggested_name": "Notes",
+                },
             ]
         }
 
@@ -662,5 +723,5 @@ class TestApplySemanticNamesDuplicateLabels(unittest.TestCase):
         self.assertIn("Notes (purchases)", result)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_ontology_quality.py
+++ b/tests/test_ontology_quality.py
@@ -1,16 +1,17 @@
 """Tests for ontology quality improvements."""
 
 import unittest
-from rdflib import Literal
-from rdflib.namespace import RDF, OWL, XSD
 
+from rdflib import Literal
+from rdflib.namespace import OWL, RDF, XSD
+
+from src.database_manager import ColumnInfo, TableInfo
 from src.ontology_generator import (
+    DenormalizedField,
+    InferredRelationship,
     OntologyGenerator,
     OntologyQualityReport,
-    InferredRelationship,
-    DenormalizedField
 )
-from src.database_manager import TableInfo, ColumnInfo
 
 
 class TestInferredRelationships(unittest.TestCase):
@@ -31,18 +32,18 @@ class TestInferredRelationships(unittest.TestCase):
                     data_type="INTEGER",
                     is_nullable=False,
                     is_primary_key=True,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
                     name="countryname",
                     data_type="VARCHAR(100)",
                     is_nullable=False,
                     is_primary_key=False,
-                    is_foreign_key=False
-                )
+                    is_foreign_key=False,
+                ),
             ],
             primary_keys=["countryid"],
-            foreign_keys=[]
+            foreign_keys=[],
         )
 
         # Suppliers table (has implicit FK to countries)
@@ -55,14 +56,14 @@ class TestInferredRelationships(unittest.TestCase):
                     data_type="INTEGER",
                     is_nullable=False,
                     is_primary_key=True,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
                     name="suppliername",
                     data_type="VARCHAR(100)",
                     is_nullable=False,
                     is_primary_key=False,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 ),
                 # This should be inferred as FK to countries
                 ColumnInfo(
@@ -70,11 +71,11 @@ class TestInferredRelationships(unittest.TestCase):
                     data_type="INTEGER",
                     is_nullable=True,
                     is_primary_key=False,
-                    is_foreign_key=False  # Not declared as FK
-                )
+                    is_foreign_key=False,  # Not declared as FK
+                ),
             ],
             primary_keys=["supplierid"],
-            foreign_keys=[]  # No declared FKs
+            foreign_keys=[],  # No declared FKs
         )
 
         # Orders table with declared FK
@@ -87,7 +88,7 @@ class TestInferredRelationships(unittest.TestCase):
                     data_type="INTEGER",
                     is_nullable=False,
                     is_primary_key=True,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
                     name="supplierid",
@@ -96,15 +97,17 @@ class TestInferredRelationships(unittest.TestCase):
                     is_primary_key=False,
                     is_foreign_key=True,
                     foreign_key_table="suppliers",
-                    foreign_key_column="supplierid"
-                )
+                    foreign_key_column="supplierid",
+                ),
             ],
             primary_keys=["orderid"],
-            foreign_keys=[{
-                "column": "supplierid",
-                "referenced_table": "suppliers",
-                "referenced_column": "supplierid"
-            }]
+            foreign_keys=[
+                {
+                    "column": "supplierid",
+                    "referenced_table": "suppliers",
+                    "referenced_column": "supplierid",
+                }
+            ],
         )
 
         return [countries, suppliers, orders]
@@ -132,7 +135,8 @@ class TestInferredRelationships(unittest.TestCase):
 
         # Should NOT find orders.supplierid -> suppliers (already declared)
         supplier_rels = [
-            r for r in inferred
+            r
+            for r in inferred
             if r.source_table == "orders" and r.target_table == "suppliers"
         ]
         self.assertEqual(len(supplier_rels), 0)
@@ -174,15 +178,12 @@ class TestInferredRelationships(unittest.TestCase):
         rel_uri = base["suppliers_has_countries"]
 
         # Should be an ObjectProperty
-        self.assertIn(
-            (rel_uri, RDF.type, OWL.ObjectProperty),
-            self.generator.graph
-        )
+        self.assertIn((rel_uri, RDF.type, OWL.ObjectProperty), self.generator.graph)
 
         # Should be marked as inferred
         self.assertIn(
             (rel_uri, oba_ns.isInferredRelationship, Literal(True)),
-            self.generator.graph
+            self.generator.graph,
         )
 
 
@@ -251,11 +252,11 @@ class TestSemanticTypeMapping(unittest.TestCase):
                     data_type="DOUBLE PRECISION",
                     is_nullable=False,
                     is_primary_key=False,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 )
             ],
             primary_keys=[],
-            foreign_keys=[]
+            foreign_keys=[],
         )
 
         self.generator.generate_from_schema([table])
@@ -284,18 +285,18 @@ class TestDenormalizedFieldDetection(unittest.TestCase):
                     data_type="INTEGER",
                     is_nullable=False,
                     is_primary_key=True,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
                     name="clientname",
                     data_type="VARCHAR(100)",
                     is_nullable=False,
                     is_primary_key=False,
-                    is_foreign_key=False
-                )
+                    is_foreign_key=False,
+                ),
             ],
             primary_keys=["clientid"],
-            foreign_keys=[]
+            foreign_keys=[],
         )
 
         # Shipments with denormalized client name
@@ -308,7 +309,7 @@ class TestDenormalizedFieldDetection(unittest.TestCase):
                     data_type="INTEGER",
                     is_nullable=False,
                     is_primary_key=True,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
                     name="clientid",
@@ -317,7 +318,7 @@ class TestDenormalizedFieldDetection(unittest.TestCase):
                     is_primary_key=False,
                     is_foreign_key=True,
                     foreign_key_table="clients",
-                    foreign_key_column="clientid"
+                    foreign_key_column="clientid",
                 ),
                 # Denormalized field - stores client name redundantly
                 ColumnInfo(
@@ -325,15 +326,17 @@ class TestDenormalizedFieldDetection(unittest.TestCase):
                     data_type="VARCHAR(100)",
                     is_nullable=True,
                     is_primary_key=False,
-                    is_foreign_key=False
-                )
+                    is_foreign_key=False,
+                ),
             ],
             primary_keys=["shipmentid"],
-            foreign_keys=[{
-                "column": "clientid",
-                "referenced_table": "clients",
-                "referenced_column": "clientid"
-            }]
+            foreign_keys=[
+                {
+                    "column": "clientid",
+                    "referenced_table": "clients",
+                    "referenced_column": "clientid",
+                }
+            ],
         )
 
         return [clients, shipments]
@@ -361,11 +364,11 @@ class TestDenormalizedFieldDetection(unittest.TestCase):
                     data_type="INTEGER",
                     is_nullable=False,
                     is_primary_key=False,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 )
             ],
             primary_keys=[],
-            foreign_keys=[]
+            foreign_keys=[],
         )
 
         clients = TableInfo(
@@ -373,7 +376,7 @@ class TestDenormalizedFieldDetection(unittest.TestCase):
             schema="public",
             columns=[],
             primary_keys=[],
-            foreign_keys=[]
+            foreign_keys=[],
         )
 
         denormalized = self.generator._detect_denormalized_fields([tables, clients])
@@ -394,12 +397,11 @@ class TestDenormalizedFieldDetection(unittest.TestCase):
         prop_uri = base["shipments_shipmentclient"]
 
         self.assertIn(
-            (prop_uri, oba_ns.isDenormalized, Literal(True)),
-            self.generator.graph
+            (prop_uri, oba_ns.isDenormalized, Literal(True)), self.generator.graph
         )
         self.assertIn(
             (prop_uri, oba_ns.likelySourceTable, Literal("clients")),
-            self.generator.graph
+            self.generator.graph,
         )
 
 
@@ -420,18 +422,18 @@ class TestEnrichmentCompleteness(unittest.TestCase):
                     data_type="INTEGER",
                     is_nullable=False,
                     is_primary_key=True,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
                     name="username",
                     data_type="VARCHAR(50)",
                     is_nullable=False,
                     is_primary_key=False,
-                    is_foreign_key=False
-                )
+                    is_foreign_key=False,
+                ),
             ],
             primary_keys=["userid"],
-            foreign_keys=[]
+            foreign_keys=[],
         )
 
         self.generator.generate_from_schema([table])
@@ -456,12 +458,12 @@ class TestEnrichmentCompleteness(unittest.TestCase):
                     is_nullable=False,
                     is_primary_key=True,
                     is_foreign_key=False,
-                    comment="Unique user identifier"
+                    comment="Unique user identifier",
                 )
             ],
             primary_keys=["userid"],
             foreign_keys=[],
-            comment="Table storing user information"
+            comment="Table storing user information",
         )
 
         self.generator.generate_from_schema([table])
@@ -487,7 +489,7 @@ class TestQualityReport(unittest.TestCase):
                     target_table="countries",
                     target_column="id",
                     confidence="high",
-                    pattern_matched="suffix_id"
+                    pattern_matched="suffix_id",
                 )
             ],
             denormalized_fields=[
@@ -496,13 +498,13 @@ class TestQualityReport(unittest.TestCase):
                     column="clientname",
                     likely_source_table="clients",
                     data_type="VARCHAR(100)",
-                    warning="Test warning"
+                    warning="Test warning",
                 )
             ],
             type_overrides=[
                 {"column": "quantity", "overridden_xsd_type": "xsd:integer"}
             ],
-            warnings=["Test warning"]
+            warnings=["Test warning"],
         )
 
         result = report.to_dict()
@@ -538,18 +540,18 @@ class TestTPCDSPatterns(unittest.TestCase):
                     data_type="INTEGER",
                     is_nullable=False,
                     is_primary_key=True,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
                     name="c_customer_id",
                     data_type="VARCHAR(16)",
                     is_nullable=False,
                     is_primary_key=False,
-                    is_foreign_key=False
-                )
+                    is_foreign_key=False,
+                ),
             ],
             primary_keys=["c_customer_sk"],
-            foreign_keys=[]
+            foreign_keys=[],
         )
 
         item = TableInfo(
@@ -561,18 +563,18 @@ class TestTPCDSPatterns(unittest.TestCase):
                     data_type="INTEGER",
                     is_nullable=False,
                     is_primary_key=True,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
                     name="i_item_id",
                     data_type="VARCHAR(16)",
                     is_nullable=False,
                     is_primary_key=False,
-                    is_foreign_key=False
-                )
+                    is_foreign_key=False,
+                ),
             ],
             primary_keys=["i_item_sk"],
-            foreign_keys=[]
+            foreign_keys=[],
         )
 
         store_sales = TableInfo(
@@ -584,25 +586,25 @@ class TestTPCDSPatterns(unittest.TestCase):
                     data_type="INTEGER",
                     is_nullable=True,
                     is_primary_key=False,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
                     name="ss_customer_sk",
                     data_type="INTEGER",
                     is_nullable=True,
                     is_primary_key=False,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
                     name="ss_item_sk",
                     data_type="INTEGER",
                     is_nullable=False,
                     is_primary_key=False,
-                    is_foreign_key=False
-                )
+                    is_foreign_key=False,
+                ),
             ],
             primary_keys=[],
-            foreign_keys=[]
+            foreign_keys=[],
         )
 
         return [customer, item, store_sales]
@@ -636,10 +638,7 @@ class TestTPCDSPatterns(unittest.TestCase):
 
         # Check STORE_SALES -> CUSTOMER relationship
         rel_uri = base["STORE_SALES_has_CUSTOMER"]
-        self.assertIn(
-            (rel_uri, RDF.type, OWL.ObjectProperty),
-            self.generator.graph
-        )
+        self.assertIn((rel_uri, RDF.type, OWL.ObjectProperty), self.generator.graph)
 
 
 class TestTableLookup(unittest.TestCase):
@@ -651,7 +650,13 @@ class TestTableLookup(unittest.TestCase):
     def test_singular_to_plural(self):
         """Test finding plural table from singular name."""
         tables = [
-            TableInfo(name="countries", schema="public", columns=[], primary_keys=[], foreign_keys=[])
+            TableInfo(
+                name="countries",
+                schema="public",
+                columns=[],
+                primary_keys=[],
+                foreign_keys=[],
+            )
         ]
         self.generator._build_table_lookup(tables)
 
@@ -663,7 +668,13 @@ class TestTableLookup(unittest.TestCase):
     def test_plural_to_singular(self):
         """Test finding singular table from plural name."""
         tables = [
-            TableInfo(name="user", schema="public", columns=[], primary_keys=[], foreign_keys=[])
+            TableInfo(
+                name="user",
+                schema="public",
+                columns=[],
+                primary_keys=[],
+                foreign_keys=[],
+            )
         ]
         self.generator._build_table_lookup(tables)
 
@@ -675,7 +686,13 @@ class TestTableLookup(unittest.TestCase):
     def test_direct_match(self):
         """Test direct name matching."""
         tables = [
-            TableInfo(name="products", schema="public", columns=[], primary_keys=[], foreign_keys=[])
+            TableInfo(
+                name="products",
+                schema="public",
+                columns=[],
+                primary_keys=[],
+                foreign_keys=[],
+            )
         ]
         self.generator._build_table_lookup(tables)
 
@@ -686,7 +703,13 @@ class TestTableLookup(unittest.TestCase):
     def test_no_match(self):
         """Test when no matching table exists."""
         tables = [
-            TableInfo(name="orders", schema="public", columns=[], primary_keys=[], foreign_keys=[])
+            TableInfo(
+                name="orders",
+                schema="public",
+                columns=[],
+                primary_keys=[],
+                foreign_keys=[],
+            )
         ]
         self.generator._build_table_lookup(tables)
 
@@ -694,5 +717,5 @@ class TestTableLookup(unittest.TestCase):
         self.assertIsNone(result)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_ontology_workflow_fix.py
+++ b/tests/test_ontology_workflow_fix.py
@@ -6,11 +6,12 @@ This test verifies the bug fix for Phase 2 where lightweight mode wasn't caching
 TableInfo objects, causing generate_ontology() to fail or re-query the database.
 """
 
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
 import pytest
-from unittest.mock import Mock, MagicMock, AsyncMock, patch
 
 import src.main as main_module
-from src.database_manager import DatabaseManager, TableInfo, ColumnInfo
+from src.database_manager import ColumnInfo, DatabaseManager, TableInfo
 
 
 def create_mock_context():
@@ -42,19 +43,19 @@ def mock_db_manager():
                         data_type="INTEGER",
                         is_nullable=False,
                         is_primary_key=True,
-                        is_foreign_key=False
+                        is_foreign_key=False,
                     ),
                     ColumnInfo(
                         name="name",
                         data_type="VARCHAR",
                         is_nullable=False,
                         is_primary_key=False,
-                        is_foreign_key=False
-                    )
+                        is_foreign_key=False,
+                    ),
                 ],
                 primary_keys=["customer_id"],
                 foreign_keys=[],
-                row_count=100
+                row_count=100,
             )
         elif table_name == "orders":
             return TableInfo(
@@ -66,7 +67,7 @@ def mock_db_manager():
                         data_type="INTEGER",
                         is_nullable=False,
                         is_primary_key=True,
-                        is_foreign_key=False
+                        is_foreign_key=False,
                     ),
                     ColumnInfo(
                         name="customer_id",
@@ -75,18 +76,18 @@ def mock_db_manager():
                         is_primary_key=False,
                         is_foreign_key=True,
                         foreign_key_table="customers",
-                        foreign_key_column="customer_id"
-                    )
+                        foreign_key_column="customer_id",
+                    ),
                 ],
                 primary_keys=["order_id"],
                 foreign_keys=[
                     {
                         "column": "customer_id",
                         "referenced_table": "customers",
-                        "referenced_column": "customer_id"
+                        "referenced_column": "customer_id",
                     }
                 ],
-                row_count=500
+                row_count=500,
             )
         elif table_name == "order_items":
             return TableInfo(
@@ -98,7 +99,7 @@ def mock_db_manager():
                         data_type="INTEGER",
                         is_nullable=False,
                         is_primary_key=True,
-                        is_foreign_key=False
+                        is_foreign_key=False,
                     ),
                     ColumnInfo(
                         name="order_id",
@@ -107,18 +108,18 @@ def mock_db_manager():
                         is_primary_key=False,
                         is_foreign_key=True,
                         foreign_key_table="orders",
-                        foreign_key_column="order_id"
-                    )
+                        foreign_key_column="order_id",
+                    ),
                 ],
                 primary_keys=["item_id"],
                 foreign_keys=[
                     {
                         "column": "order_id",
                         "referenced_table": "orders",
-                        "referenced_column": "order_id"
+                        "referenced_column": "order_id",
                     }
                 ],
-                row_count=1500
+                row_count=1500,
             )
         return None
 
@@ -139,11 +140,13 @@ def mock_context():
 async def test_lightweight_caches_for_ontology(mock_context, mock_db_manager, tmp_path):
     """Test that lightweight mode caches full TableInfo for generate_ontology()."""
 
-    with patch('src.main.get_session_db_manager', return_value=mock_db_manager), \
-         patch('src.main.get_session_data') as mock_session_data, \
-         patch('src.handlers.ontology_generation.ensure_output_dir', return_value=tmp_path), \
-         patch('src.main.get_session_safe_filename', return_value="test"):
-
+    with patch("src.main.get_session_db_manager", return_value=mock_db_manager), patch(
+        "src.main.get_session_data"
+    ) as mock_session_data, patch(
+        "src.handlers.ontology_generation.ensure_output_dir", return_value=tmp_path
+    ), patch(
+        "src.main.get_session_safe_filename", return_value="test"
+    ):
         # Mock session data
         session = Mock()
         session.get_cached_schema.return_value = None  # No cache initially
@@ -159,7 +162,9 @@ async def test_lightweight_caches_for_ontology(mock_context, mock_db_manager, tm
 
         # Step 1: Call discover_schema in lightweight mode
         # Use .fn accessor to handle both FunctionTool (under coverage) and plain function
-        analyze_fn = getattr(main_module.discover_schema, 'fn', main_module.discover_schema)
+        analyze_fn = getattr(
+            main_module.discover_schema, "fn", main_module.discover_schema
+        )
         result = await analyze_fn(mock_context, schema_name="public", lightweight=True)
 
         # Verify lightweight result structure
@@ -189,43 +194,64 @@ async def test_lightweight_caches_for_ontology(mock_context, mock_db_manager, tm
 async def test_ontology_uses_lightweight_cache(mock_context, mock_db_manager, tmp_path):
     """Test that generate_ontology() works with data cached by lightweight mode."""
 
-    with patch('src.main.get_session_db_manager', return_value=mock_db_manager), \
-         patch('src.main.get_session_data') as mock_session_data, \
-         patch('src.handlers.ontology_generation.ensure_output_dir', return_value=tmp_path), \
-         patch('src.main.get_session_safe_filename', return_value="test"), \
-         patch('src.main._server_state') as mock_server_state:
-
+    with patch("src.main.get_session_db_manager", return_value=mock_db_manager), patch(
+        "src.main.get_session_data"
+    ) as mock_session_data, patch(
+        "src.handlers.ontology_generation.ensure_output_dir", return_value=tmp_path
+    ), patch(
+        "src.main.get_session_safe_filename", return_value="test"
+    ), patch(
+        "src.main._server_state"
+    ) as mock_server_state:
         # Prepare cached tables (simulating what lightweight mode would cache)
         cached_tables = [
             TableInfo(
                 name="customers",
                 schema="public",
                 columns=[
-                    ColumnInfo(name="customer_id", data_type="INTEGER", is_nullable=False,
-                              is_primary_key=True, is_foreign_key=False)
+                    ColumnInfo(
+                        name="customer_id",
+                        data_type="INTEGER",
+                        is_nullable=False,
+                        is_primary_key=True,
+                        is_foreign_key=False,
+                    )
                 ],
                 primary_keys=["customer_id"],
                 foreign_keys=[],
-                row_count=100
+                row_count=100,
             ),
             TableInfo(
                 name="orders",
                 schema="public",
                 columns=[
-                    ColumnInfo(name="order_id", data_type="INTEGER", is_nullable=False,
-                              is_primary_key=True, is_foreign_key=False),
-                    ColumnInfo(name="customer_id", data_type="INTEGER", is_nullable=False,
-                              is_primary_key=False, is_foreign_key=True,
-                              foreign_key_table="customers", foreign_key_column="customer_id")
+                    ColumnInfo(
+                        name="order_id",
+                        data_type="INTEGER",
+                        is_nullable=False,
+                        is_primary_key=True,
+                        is_foreign_key=False,
+                    ),
+                    ColumnInfo(
+                        name="customer_id",
+                        data_type="INTEGER",
+                        is_nullable=False,
+                        is_primary_key=False,
+                        is_foreign_key=True,
+                        foreign_key_table="customers",
+                        foreign_key_column="customer_id",
+                    ),
                 ],
                 primary_keys=["order_id"],
-                foreign_keys=[{
-                    "column": "customer_id",
-                    "referenced_table": "customers",
-                    "referenced_column": "customer_id"
-                }],
-                row_count=500
-            )
+                foreign_keys=[
+                    {
+                        "column": "customer_id",
+                        "referenced_table": "customers",
+                        "referenced_column": "customer_id",
+                    }
+                ],
+                row_count=500,
+            ),
         ]
 
         # Mock session with cached data
@@ -238,7 +264,9 @@ async def test_ontology_uses_lightweight_cache(mock_context, mock_db_manager, tm
 
         # Mock ontology generator
         mock_generator = Mock()
-        mock_generator.generate_from_schema.return_value = "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ."
+        mock_generator.generate_from_schema.return_value = (
+            "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ."
+        )
         mock_generator.graph = Mock()
         mock_generator.graph.parse = Mock()
         mock_generator.base_uri = "http://example.org/"
@@ -246,13 +274,15 @@ async def test_ontology_uses_lightweight_cache(mock_context, mock_db_manager, tm
         mock_generator.extract_names_for_review.return_value = {
             "tables": [],
             "columns": [],
-            "cryptic_count": 0
+            "cryptic_count": 0,
         }
         mock_server_state.get_ontology_generator.return_value = mock_generator
 
         # Step 2: Call generate_ontology WITHOUT schema_info parameter
         # Use .fn accessor to handle both FunctionTool (under coverage) and plain function
-        generate_fn = getattr(main_module.generate_ontology, 'fn', main_module.generate_ontology)
+        generate_fn = getattr(
+            main_module.generate_ontology, "fn", main_module.generate_ontology
+        )
         await generate_fn(mock_context)
 
         # Verify it used the cached data
@@ -266,15 +296,20 @@ async def test_ontology_uses_lightweight_cache(mock_context, mock_db_manager, tm
 
 
 @pytest.mark.asyncio
-async def test_full_workflow_lightweight_to_ontology(mock_context, mock_db_manager, tmp_path):
+async def test_full_workflow_lightweight_to_ontology(
+    mock_context, mock_db_manager, tmp_path
+):
     """Integration test: lightweight analyze -> generate ontology."""
 
-    with patch('src.main.get_session_db_manager', return_value=mock_db_manager), \
-         patch('src.main.get_session_data') as mock_session_data, \
-         patch('src.handlers.ontology_generation.ensure_output_dir', return_value=tmp_path), \
-         patch('src.main.get_session_safe_filename', return_value="test"), \
-         patch('src.main._server_state') as mock_server_state:
-
+    with patch("src.main.get_session_db_manager", return_value=mock_db_manager), patch(
+        "src.main.get_session_data"
+    ) as mock_session_data, patch(
+        "src.handlers.ontology_generation.ensure_output_dir", return_value=tmp_path
+    ), patch(
+        "src.main.get_session_safe_filename", return_value="test"
+    ), patch(
+        "src.main._server_state"
+    ) as mock_server_state:
         # Real session-like behavior
         cached_data = {}
 
@@ -316,7 +351,9 @@ async def test_full_workflow_lightweight_to_ontology(mock_context, mock_db_manag
 
         # Mock ontology generator
         mock_generator = Mock()
-        mock_generator.generate_from_schema.return_value = "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ."
+        mock_generator.generate_from_schema.return_value = (
+            "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ."
+        )
         mock_generator.graph = Mock()
         mock_generator.graph.parse = Mock()
         mock_generator.base_uri = "http://example.org/"
@@ -324,16 +361,22 @@ async def test_full_workflow_lightweight_to_ontology(mock_context, mock_db_manag
         mock_generator.extract_names_for_review.return_value = {
             "tables": [],
             "columns": [],
-            "cryptic_count": 0
+            "cryptic_count": 0,
         }
         mock_server_state.get_ontology_generator.return_value = mock_generator
 
         # Use .fn accessor to handle both FunctionTool (under coverage) and plain function
-        analyze_fn = getattr(main_module.discover_schema, 'fn', main_module.discover_schema)
-        generate_fn = getattr(main_module.generate_ontology, 'fn', main_module.generate_ontology)
+        analyze_fn = getattr(
+            main_module.discover_schema, "fn", main_module.discover_schema
+        )
+        generate_fn = getattr(
+            main_module.generate_ontology, "fn", main_module.generate_ontology
+        )
 
         # Step 1: discover_schema(lightweight=True)
-        schema_result = await analyze_fn(mock_context, schema_name="public", lightweight=True)
+        schema_result = await analyze_fn(
+            mock_context, schema_name="public", lightweight=True
+        )
 
         assert schema_result["mode"] == "lightweight"
         assert schema_result["table_count"] == 3

--- a/tests/test_owl_axioms.py
+++ b/tests/test_owl_axioms.py
@@ -1,12 +1,13 @@
 """Tests for OWL axiom generation: FunctionalProperty, disjointWith, propertyChainAxiom."""
 
 import unittest
-from rdflib import URIRef, Namespace
-from rdflib.namespace import RDF, RDFS, OWL
 
-from src.ontology_generator import OntologyGenerator
-from src.database_manager import TableInfo, ColumnInfo
+from rdflib import Namespace, URIRef
+from rdflib.namespace import OWL, RDF, RDFS
+
 from src.constants import OBA_NAMESPACE
+from src.database_manager import ColumnInfo, TableInfo
+from src.ontology_generator import OntologyGenerator
 
 OBA = Namespace(OBA_NAMESPACE)
 
@@ -28,12 +29,18 @@ class TestOwlAxioms(unittest.TestCase):
             schema="public",
             columns=[
                 ColumnInfo(
-                    name="id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=True, is_foreign_key=False,
+                    name="id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
-                    name="name", data_type="VARCHAR(200)",
-                    is_nullable=False, is_primary_key=False, is_foreign_key=False,
+                    name="name",
+                    data_type="VARCHAR(200)",
+                    is_nullable=False,
+                    is_primary_key=False,
+                    is_foreign_key=False,
                 ),
             ],
             primary_keys=["id"],
@@ -46,21 +53,37 @@ class TestOwlAxioms(unittest.TestCase):
             schema="public",
             columns=[
                 ColumnInfo(
-                    name="id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=True, is_foreign_key=False,
+                    name="id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
-                    name="customer_id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=False, is_foreign_key=True,
-                    foreign_key_table="customers", foreign_key_column="id",
+                    name="customer_id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=False,
+                    is_foreign_key=True,
+                    foreign_key_table="customers",
+                    foreign_key_column="id",
                 ),
                 ColumnInfo(
-                    name="total", data_type="DECIMAL(12,2)",
-                    is_nullable=False, is_primary_key=False, is_foreign_key=False,
+                    name="total",
+                    data_type="DECIMAL(12,2)",
+                    is_nullable=False,
+                    is_primary_key=False,
+                    is_foreign_key=False,
                 ),
             ],
             primary_keys=["id"],
-            foreign_keys=[{"column": "customer_id", "referenced_table": "customers", "referenced_column": "id"}],
+            foreign_keys=[
+                {
+                    "column": "customer_id",
+                    "referenced_table": "customers",
+                    "referenced_column": "id",
+                }
+            ],
             row_count=482000,
         )
 
@@ -69,21 +92,37 @@ class TestOwlAxioms(unittest.TestCase):
             schema="public",
             columns=[
                 ColumnInfo(
-                    name="id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=True, is_foreign_key=False,
+                    name="id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
-                    name="customer_id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=False, is_foreign_key=True,
-                    foreign_key_table="customers", foreign_key_column="id",
+                    name="customer_id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=False,
+                    is_foreign_key=True,
+                    foreign_key_table="customers",
+                    foreign_key_column="id",
                 ),
                 ColumnInfo(
-                    name="refund_amount", data_type="DECIMAL(12,2)",
-                    is_nullable=False, is_primary_key=False, is_foreign_key=False,
+                    name="refund_amount",
+                    data_type="DECIMAL(12,2)",
+                    is_nullable=False,
+                    is_primary_key=False,
+                    is_foreign_key=False,
                 ),
             ],
             primary_keys=["id"],
-            foreign_keys=[{"column": "customer_id", "referenced_table": "customers", "referenced_column": "id"}],
+            foreign_keys=[
+                {
+                    "column": "customer_id",
+                    "referenced_table": "customers",
+                    "referenced_column": "id",
+                }
+            ],
             row_count=31000,
         )
 
@@ -125,12 +164,18 @@ class TestOwlAxioms(unittest.TestCase):
             schema="public",
             columns=[
                 ColumnInfo(
-                    name="id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=True, is_foreign_key=False,
+                    name="id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
-                    name="name", data_type="VARCHAR(100)",
-                    is_nullable=False, is_primary_key=False, is_foreign_key=False,
+                    name="name",
+                    data_type="VARCHAR(100)",
+                    is_nullable=False,
+                    is_primary_key=False,
+                    is_foreign_key=False,
                 ),
             ],
             primary_keys=["id"],
@@ -142,12 +187,18 @@ class TestOwlAxioms(unittest.TestCase):
             schema="public",
             columns=[
                 ColumnInfo(
-                    name="id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=True, is_foreign_key=False,
+                    name="id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
-                    name="product_id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=False, is_foreign_key=False,
+                    name="product_id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=False,
+                    is_foreign_key=False,
                 ),
             ],
             primary_keys=["id"],
@@ -183,10 +234,11 @@ class TestOwlAxioms(unittest.TestCase):
         g = self.generator.graph
 
         # Either direction is valid for disjointWith (symmetric)
-        has_disjoint = (
-            (orders_uri, OWL.disjointWith, returns_uri) in g
-            or (returns_uri, OWL.disjointWith, orders_uri) in g
-        )
+        has_disjoint = (orders_uri, OWL.disjointWith, returns_uri) in g or (
+            returns_uri,
+            OWL.disjointWith,
+            orders_uri,
+        ) in g
         self.assertTrue(has_disjoint, "orders and returns should be owl:disjointWith")
 
     def test_no_disjoint_between_fk_pair(self):
@@ -221,17 +273,30 @@ class TestOwlAxioms(unittest.TestCase):
             schema="public",
             columns=[
                 ColumnInfo(
-                    name="id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=True, is_foreign_key=False,
+                    name="id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
-                    name="customer_id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=False, is_foreign_key=True,
-                    foreign_key_table="customers", foreign_key_column="id",
+                    name="customer_id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=False,
+                    is_foreign_key=True,
+                    foreign_key_table="customers",
+                    foreign_key_column="id",
                 ),
             ],
             primary_keys=["id"],
-            foreign_keys=[{"column": "customer_id", "referenced_table": "customers", "referenced_column": "id"}],
+            foreign_keys=[
+                {
+                    "column": "customer_id",
+                    "referenced_table": "customers",
+                    "referenced_column": "id",
+                }
+            ],
             row_count=200000,
         )
 
@@ -256,12 +321,18 @@ class TestOwlAxioms(unittest.TestCase):
             schema="public",
             columns=[
                 ColumnInfo(
-                    name="id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=True, is_foreign_key=False,
+                    name="id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
-                    name="name", data_type="VARCHAR(100)",
-                    is_nullable=False, is_primary_key=False, is_foreign_key=False,
+                    name="name",
+                    data_type="VARCHAR(100)",
+                    is_nullable=False,
+                    is_primary_key=False,
+                    is_foreign_key=False,
                 ),
             ],
             primary_keys=["id"],
@@ -274,17 +345,30 @@ class TestOwlAxioms(unittest.TestCase):
             schema="public",
             columns=[
                 ColumnInfo(
-                    name="id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=True, is_foreign_key=False,
+                    name="id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
-                    name="region_id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=False, is_foreign_key=True,
-                    foreign_key_table="regions", foreign_key_column="id",
+                    name="region_id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=False,
+                    is_foreign_key=True,
+                    foreign_key_table="regions",
+                    foreign_key_column="id",
                 ),
             ],
             primary_keys=["id"],
-            foreign_keys=[{"column": "region_id", "referenced_table": "regions", "referenced_column": "id"}],
+            foreign_keys=[
+                {
+                    "column": "region_id",
+                    "referenced_table": "regions",
+                    "referenced_column": "id",
+                }
+            ],
             row_count=15000,
         )
 
@@ -311,8 +395,11 @@ class TestOwlAxioms(unittest.TestCase):
             schema="public",
             columns=[
                 ColumnInfo(
-                    name="id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=True, is_foreign_key=False,
+                    name="id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_foreign_key=False,
                 ),
             ],
             primary_keys=["id"],
@@ -324,17 +411,30 @@ class TestOwlAxioms(unittest.TestCase):
             schema="public",
             columns=[
                 ColumnInfo(
-                    name="id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=True, is_foreign_key=False,
+                    name="id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
-                    name="region_id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=False, is_foreign_key=True,
-                    foreign_key_table="regions", foreign_key_column="id",
+                    name="region_id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=False,
+                    is_foreign_key=True,
+                    foreign_key_table="regions",
+                    foreign_key_column="id",
                 ),
             ],
             primary_keys=["id"],
-            foreign_keys=[{"column": "region_id", "referenced_table": "regions", "referenced_column": "id"}],
+            foreign_keys=[
+                {
+                    "column": "region_id",
+                    "referenced_table": "regions",
+                    "referenced_column": "id",
+                }
+            ],
             row_count=15000,
         )
         # orders FK to both customers AND regions (direct)
@@ -343,24 +443,43 @@ class TestOwlAxioms(unittest.TestCase):
             schema="public",
             columns=[
                 ColumnInfo(
-                    name="id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=True, is_foreign_key=False,
+                    name="id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
-                    name="customer_id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=False, is_foreign_key=True,
-                    foreign_key_table="customers", foreign_key_column="id",
+                    name="customer_id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=False,
+                    is_foreign_key=True,
+                    foreign_key_table="customers",
+                    foreign_key_column="id",
                 ),
                 ColumnInfo(
-                    name="region_id", data_type="INTEGER",
-                    is_nullable=False, is_primary_key=False, is_foreign_key=True,
-                    foreign_key_table="regions", foreign_key_column="id",
+                    name="region_id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=False,
+                    is_foreign_key=True,
+                    foreign_key_table="regions",
+                    foreign_key_column="id",
                 ),
             ],
             primary_keys=["id"],
             foreign_keys=[
-                {"column": "customer_id", "referenced_table": "customers", "referenced_column": "id"},
-                {"column": "region_id", "referenced_table": "regions", "referenced_column": "id"},
+                {
+                    "column": "customer_id",
+                    "referenced_table": "customers",
+                    "referenced_column": "id",
+                },
+                {
+                    "column": "region_id",
+                    "referenced_table": "regions",
+                    "referenced_column": "id",
+                },
             ],
             row_count=482000,
         )
@@ -384,7 +503,6 @@ class TestOwlAxioms(unittest.TestCase):
         g = self.generator.graph
         chain_triples = list(g.triples((None, OWL.propertyChainAxiom, None)))
         self.assertEqual(len(chain_triples), 0)
-
 
     # -------------------------------------------------------------------------
     # oba:joinsTo shared traversable join predicate tests (Phase 1)

--- a/tests/test_oxigraph_autopersist.py
+++ b/tests/test_oxigraph_autopersist.py
@@ -8,14 +8,15 @@ This module tests:
 - Fallback behavior when Oxigraph not available
 """
 
-import pytest
-import tempfile
 import shutil
+import tempfile
 from pathlib import Path
-from unittest.mock import Mock, AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
-from src.oxigraph_store import OxigraphStoreManager, OXIGRAPH_AVAILABLE
-from src.database_manager import TableInfo, ColumnInfo
+import pytest
+
+from src.database_manager import ColumnInfo, TableInfo
+from src.oxigraph_store import OXIGRAPH_AVAILABLE, OxigraphStoreManager
 
 
 class TestOxigraphStoreManager:
@@ -86,7 +87,11 @@ class TestOxigraphStoreManager:
         assert exported_ttl is not None
         assert len(exported_ttl) > 0
         # export_graph may return bytes or str
-        exported_str = exported_ttl.decode("utf-8") if isinstance(exported_ttl, bytes) else exported_ttl
+        exported_str = (
+            exported_ttl.decode("utf-8")
+            if isinstance(exported_ttl, bytes)
+            else exported_ttl
+        )
         assert "Customer" in exported_str or "ns:Customer" in exported_str
 
     @pytest.mark.skipif(not OXIGRAPH_AVAILABLE, reason="Oxigraph not available")
@@ -173,8 +178,8 @@ class TestAutoPersistBehavior:
         ]
 
     @pytest.mark.skipif(not OXIGRAPH_AVAILABLE, reason="Oxigraph not available")
-    @patch('src.main.get_oxigraph_store')
-    @patch('src.main.get_session_data')
+    @patch("src.main.get_oxigraph_store")
+    @patch("src.main.get_session_data")
     async def test_auto_persist_enabled_returns_summary(
         self, mock_session, mock_get_store, mock_context, sample_tables
     ):
@@ -197,17 +202,19 @@ class TestAutoPersistBehavior:
 
         # Call with auto_persist=True (default)
         result = await generate_ontology(
-            mock_context,
-            schema_name="public",
-            auto_persist=True
+            mock_context, schema_name="public", auto_persist=True
         )
 
         # Should return summary, not full TTL
         assert isinstance(result, str)
-        assert "Ontology generated" in result or "triples" in result.lower() or "@prefix" in result
+        assert (
+            "Ontology generated" in result
+            or "triples" in result.lower()
+            or "@prefix" in result
+        )
 
-    @patch('src.server_state.OXIGRAPH_AVAILABLE', False)
-    @patch('src.main.get_session_data')
+    @patch("src.server_state.OXIGRAPH_AVAILABLE", False)
+    @patch("src.main.get_session_data")
     async def test_auto_persist_fallback_when_oxigraph_unavailable(
         self, mock_session, mock_context, sample_tables
     ):
@@ -225,9 +232,7 @@ class TestAutoPersistBehavior:
 
         # Call with auto_persist=True (should fallback since oxigraph may not be available)
         result = await generate_ontology(
-            mock_context,
-            schema_name="public",
-            auto_persist=True
+            mock_context, schema_name="public", auto_persist=True
         )
 
         # Should return minimal graph summary (not full TTL)
@@ -235,7 +240,7 @@ class TestAutoPersistBehavior:
         assert len(result) > 0
         assert "Minimal Graph Summary" in result or "Classes" in result
 
-    @patch('src.main.get_session_data')
+    @patch("src.main.get_session_data")
     async def test_auto_persist_false_returns_minimal_summary(
         self, mock_session, mock_context, sample_tables
     ):
@@ -253,9 +258,7 @@ class TestAutoPersistBehavior:
 
         # Call with auto_persist=False
         result = await generate_ontology(
-            mock_context,
-            schema_name="public",
-            auto_persist=False
+            mock_context, schema_name="public", auto_persist=False
         )
 
         # Should return minimal graph summary instead of full TTL
@@ -277,8 +280,20 @@ class TestSchemaHashDetection:
                 name="users",
                 schema="public",
                 columns=[
-                    ColumnInfo(name="id", data_type="integer", is_nullable=False, is_primary_key=True, is_foreign_key=False),
-                    ColumnInfo(name="name", data_type="varchar", is_nullable=False, is_primary_key=False, is_foreign_key=False),
+                    ColumnInfo(
+                        name="id",
+                        data_type="integer",
+                        is_nullable=False,
+                        is_primary_key=True,
+                        is_foreign_key=False,
+                    ),
+                    ColumnInfo(
+                        name="name",
+                        data_type="varchar",
+                        is_nullable=False,
+                        is_primary_key=False,
+                        is_foreign_key=False,
+                    ),
                 ],
                 primary_keys=["id"],
                 foreign_keys=[],
@@ -290,8 +305,20 @@ class TestSchemaHashDetection:
                 name="users",
                 schema="public",
                 columns=[
-                    ColumnInfo(name="id", data_type="integer", is_nullable=False, is_primary_key=True, is_foreign_key=False),
-                    ColumnInfo(name="name", data_type="varchar", is_nullable=False, is_primary_key=False, is_foreign_key=False),
+                    ColumnInfo(
+                        name="id",
+                        data_type="integer",
+                        is_nullable=False,
+                        is_primary_key=True,
+                        is_foreign_key=False,
+                    ),
+                    ColumnInfo(
+                        name="name",
+                        data_type="varchar",
+                        is_nullable=False,
+                        is_primary_key=False,
+                        is_foreign_key=False,
+                    ),
                 ],
                 primary_keys=["id"],
                 foreign_keys=[],
@@ -313,7 +340,13 @@ class TestSchemaHashDetection:
                 name="users",
                 schema="public",
                 columns=[
-                    ColumnInfo(name="id", data_type="integer", is_nullable=False, is_primary_key=True, is_foreign_key=False),
+                    ColumnInfo(
+                        name="id",
+                        data_type="integer",
+                        is_nullable=False,
+                        is_primary_key=True,
+                        is_foreign_key=False,
+                    ),
                 ],
                 primary_keys=["id"],
                 foreign_keys=[],
@@ -326,8 +359,20 @@ class TestSchemaHashDetection:
                 name="users",
                 schema="public",
                 columns=[
-                    ColumnInfo(name="id", data_type="integer", is_nullable=False, is_primary_key=True, is_foreign_key=False),
-                    ColumnInfo(name="email", data_type="varchar", is_nullable=True, is_primary_key=False, is_foreign_key=False),
+                    ColumnInfo(
+                        name="id",
+                        data_type="integer",
+                        is_nullable=False,
+                        is_primary_key=True,
+                        is_foreign_key=False,
+                    ),
+                    ColumnInfo(
+                        name="email",
+                        data_type="varchar",
+                        is_nullable=True,
+                        is_primary_key=False,
+                        is_foreign_key=False,
+                    ),
                 ],
                 primary_keys=["id"],
                 foreign_keys=[],
@@ -348,7 +393,13 @@ class TestSchemaHashDetection:
                 name="users",
                 schema="public",
                 columns=[
-                    ColumnInfo(name="id", data_type="integer", is_nullable=False, is_primary_key=True, is_foreign_key=False),
+                    ColumnInfo(
+                        name="id",
+                        data_type="integer",
+                        is_nullable=False,
+                        is_primary_key=True,
+                        is_foreign_key=False,
+                    ),
                 ],
                 primary_keys=["id"],
                 foreign_keys=[],
@@ -361,7 +412,13 @@ class TestSchemaHashDetection:
                 name="users",
                 schema="public",
                 columns=[
-                    ColumnInfo(name="id", data_type="integer", is_nullable=False, is_primary_key=True, is_foreign_key=False),
+                    ColumnInfo(
+                        name="id",
+                        data_type="integer",
+                        is_nullable=False,
+                        is_primary_key=True,
+                        is_foreign_key=False,
+                    ),
                 ],
                 primary_keys=["id"],
                 foreign_keys=[],

--- a/tests/test_phase1_token_reduction.py
+++ b/tests/test_phase1_token_reduction.py
@@ -8,8 +8,9 @@ Verifies that:
 4. No functionality regression
 """
 
-import pytest
 from pathlib import Path
+
+import pytest
 
 import src.main as main_module
 from src.main import mcp
@@ -23,7 +24,7 @@ def _get_tool_fn(name):
     This helper normalizes access.
     """
     obj = getattr(main_module, name)
-    return getattr(obj, 'fn', obj)
+    return getattr(obj, "fn", obj)
 
 
 def _get_tool_docstring(name):
@@ -48,7 +49,7 @@ class TestPhase1TokenReduction:
         expected_skills = [
             "fan-trap-prevention.md",
             "sql-best-practices.md",
-            "chart-examples.md"
+            "chart-examples.md",
         ]
 
         for skill in expected_skills:
@@ -111,7 +112,9 @@ class TestPhase1TokenReduction:
 
         # Should be much shorter than original 2,427 tokens (~9,708 chars)
         # Current condensed version is ~2,100 chars which is well under the original
-        assert len(instructions) < 3000, f"Instructions not condensed: {len(instructions)} chars"
+        assert (
+            len(instructions) < 3000
+        ), f"Instructions not condensed: {len(instructions)} chars"
 
         # Should contain skill references
         assert "/fan-trap-prevention" in instructions
@@ -120,33 +123,39 @@ class TestPhase1TokenReduction:
 
     def test_execute_sql_query_docstring_condensed(self):
         """Verify execute_sql_query docstring is condensed."""
-        docstring = _get_tool_docstring('execute_sql_query')
+        docstring = _get_tool_docstring("execute_sql_query")
         assert docstring is not None, "execute_sql_query has no docstring"
 
         # Original was ~12,804 chars, should be much smaller now
-        assert len(docstring) < 4000, f"execute_sql_query docstring not condensed: {len(docstring)} chars"
+        assert (
+            len(docstring) < 4000
+        ), f"execute_sql_query docstring not condensed: {len(docstring)} chars"
 
         # Should mention fan-trap or validation
         assert "fan-trap" in docstring.lower() or "validation" in docstring.lower()
 
     def test_generate_chart_docstring_condensed(self):
         """Verify generate_chart docstring is condensed."""
-        docstring = _get_tool_docstring('generate_chart')
+        docstring = _get_tool_docstring("generate_chart")
         assert docstring is not None, "generate_chart has no docstring"
 
         # Original was ~8,502 chars, should be much smaller now
-        assert len(docstring) < 3000, f"generate_chart docstring not condensed: {len(docstring)} chars"
+        assert (
+            len(docstring) < 3000
+        ), f"generate_chart docstring not condensed: {len(docstring)} chars"
 
         # Should mention chart-related content
         assert "chart" in docstring.lower()
 
     def test_discover_schema_docstring_condensed(self):
         """Verify discover_schema docstring is condensed."""
-        docstring = _get_tool_docstring('discover_schema')
+        docstring = _get_tool_docstring("discover_schema")
         assert docstring is not None, "discover_schema has no docstring"
 
         # Original was ~3,775 chars, should be much smaller now
-        assert len(docstring) < 3000, f"discover_schema docstring not condensed: {len(docstring)} chars"
+        assert (
+            len(docstring) < 3000
+        ), f"discover_schema docstring not condensed: {len(docstring)} chars"
 
     @pytest.mark.asyncio
     async def test_all_tools_still_registered(self):
@@ -167,7 +176,7 @@ class TestPhase1TokenReduction:
             "load_my_ontology",
             "sample_table_data",
             "execute_sql_query",
-            "generate_chart"
+            "generate_chart",
         ]
 
         for tool in expected_tools:
@@ -186,7 +195,6 @@ class TestPhase1TokenReduction:
         assert new_lines < 5000, f"main.py seems too large: {new_lines} lines"
 
 
-
 class TestFunctionalityPreserved:
     """Test that all functionality still works after changes."""
 
@@ -194,6 +202,7 @@ class TestFunctionalityPreserved:
         """Verify MCP server imports successfully."""
         try:
             from src.main import mcp
+
             assert mcp is not None
         except ImportError as e:
             pytest.fail(f"Failed to import MCP server: {e}")
@@ -202,6 +211,7 @@ class TestFunctionalityPreserved:
         """Verify DatabaseManager imports successfully."""
         try:
             from src.database_manager import DatabaseManager
+
             assert DatabaseManager is not None
         except ImportError as e:
             pytest.fail(f"Failed to import DatabaseManager: {e}")
@@ -210,6 +220,7 @@ class TestFunctionalityPreserved:
         """Verify OntologyGenerator imports successfully."""
         try:
             from src.ontology_generator import OntologyGenerator
+
             assert OntologyGenerator is not None
         except ImportError as e:
             pytest.fail(f"Failed to import OntologyGenerator: {e}")
@@ -224,7 +235,7 @@ class TestFunctionalityPreserved:
             "discover_schema",
             "generate_ontology",
             "execute_sql_query",
-            "generate_chart"
+            "generate_chart",
         ]
 
         # All should be async functions (accessed via the underlying .fn when needed)

--- a/tests/test_phase2_hierarchical.py
+++ b/tests/test_phase2_hierarchical.py
@@ -10,6 +10,7 @@ Verifies that:
 """
 
 import inspect
+
 import pytest
 
 import src.main as main_module
@@ -24,7 +25,7 @@ def _get_tool_fn(name):
     This helper normalizes access.
     """
     obj = getattr(main_module, name)
-    return getattr(obj, 'fn', obj)
+    return getattr(obj, "fn", obj)
 
 
 def _get_tool_docstring(name):
@@ -38,7 +39,7 @@ class TestPhase2LightweightMode:
 
     def test_discover_schema_has_lightweight_parameter(self):
         """Verify discover_schema has lightweight parameter."""
-        fn = _get_tool_fn('discover_schema')
+        fn = _get_tool_fn("discover_schema")
         sig = inspect.signature(fn)
         params = sig.parameters
 
@@ -57,7 +58,7 @@ class TestPhase2LightweightMode:
 
     def test_get_table_details_has_required_params(self):
         """Verify get_table_details has required parameters."""
-        fn = _get_tool_fn('get_table_details')
+        fn = _get_tool_fn("get_table_details")
         sig = inspect.signature(fn)
         params = sig.parameters
 
@@ -67,7 +68,7 @@ class TestPhase2LightweightMode:
 
     def test_discover_schema_docstring_mentions_lightweight(self):
         """Verify discover_schema docstring explains lightweight mode."""
-        docstring = _get_tool_docstring('discover_schema')
+        docstring = _get_tool_docstring("discover_schema")
         assert docstring is not None
 
         # Should explain lightweight mode
@@ -75,7 +76,7 @@ class TestPhase2LightweightMode:
 
     def test_get_table_details_docstring_complete(self):
         """Verify get_table_details has complete docstring."""
-        docstring = _get_tool_docstring('get_table_details')
+        docstring = _get_tool_docstring("get_table_details")
         assert docstring is not None
 
         # Should explain purpose
@@ -112,7 +113,7 @@ class TestPhase2FunctionalityPreserved:
 
     def test_discover_schema_backward_compatible(self):
         """Verify discover_schema defaults to lightweight=True."""
-        fn = _get_tool_fn('discover_schema')
+        fn = _get_tool_fn("discover_schema")
         sig = inspect.signature(fn)
         lightweight_param = sig.parameters["lightweight"]
 
@@ -139,7 +140,7 @@ class TestPhase2FunctionalityPreserved:
             "sample_table_data",
             "execute_sql_query",
             "generate_chart",
-            "cleanup_workspace"
+            "cleanup_workspace",
         ]
 
         for tool in expected_tools:
@@ -162,11 +163,19 @@ class TestPhase2FunctionalityPreserved:
     def test_imports_still_work(self):
         """Verify all imports still work after changes."""
         try:
-            from src.main import mcp, discover_schema, get_table_details
-            from src.database_manager import DatabaseManager, TableInfo, ColumnInfo
+            from src.database_manager import ColumnInfo, DatabaseManager, TableInfo
+            from src.main import discover_schema, get_table_details, mcp
 
-            assert all([mcp, discover_schema, get_table_details,
-                       DatabaseManager, TableInfo, ColumnInfo])
+            assert all(
+                [
+                    mcp,
+                    discover_schema,
+                    get_table_details,
+                    DatabaseManager,
+                    TableInfo,
+                    ColumnInfo,
+                ]
+            )
         except ImportError as e:
             pytest.fail(f"Import failed: {e}")
 
@@ -176,8 +185,8 @@ class TestPhase2HierarchicalWorkflow:
 
     def test_workflow_documentation_in_docstrings(self):
         """Verify hierarchical workflow is documented."""
-        analyze_doc = _get_tool_docstring('discover_schema')
-        details_doc = _get_tool_docstring('get_table_details')
+        analyze_doc = _get_tool_docstring("discover_schema")
+        details_doc = _get_tool_docstring("get_table_details")
 
         # discover_schema should mention lightweight mode
         assert "lightweight" in analyze_doc.lower()
@@ -195,7 +204,7 @@ class TestPhase2HierarchicalWorkflow:
             "relationships",
             "mode",
             "token_savings",
-            "note"
+            "note",
         ]
 
         # Optional key:
@@ -208,13 +217,7 @@ class TestPhase2HierarchicalWorkflow:
     def test_full_response_structure_unchanged(self):
         """Verify full mode response structure is backward compatible."""
         # Expected structure for lightweight=False (existing behavior):
-        expected_keys = [
-            "schema",
-            "table_count",
-            "tables",
-            "schema_file",
-            "next_steps"
-        ]
+        expected_keys = ["schema", "table_count", "tables", "schema_file", "next_steps"]
 
         # This documents backward compatibility
         assert all(isinstance(key, str) for key in expected_keys)
@@ -236,7 +239,7 @@ class TestPhase2EdgeCases:
 
     def test_get_table_details_without_schema(self):
         """Test get_table_details uses default schema."""
-        fn = _get_tool_fn('get_table_details')
+        fn = _get_tool_fn("get_table_details")
         sig = inspect.signature(fn)
         schema_param = sig.parameters["schema_name"]
 

--- a/tests/test_reachability.py
+++ b/tests/test_reachability.py
@@ -26,9 +26,36 @@ def _tbl(name, fks=None):
 def _build():
     tables = [
         _tbl("customers"),
-        _tbl("orders", [{"column": "customer_id", "referenced_table": "customers", "referenced_column": "id"}]),
-        _tbl("order_items", [{"column": "order_id", "referenced_table": "orders", "referenced_column": "id"}]),
-        _tbl("returns", [{"column": "customer_id", "referenced_table": "customers", "referenced_column": "id"}]),
+        _tbl(
+            "orders",
+            [
+                {
+                    "column": "customer_id",
+                    "referenced_table": "customers",
+                    "referenced_column": "id",
+                }
+            ],
+        ),
+        _tbl(
+            "order_items",
+            [
+                {
+                    "column": "order_id",
+                    "referenced_table": "orders",
+                    "referenced_column": "id",
+                }
+            ],
+        ),
+        _tbl(
+            "returns",
+            [
+                {
+                    "column": "customer_id",
+                    "referenced_table": "customers",
+                    "referenced_column": "id",
+                }
+            ],
+        ),
     ]
     r = GraphRetriever()
     r.build_graph(tables)
@@ -57,7 +84,11 @@ def test_reachable_from_dimension_is_empty():
 def test_measurable_from_walks_to_finer_grain():
     r = _build()
     # everything that fans out customers
-    assert set(r.measurable_from("customers")["tables"]) == {"orders", "order_items", "returns"}
+    assert set(r.measurable_from("customers")["tables"]) == {
+        "orders",
+        "order_items",
+        "returns",
+    }
 
 
 def test_measurable_from_interior_fact():
@@ -89,8 +120,14 @@ def test_unknown_table():
 def test_cycle_terminates():
     # Mutual FKs a <-> b must not loop forever.
     tables = [
-        _tbl("a", [{"column": "b_id", "referenced_table": "b", "referenced_column": "id"}]),
-        _tbl("b", [{"column": "a_id", "referenced_table": "a", "referenced_column": "id"}]),
+        _tbl(
+            "a",
+            [{"column": "b_id", "referenced_table": "b", "referenced_column": "id"}],
+        ),
+        _tbl(
+            "b",
+            [{"column": "a_id", "referenced_table": "a", "referenced_column": "id"}],
+        ),
     ]
     r = GraphRetriever()
     r.build_graph(tables)
@@ -100,7 +137,18 @@ def test_cycle_terminates():
 
 
 def test_self_reference_terminates():
-    tables = [_tbl("employee", [{"column": "manager_id", "referenced_table": "employee", "referenced_column": "id"}])]
+    tables = [
+        _tbl(
+            "employee",
+            [
+                {
+                    "column": "manager_id",
+                    "referenced_table": "employee",
+                    "referenced_column": "id",
+                }
+            ],
+        )
+    ]
     r = GraphRetriever()
     r.build_graph(tables)
     # A self-loop reaches nothing new beyond itself (anchor excluded from results).

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -27,7 +27,9 @@ class TestResources(unittest.TestCase):
         self.assertEqual(set(mcp.registered), set(resources._SKILLS))
         self.assertEqual(len(mcp.registered), 4)
 
-    def test_loader_reads_existing_skill(self, ):
+    def test_loader_reads_existing_skill(
+        self,
+    ):
         loader = resources._make_skill_loader("fan-trap-prevention.md", "title")
         self.assertEqual(loader.__doc__, "title")
         self.assertTrue(loader.__name__.endswith("_skill"))

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,16 +1,16 @@
 """Security tests for OrionBelt Analytics."""
 
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
+from src.database_manager import DatabaseManager
 from src.security import (
-    SQLInjectionValidator,
     IdentifierValidator,
     SecureCredentialManager,
     SecurityLevel,
-    audit_log_security_event
+    SQLInjectionValidator,
+    audit_log_security_event,
 )
-from src.database_manager import DatabaseManager
 
 
 class TestSQLInjectionValidator(unittest.TestCase):
@@ -25,15 +25,15 @@ class TestSQLInjectionValidator(unittest.TestCase):
             "SELECT * FROM users",
             "SELECT id, name FROM users WHERE active = true",
             "SELECT COUNT(*) FROM orders ORDER BY created_at LIMIT 10",
-            ("SELECT u.name, o.total FROM users u JOIN orders o ON "
-             "u.id = o.user_id"),
+            (
+                "SELECT u.name, o.total FROM users u JOIN orders o ON "
+                "u.id = o.user_id"
+            ),
         ]
 
         for query in safe_queries:
             result = self.validator.validate_query(query)
-            self.assertTrue(
-                result["is_safe"], f"Safe query marked as unsafe: {query}"
-            )
+            self.assertTrue(result["is_safe"], f"Safe query marked as unsafe: {query}")
             self.assertEqual(result["risk_level"], "low")
 
     def test_sql_injection_attempts(self) -> None:
@@ -45,15 +45,12 @@ class TestSQLInjectionValidator(unittest.TestCase):
             "SELECT * FROM users WHERE name = 'admin'--",
             "SELECT * FROM users; DELETE FROM users WHERE 1=1",
             "SELECT /*comment*/ * FROM users",
-            ("SELECT * FROM users WHERE id = 1; INSERT INTO logs "
-             "VALUES ('hacked')"),
+            ("SELECT * FROM users WHERE id = 1; INSERT INTO logs " "VALUES ('hacked')"),
         ]
 
         for query in malicious_queries:
             result = self.validator.validate_query(query)
-            self.assertFalse(
-                result["is_safe"], f"Malicious query not blocked: {query}"
-            )
+            self.assertFalse(result["is_safe"], f"Malicious query not blocked: {query}")
             self.assertIn(result["risk_level"], ["medium", "high", "critical"])
             self.assertTrue(len(result["issues"]) > 0)
 
@@ -70,9 +67,7 @@ class TestSQLInjectionValidator(unittest.TestCase):
             self.assertFalse(
                 result["is_safe"], f"Multiple statements not blocked: {query}"
             )
-            self.assertIn(
-                "Multiple SQL statements not allowed", result["issues"]
-            )
+            self.assertIn("Multiple SQL statements not allowed", result["issues"])
 
     def test_empty_queries(self) -> None:
         """Test handling of empty or whitespace-only queries."""
@@ -111,13 +106,13 @@ class TestIdentifierValidator(unittest.TestCase):
             "_private_table",
             "table123",
             "a",
-            "TABLE_WITH_UNDERSCORES"
+            "TABLE_WITH_UNDERSCORES",
         ]
 
         for identifier in valid_identifiers:
             self.assertTrue(
                 IdentifierValidator.validate_identifier(identifier),
-                f"Valid identifier rejected: {identifier}"
+                f"Valid identifier rejected: {identifier}",
             )
 
     def test_invalid_identifiers(self) -> None:
@@ -137,7 +132,7 @@ class TestIdentifierValidator(unittest.TestCase):
         for identifier in invalid_identifiers:
             self.assertFalse(
                 IdentifierValidator.validate_identifier(identifier),
-                f"Invalid identifier accepted: {identifier}"
+                f"Invalid identifier accepted: {identifier}",
             )
 
     def test_qualified_identifiers(self) -> None:
@@ -146,7 +141,7 @@ class TestIdentifierValidator(unittest.TestCase):
             "schema.table",
             "database.schema.table",
             "public.users",
-            "_schema._table"
+            "_schema._table",
         ]
 
         invalid_qualified = [
@@ -159,13 +154,13 @@ class TestIdentifierValidator(unittest.TestCase):
         for identifier in valid_qualified:
             self.assertTrue(
                 IdentifierValidator.validate_qualified_identifier(identifier),
-                f"Valid qualified identifier rejected: {identifier}"
+                f"Valid qualified identifier rejected: {identifier}",
             )
 
         for identifier in invalid_qualified:
             self.assertFalse(
                 IdentifierValidator.validate_qualified_identifier(identifier),
-                f"Invalid qualified identifier accepted: {identifier}"
+                f"Invalid qualified identifier accepted: {identifier}",
             )
 
     def test_identifier_sanitization(self) -> None:
@@ -197,7 +192,7 @@ class TestSecureCredentialManager(unittest.TestCase):
             "port": 5432,
             "database": "testdb",
             "username": "testuser",
-            "password": "secret123"
+            "password": "secret123",
         }
 
         # Encrypt credentials
@@ -216,7 +211,7 @@ class TestSecureCredentialManager(unittest.TestCase):
             "username": "testuser",
             "password": "secret123",
             "api_key": "key123",
-            "token": "token456"
+            "token": "token456",
         }
 
         sanitized = self.manager._sanitize_credentials(test_credentials)
@@ -233,8 +228,9 @@ class TestSecureCredentialManager(unittest.TestCase):
     def test_encryption_without_master_password(self) -> None:
         """Test that encryption fails without master password."""
         # Patch load_dotenv and os.getenv to prevent loading from .env file
-        with patch('src.security.load_dotenv'), \
-             patch('src.security.os.getenv', return_value=None):
+        with patch("src.security.load_dotenv"), patch(
+            "src.security.os.getenv", return_value=None
+        ):
             manager = SecureCredentialManager()
 
             with self.assertRaises(ValueError):
@@ -252,10 +248,8 @@ class TestDatabaseManagerSecurity(unittest.TestCase):
     def setUp(self) -> None:
         self.db_manager = DatabaseManager()
 
-    @patch('src.drivers.postgresql.create_engine')
-    def test_secure_postgresql_connection(
-        self, mock_create_engine: MagicMock
-    ) -> None:
+    @patch("src.drivers.postgresql.create_engine")
+    def test_secure_postgresql_connection(self, mock_create_engine: MagicMock) -> None:
         """Test that PostgreSQL connections use secure practices."""
         mock_engine = MagicMock()
         mock_create_engine.return_value = mock_engine
@@ -269,7 +263,7 @@ class TestDatabaseManagerSecurity(unittest.TestCase):
             port=5432,
             database="testdb",
             username="testuser",
-            password="testpass"
+            password="testpass",
         )
 
         self.assertTrue(result)
@@ -292,14 +286,10 @@ class TestDatabaseManagerSecurity(unittest.TestCase):
 
         # Test with invalid schema name (contains semicolon)
         with self.assertRaises(ValueError):
-            self.db_manager.sample_table_data(
-                "valid_table", "invalid;schema", limit=10
-            )
+            self.db_manager.sample_table_data("valid_table", "invalid;schema", limit=10)
 
-    @patch('src.database_manager.sql_validator')
-    def test_sql_validation_integration(
-        self, mock_validator: MagicMock
-    ) -> None:
+    @patch("src.database_manager.sql_validator")
+    def test_sql_validation_integration(self, mock_validator: MagicMock) -> None:
         """Test that SQL validation is integrated into query execution."""
         # Set up engine mock to pass the connection check
         self.db_manager.engine = MagicMock()
@@ -308,7 +298,7 @@ class TestDatabaseManagerSecurity(unittest.TestCase):
         mock_validator.validate_query.return_value = {
             "is_safe": False,
             "issues": ["Potential SQL injection"],
-            "risk_level": "critical"
+            "risk_level": "critical",
         }
 
         result = self.db_manager.validate_sql_syntax(
@@ -323,13 +313,13 @@ class TestDatabaseManagerSecurity(unittest.TestCase):
 class TestSecurityAuditing(unittest.TestCase):
     """Test security auditing functionality."""
 
-    @patch('src.security.logger')
+    @patch("src.security.logger")
     def test_security_event_logging(self, mock_logger: MagicMock) -> None:
         """Test that security events are properly logged."""
         audit_log_security_event(
             "test_security_event",
             {"user": "testuser", "action": "attempted_injection"},
-            SecurityLevel.HIGH
+            SecurityLevel.HIGH,
         )
 
         # Verify that warning was logged
@@ -340,19 +330,13 @@ class TestSecurityAuditing(unittest.TestCase):
         self.assertIn("test_security_event", log_message)
         self.assertIn("high", log_message)
 
-    @patch('src.security.logger')
-    def test_sensitive_data_redaction_in_audit(
-        self, mock_logger: MagicMock
-    ) -> None:
+    @patch("src.security.logger")
+    def test_sensitive_data_redaction_in_audit(self, mock_logger: MagicMock) -> None:
         """Test that sensitive data is redacted in audit logs."""
         audit_log_security_event(
             "credential_test",
-            {
-                "username": "testuser",
-                "password": "secret123",
-                "host": "localhost"
-            },
-            SecurityLevel.MEDIUM
+            {"username": "testuser", "password": "secret123", "host": "localhost"},
+            SecurityLevel.MEDIUM,
         )
 
         log_message = mock_logger.warning.call_args[0][0]
@@ -366,5 +350,5 @@ class TestSecurityAuditing(unittest.TestCase):
         self.assertIn("localhost", log_message)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,14 +1,15 @@
 """Comprehensive tests for the OrionBelt Analytics MCP server."""
 
 import json
-import pytest
 import unittest
-from unittest.mock import patch, MagicMock, Mock, AsyncMock
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
 
 import src.main as main_module
-from src.database_manager import TableInfo, ColumnInfo
-from src.ontology_generator import OntologyGenerator
 from src.config import ConfigManager
+from src.database_manager import ColumnInfo, TableInfo
+from src.ontology_generator import OntologyGenerator
 
 
 def create_mock_context(session_id: str = "test-session-123"):
@@ -40,7 +41,7 @@ class TestMCPTools(unittest.TestCase):
                     is_nullable=False,
                     is_primary_key=True,
                     is_foreign_key=False,
-                    comment="User unique identifier"
+                    comment="User unique identifier",
                 ),
                 ColumnInfo(
                     name="name",
@@ -48,7 +49,7 @@ class TestMCPTools(unittest.TestCase):
                     is_nullable=False,
                     is_primary_key=False,
                     is_foreign_key=False,
-                    comment="User full name"
+                    comment="User full name",
                 ),
                 ColumnInfo(
                     name="email",
@@ -56,13 +57,13 @@ class TestMCPTools(unittest.TestCase):
                     is_nullable=True,
                     is_primary_key=False,
                     is_foreign_key=False,
-                    comment="User email address"
-                )
+                    comment="User email address",
+                ),
             ],
             primary_keys=["id"],
             foreign_keys=[],
             comment="User accounts table",
-            row_count=150
+            row_count=150,
         )
 
         # Sample table info for orders table with foreign key
@@ -75,7 +76,7 @@ class TestMCPTools(unittest.TestCase):
                     data_type="INTEGER",
                     is_nullable=False,
                     is_primary_key=True,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
                     name="user_id",
@@ -84,25 +85,25 @@ class TestMCPTools(unittest.TestCase):
                     is_primary_key=False,
                     is_foreign_key=True,
                     foreign_key_table="users",
-                    foreign_key_column="id"
+                    foreign_key_column="id",
                 ),
                 ColumnInfo(
                     name="total_amount",
                     data_type="DECIMAL(10,2)",
                     is_nullable=False,
                     is_primary_key=False,
-                    is_foreign_key=False
-                )
+                    is_foreign_key=False,
+                ),
             ],
             primary_keys=["id"],
             foreign_keys=[
                 {
                     "column": "user_id",
                     "referenced_table": "users",
-                    "referenced_column": "id"
+                    "referenced_column": "id",
                 }
             ],
-            row_count=500
+            row_count=500,
         )
 
         # Mock context
@@ -126,7 +127,7 @@ class TestMCPToolsAsync:
                     is_nullable=False,
                     is_primary_key=True,
                     is_foreign_key=False,
-                    comment="User unique identifier"
+                    comment="User unique identifier",
                 ),
                 ColumnInfo(
                     name="name",
@@ -134,7 +135,7 @@ class TestMCPToolsAsync:
                     is_nullable=False,
                     is_primary_key=False,
                     is_foreign_key=False,
-                    comment="User full name"
+                    comment="User full name",
                 ),
                 ColumnInfo(
                     name="email",
@@ -142,13 +143,13 @@ class TestMCPToolsAsync:
                     is_nullable=True,
                     is_primary_key=False,
                     is_foreign_key=False,
-                    comment="User email address"
-                )
+                    comment="User email address",
+                ),
             ],
             primary_keys=["id"],
             foreign_keys=[],
             comment="User accounts table",
-            row_count=150
+            row_count=150,
         )
 
     @pytest.fixture
@@ -163,7 +164,7 @@ class TestMCPToolsAsync:
                     data_type="INTEGER",
                     is_nullable=False,
                     is_primary_key=True,
-                    is_foreign_key=False
+                    is_foreign_key=False,
                 ),
                 ColumnInfo(
                     name="user_id",
@@ -172,25 +173,25 @@ class TestMCPToolsAsync:
                     is_primary_key=False,
                     is_foreign_key=True,
                     foreign_key_table="users",
-                    foreign_key_column="id"
+                    foreign_key_column="id",
                 ),
                 ColumnInfo(
                     name="total_amount",
                     data_type="DECIMAL(10,2)",
                     is_nullable=False,
                     is_primary_key=False,
-                    is_foreign_key=False
-                )
+                    is_foreign_key=False,
+                ),
             ],
             primary_keys=["id"],
             foreign_keys=[
                 {
                     "column": "user_id",
                     "referenced_table": "users",
-                    "referenced_column": "id"
+                    "referenced_column": "id",
                 }
             ],
-            row_count=500
+            row_count=500,
         )
 
     @pytest.fixture
@@ -220,27 +221,29 @@ class TestMCPToolsAsync:
         session.get_last_analyzed_schema = Mock(return_value=None)
         return session
 
-    async def test_connect_database_postgresql_success(self, mock_ctx, mock_session_data):
+    async def test_connect_database_postgresql_success(
+        self, mock_ctx, mock_session_data
+    ):
         """Test successful PostgreSQL connection with session isolation."""
         mock_db_manager = Mock()
         mock_db_manager.connect_postgresql.return_value = True
         mock_session_data.db_manager = mock_db_manager
 
-        with patch('src.main.get_session_data', return_value=mock_session_data), \
-             patch('src.main.get_session_db_manager', return_value=mock_db_manager), \
-             patch('src.main._get_connection_fingerprint', return_value="test1234abcd"), \
-             patch.dict('os.environ', {
-                 'POSTGRES_HOST': 'localhost',
-                 'POSTGRES_PORT': '5432',
-                 'POSTGRES_DATABASE': 'testdb',
-                 'POSTGRES_USERNAME': 'testuser',
-                 'POSTGRES_PASSWORD': 'testpass'
-             }):
-
-            result = await main_module.connect_database(
-                mock_ctx,
-                db_type="postgresql"
-            )
+        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
+            "src.main.get_session_db_manager", return_value=mock_db_manager
+        ), patch(
+            "src.main._get_connection_fingerprint", return_value="test1234abcd"
+        ), patch.dict(
+            "os.environ",
+            {
+                "POSTGRES_HOST": "localhost",
+                "POSTGRES_PORT": "5432",
+                "POSTGRES_DATABASE": "testdb",
+                "POSTGRES_USERNAME": "testuser",
+                "POSTGRES_PASSWORD": "testpass",
+            },
+        ):
+            result = await main_module.connect_database(mock_ctx, db_type="postgresql")
 
         assert "Successfully connected" in result
         assert "postgresql" in result
@@ -250,57 +253,60 @@ class TestMCPToolsAsync:
             port=5432,
             database="testdb",
             username="testuser",
-            password="testpass"
+            password="testpass",
         )
 
-    async def test_connect_database_postgresql_failure(self, mock_ctx, mock_session_data):
+    async def test_connect_database_postgresql_failure(
+        self, mock_ctx, mock_session_data
+    ):
         """Test PostgreSQL connection failure with proper error handling."""
         mock_db_manager = Mock()
         mock_db_manager.connect_postgresql.return_value = False
         mock_session_data.db_manager = mock_db_manager
 
-        with patch('src.main.get_session_data', return_value=mock_session_data), \
-             patch('src.main.get_session_db_manager', return_value=mock_db_manager), \
-             patch.dict('os.environ', {
-                 'POSTGRES_HOST': 'localhost',
-                 'POSTGRES_PORT': '5432',
-                 'POSTGRES_DATABASE': 'testdb',
-                 'POSTGRES_USERNAME': 'testuser',
-                 'POSTGRES_PASSWORD': 'wrongpass'
-             }):
-
-            result = await main_module.connect_database(
-                mock_ctx,
-                db_type="postgresql"
-            )
+        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
+            "src.main.get_session_db_manager", return_value=mock_db_manager
+        ), patch.dict(
+            "os.environ",
+            {
+                "POSTGRES_HOST": "localhost",
+                "POSTGRES_PORT": "5432",
+                "POSTGRES_DATABASE": "testdb",
+                "POSTGRES_USERNAME": "testuser",
+                "POSTGRES_PASSWORD": "wrongpass",
+            },
+        ):
+            result = await main_module.connect_database(mock_ctx, db_type="postgresql")
 
         # Error responses are dicts from .to_response()
         error_data = json.loads(result) if isinstance(result, str) else result
         assert error_data["error_type"] == "connection_error"
         assert "Failed to connect" in error_data["error"]
 
-    async def test_connect_database_snowflake_success(self, mock_ctx, mock_session_data):
+    async def test_connect_database_snowflake_success(
+        self, mock_ctx, mock_session_data
+    ):
         """Test successful Snowflake connection."""
         mock_db_manager = Mock()
         mock_db_manager.connect_snowflake.return_value = True
         mock_session_data.db_manager = mock_db_manager
 
-        with patch('src.main.get_session_data', return_value=mock_session_data), \
-             patch('src.main.get_session_db_manager', return_value=mock_db_manager), \
-             patch('src.main._get_connection_fingerprint', return_value="test5678efgh"), \
-             patch.dict('os.environ', {
-                 'SNOWFLAKE_ACCOUNT': 'test-account',
-                 'SNOWFLAKE_USERNAME': 'testuser',
-                 'SNOWFLAKE_PASSWORD': 'testpass',
-                 'SNOWFLAKE_WAREHOUSE': 'COMPUTE_WH',
-                 'SNOWFLAKE_DATABASE': 'TESTDB',
-                 'SNOWFLAKE_SCHEMA': 'PUBLIC'
-             }):
-
-            result = await main_module.connect_database(
-                mock_ctx,
-                db_type="snowflake"
-            )
+        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
+            "src.main.get_session_db_manager", return_value=mock_db_manager
+        ), patch(
+            "src.main._get_connection_fingerprint", return_value="test5678efgh"
+        ), patch.dict(
+            "os.environ",
+            {
+                "SNOWFLAKE_ACCOUNT": "test-account",
+                "SNOWFLAKE_USERNAME": "testuser",
+                "SNOWFLAKE_PASSWORD": "testpass",
+                "SNOWFLAKE_WAREHOUSE": "COMPUTE_WH",
+                "SNOWFLAKE_DATABASE": "TESTDB",
+                "SNOWFLAKE_SCHEMA": "PUBLIC",
+            },
+        ):
+            result = await main_module.connect_database(mock_ctx, db_type="snowflake")
 
         assert "Successfully connected" in result
         assert "snowflake" in result
@@ -314,27 +320,28 @@ class TestMCPToolsAsync:
         assert "Invalid database type" in error_data["error"]
         assert "oracle" in error_data["error"]
 
-    async def test_connect_database_missing_parameters(self, mock_ctx, mock_session_data):
+    async def test_connect_database_missing_parameters(
+        self, mock_ctx, mock_session_data
+    ):
         """Test connection with missing required environment variables."""
         # Use os.environ.get patching to simulate missing env vars
-        with patch('src.main.get_session_data', return_value=mock_session_data), \
-             patch('os.getenv') as mock_getenv:
+        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
+            "os.getenv"
+        ) as mock_getenv:
             # Only return value for POSTGRES_HOST, return None for others
             def getenv_side_effect(key, default=None):
                 env_map = {
-                    'POSTGRES_HOST': 'localhost',
-                    'POSTGRES_PORT': None,
-                    'POSTGRES_DATABASE': None,
-                    'POSTGRES_USERNAME': None,
-                    'POSTGRES_PASSWORD': None,
+                    "POSTGRES_HOST": "localhost",
+                    "POSTGRES_PORT": None,
+                    "POSTGRES_DATABASE": None,
+                    "POSTGRES_USERNAME": None,
+                    "POSTGRES_PASSWORD": None,
                 }
                 return env_map.get(key, default)
+
             mock_getenv.side_effect = getenv_side_effect
 
-            result = await main_module.connect_database(
-                mock_ctx,
-                db_type="postgresql"
-            )
+            result = await main_module.connect_database(mock_ctx, db_type="postgresql")
 
         error_data = json.loads(result) if isinstance(result, str) else result
         assert error_data["error_type"] == "validation_error"
@@ -346,22 +353,21 @@ class TestMCPToolsAsync:
         mock_db_manager.connect_postgresql.side_effect = Exception("Connection error")
         mock_session_data.db_manager = mock_db_manager
 
-        with patch('src.main.get_session_data', return_value=mock_session_data), \
-             patch('src.main.get_session_db_manager', return_value=mock_db_manager), \
-             patch.dict('os.environ', {
-                 'POSTGRES_HOST': 'localhost',
-                 'POSTGRES_PORT': '5432',
-                 'POSTGRES_DATABASE': 'testdb',
-                 'POSTGRES_USERNAME': 'testuser',
-                 'POSTGRES_PASSWORD': 'testpass'
-             }):
-
+        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
+            "src.main.get_session_db_manager", return_value=mock_db_manager
+        ), patch.dict(
+            "os.environ",
+            {
+                "POSTGRES_HOST": "localhost",
+                "POSTGRES_PORT": "5432",
+                "POSTGRES_DATABASE": "testdb",
+                "POSTGRES_USERNAME": "testuser",
+                "POSTGRES_PASSWORD": "testpass",
+            },
+        ):
             # The function raises exception (no internal error handling)
             with pytest.raises(Exception, match="Connection error"):
-                await main_module.connect_database(
-                    mock_ctx,
-                    db_type="postgresql"
-                )
+                await main_module.connect_database(mock_ctx, db_type="postgresql")
 
     async def test_list_schemas_success(self, mock_ctx, mock_session_data):
         """Test successful schema listing with session isolation."""
@@ -369,9 +375,9 @@ class TestMCPToolsAsync:
         mock_db_manager.get_schemas.return_value = ["public", "private", "analytics"]
         mock_session_data.db_manager = mock_db_manager
 
-        with patch('src.main.get_session_data', return_value=mock_session_data), \
-             patch('src.main.get_session_db_manager', return_value=mock_db_manager):
-
+        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
+            "src.main.get_session_db_manager", return_value=mock_db_manager
+        ):
             result = await main_module.list_schemas(mock_ctx)
 
         assert isinstance(result, list)
@@ -386,31 +392,37 @@ class TestMCPToolsAsync:
         mock_db_manager.get_schemas.side_effect = RuntimeError("No database connection")
         mock_session_data.db_manager = mock_db_manager
 
-        with patch('src.main.get_session_data', return_value=mock_session_data), \
-             patch('src.main.get_session_db_manager', return_value=mock_db_manager):
-
+        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
+            "src.main.get_session_db_manager", return_value=mock_db_manager
+        ):
             # The function raises exception (no internal error handling)
             with pytest.raises(RuntimeError, match="No database connection"):
                 await main_module.list_schemas(mock_ctx)
 
-    async def test_discover_schema_success(self, mock_ctx, mock_session_data, sample_users_table, sample_orders_table):
+    async def test_discover_schema_success(
+        self, mock_ctx, mock_session_data, sample_users_table, sample_orders_table
+    ):
         """Test successful schema analysis with session isolation."""
         mock_db_manager = Mock()
         mock_db_manager.get_tables.return_value = ["users", "orders"]
         mock_db_manager.analyze_table.side_effect = [
             sample_users_table,
-            sample_orders_table
+            sample_orders_table,
         ]
         mock_session_data.db_manager = mock_db_manager
 
-        with patch('src.main.get_session_data', return_value=mock_session_data), \
-             patch('src.main.get_session_db_manager', return_value=mock_db_manager), \
-             patch('src.server_state.get_session_id', return_value="test-session"), \
-             patch('src.main.get_session_safe_filename', return_value="test_schema.json"), \
-             patch('builtins.open', MagicMock()), \
-             patch('json.dump'):
-
-            result = await main_module.discover_schema(mock_ctx, "public", lightweight=False)
+        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
+            "src.main.get_session_db_manager", return_value=mock_db_manager
+        ), patch("src.server_state.get_session_id", return_value="test-session"), patch(
+            "src.main.get_session_safe_filename", return_value="test_schema.json"
+        ), patch(
+            "builtins.open", MagicMock()
+        ), patch(
+            "json.dump"
+        ):
+            result = await main_module.discover_schema(
+                mock_ctx, "public", lightweight=False
+            )
 
         assert isinstance(result, dict)
         assert result["schema"] == "public"
@@ -433,14 +445,16 @@ class TestMCPToolsAsync:
         mock_db_manager.get_tables.side_effect = RuntimeError("No database connection")
         mock_session_data.db_manager = mock_db_manager
 
-        with patch('src.main.get_session_data', return_value=mock_session_data), \
-             patch('src.main.get_session_db_manager', return_value=mock_db_manager):
-
+        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
+            "src.main.get_session_db_manager", return_value=mock_db_manager
+        ):
             # The function raises exception (no internal error handling)
             with pytest.raises(RuntimeError, match="No database connection"):
                 await main_module.discover_schema(mock_ctx, "public")
 
-    async def test_generate_ontology_success(self, mock_ctx, mock_session_data, sample_users_table):
+    async def test_generate_ontology_success(
+        self, mock_ctx, mock_session_data, sample_users_table
+    ):
         """Test successful ontology generation with session isolation."""
         mock_db_manager = Mock()
         mock_db_manager.get_tables.return_value = ["users"]
@@ -450,24 +464,33 @@ class TestMCPToolsAsync:
 
         # Mock the ontology generator
         mock_generator = Mock()
-        mock_generator.generate_from_schema.return_value = "@prefix ns: <http://example.com/ontology/> ."
-        mock_generator.serialize_ontology.return_value = "@prefix ns: <http://example.com/ontology/> ."
+        mock_generator.generate_from_schema.return_value = (
+            "@prefix ns: <http://example.com/ontology/> ."
+        )
+        mock_generator.serialize_ontology.return_value = (
+            "@prefix ns: <http://example.com/ontology/> ."
+        )
 
-        with patch('src.main.get_session_data', return_value=mock_session_data), \
-             patch('src.main.get_session_db_manager', return_value=mock_db_manager), \
-             patch('src.main.get_session_safe_filename', return_value="test_ontology.ttl"), \
-             patch('src.server_state.OntologyGenerator', return_value=mock_generator), \
-             patch('builtins.open', MagicMock()):
-
+        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
+            "src.main.get_session_db_manager", return_value=mock_db_manager
+        ), patch(
+            "src.main.get_session_safe_filename", return_value="test_ontology.ttl"
+        ), patch(
+            "src.server_state.OntologyGenerator", return_value=mock_generator
+        ), patch(
+            "builtins.open", MagicMock()
+        ):
             result = await main_module.generate_ontology(
-                mock_ctx,
-                schema_name="public",
-                base_uri="http://example.com/ontology/"
+                mock_ctx, schema_name="public", base_uri="http://example.com/ontology/"
             )
 
         assert isinstance(result, str)
         # Result is now a minimal graph summary or Oxigraph persisted summary
-        assert "Minimal Graph Summary" in result or "Ontology generated" in result or "triples" in result.lower()
+        assert (
+            "Minimal Graph Summary" in result
+            or "Ontology generated" in result
+            or "triples" in result.lower()
+        )
 
     async def test_generate_ontology_no_tables(self, mock_ctx, mock_session_data):
         """Test ontology generation with no tables."""
@@ -475,13 +498,10 @@ class TestMCPToolsAsync:
         mock_db_manager.get_tables.return_value = []
         mock_session_data.db_manager = mock_db_manager
 
-        with patch('src.main.get_session_data', return_value=mock_session_data), \
-             patch('src.main.get_session_db_manager', return_value=mock_db_manager):
-
-            result = await main_module.generate_ontology(
-                mock_ctx,
-                schema_name="public"
-            )
+        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
+            "src.main.get_session_db_manager", return_value=mock_db_manager
+        ):
+            result = await main_module.generate_ontology(mock_ctx, schema_name="public")
 
         # Error responses are dicts from .to_response()
         error_data = json.loads(result) if isinstance(result, str) else result
@@ -493,15 +513,17 @@ class TestMCPToolsAsync:
         mock_db_manager = Mock()
         sample_data = [
             {"id": 1, "name": "John Doe", "email": "john@example.com"},
-            {"id": 2, "name": "Jane Smith", "email": "jane@example.com"}
+            {"id": 2, "name": "Jane Smith", "email": "jane@example.com"},
         ]
         mock_db_manager.sample_table_data.return_value = sample_data
         mock_session_data.db_manager = mock_db_manager
 
-        with patch('src.main.get_session_data', return_value=mock_session_data), \
-             patch('src.main.get_session_db_manager', return_value=mock_db_manager):
-
-            result = await main_module.sample_table_data(mock_ctx, "users", "public", 10)
+        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
+            "src.main.get_session_db_manager", return_value=mock_db_manager
+        ):
+            result = await main_module.sample_table_data(
+                mock_ctx, "users", "public", 10
+            )
 
         assert isinstance(result, list)
         assert len(result) == 2
@@ -511,9 +533,11 @@ class TestMCPToolsAsync:
         # Verify the call was made with correct parameters
         mock_db_manager.sample_table_data.assert_called_once_with("users", "public", 10)
 
-    async def test_sample_table_data_invalid_table_name(self, mock_ctx, mock_session_data):
+    async def test_sample_table_data_invalid_table_name(
+        self, mock_ctx, mock_session_data
+    ):
         """Test table data sampling with invalid table name returns error."""
-        with patch('src.main.get_session_data', return_value=mock_session_data):
+        with patch("src.main.get_session_data", return_value=mock_session_data):
             # Empty table name returns error list
             result = await main_module.sample_table_data(mock_ctx, "", "public", 10)
 
@@ -525,15 +549,19 @@ class TestMCPToolsAsync:
     async def test_sample_table_data_database_error(self, mock_ctx, mock_session_data):
         """Test table data sampling with database error raises exception."""
         mock_db_manager = Mock()
-        mock_db_manager.sample_table_data.side_effect = ValueError("Invalid table name format")
+        mock_db_manager.sample_table_data.side_effect = ValueError(
+            "Invalid table name format"
+        )
         mock_session_data.db_manager = mock_db_manager
 
-        with patch('src.main.get_session_data', return_value=mock_session_data), \
-             patch('src.main.get_session_db_manager', return_value=mock_db_manager):
-
+        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
+            "src.main.get_session_db_manager", return_value=mock_db_manager
+        ):
             # The function raises exception (no internal error handling)
             with pytest.raises(ValueError, match="Invalid table name format"):
-                await main_module.sample_table_data(mock_ctx, "invalid-table", "public", 10)
+                await main_module.sample_table_data(
+                    mock_ctx, "invalid-table", "public", 10
+                )
 
 
 class TestOntologyGenerator(unittest.TestCase):
@@ -553,7 +581,7 @@ class TestOntologyGenerator(unittest.TestCase):
                     is_nullable=False,
                     is_primary_key=True,
                     is_foreign_key=False,
-                    comment="Primary key"
+                    comment="Primary key",
                 ),
                 ColumnInfo(
                     name="name",
@@ -561,7 +589,7 @@ class TestOntologyGenerator(unittest.TestCase):
                     is_nullable=False,
                     is_primary_key=False,
                     is_foreign_key=False,
-                    comment="Entity name"
+                    comment="Entity name",
                 ),
                 ColumnInfo(
                     name="created_at",
@@ -569,13 +597,13 @@ class TestOntologyGenerator(unittest.TestCase):
                     is_nullable=True,
                     is_primary_key=False,
                     is_foreign_key=False,
-                    comment="Creation timestamp"
-                )
+                    comment="Creation timestamp",
+                ),
             ],
             primary_keys=["id"],
             foreign_keys=[],
             comment="Test table for ontology generation",
-            row_count=10
+            row_count=10,
         )
 
     def test_generate_ontology_structure(self):
@@ -637,11 +665,13 @@ class TestOntologyGenerator(unittest.TestCase):
         sample_data = {
             "test_table": [
                 {"id": 1, "name": "Test Item 1", "created_at": "2023-01-01T00:00:00"},
-                {"id": 2, "name": "Test Item 2", "created_at": "2023-01-02T00:00:00"}
+                {"id": 2, "name": "Test Item 2", "created_at": "2023-01-02T00:00:00"},
             ]
         }
 
-        enrichment_data = self.generator.get_enrichment_data([self.sample_table], sample_data)
+        enrichment_data = self.generator.get_enrichment_data(
+            [self.sample_table], sample_data
+        )
 
         self.assertIn("schema_data", enrichment_data)
         self.assertIn("instructions", enrichment_data)
@@ -666,7 +696,7 @@ class TestOntologyGenerator(unittest.TestCase):
                 {
                     "original_name": "test_table",
                     "suggested_name": "TestEntity",
-                    "description": "A test entity for demonstration purposes"
+                    "description": "A test entity for demonstration purposes",
                 }
             ],
             "properties": [
@@ -674,10 +704,10 @@ class TestOntologyGenerator(unittest.TestCase):
                     "table_name": "test_table",
                     "original_name": "name",
                     "suggested_name": "entityName",
-                    "description": "The name of the test entity"
+                    "description": "The name of the test entity",
                 }
             ],
-            "relationships": []
+            "relationships": [],
         }
 
         # Apply enrichment
@@ -698,28 +728,31 @@ class TestConfigManager(unittest.TestCase):
 
     def test_validate_db_config_postgresql(self):
         """Test PostgreSQL configuration validation."""
-        with patch.dict('os.environ', {
-            'POSTGRES_HOST': 'localhost',
-            'POSTGRES_PORT': '5432',
-            'POSTGRES_DATABASE': 'testdb',
-            'POSTGRES_USERNAME': 'testuser',
-            'POSTGRES_PASSWORD': 'testpass'
-        }):
-            validation = self.config_manager.validate_db_config('postgresql')
-            self.assertTrue(validation['valid'])
-            self.assertEqual(len(validation['missing_params']), 0)
+        with patch.dict(
+            "os.environ",
+            {
+                "POSTGRES_HOST": "localhost",
+                "POSTGRES_PORT": "5432",
+                "POSTGRES_DATABASE": "testdb",
+                "POSTGRES_USERNAME": "testuser",
+                "POSTGRES_PASSWORD": "testpass",
+            },
+        ):
+            validation = self.config_manager.validate_db_config("postgresql")
+            self.assertTrue(validation["valid"])
+            self.assertEqual(len(validation["missing_params"]), 0)
 
     def test_validate_db_config_missing_params(self):
         """Test configuration validation with missing parameters."""
-        with patch.dict('os.environ', {}, clear=True):
-            validation = self.config_manager.validate_db_config('postgresql')
-            self.assertFalse(validation['valid'])
-            self.assertGreater(len(validation['missing_params']), 0)
+        with patch.dict("os.environ", {}, clear=True):
+            validation = self.config_manager.validate_db_config("postgresql")
+            self.assertFalse(validation["valid"])
+            self.assertGreater(len(validation["missing_params"]), 0)
 
     def test_validate_db_config_invalid_type(self):
         """Test configuration validation with invalid database type."""
         with self.assertRaises(ValueError):
-            self.config_manager.validate_db_config('invalid_db_type')
+            self.config_manager.validate_db_config("invalid_db_type")
 
 
 class TestUtilityFunctions(unittest.TestCase):
@@ -730,36 +763,33 @@ class TestUtilityFunctions(unittest.TestCase):
         from src.utils import sanitize_for_logging
 
         sensitive_data = {
-            'host': 'localhost',
-            'port': 5432,
-            'password': 'secret123',
-            'api_key': 'sk-1234567890',
-            'config': {
-                'username': 'user',
-                'secret': 'hidden'
-            }
+            "host": "localhost",
+            "port": 5432,
+            "password": "secret123",
+            "api_key": "sk-1234567890",
+            "config": {"username": "user", "secret": "hidden"},
         }
 
         sanitized = sanitize_for_logging(sensitive_data)
 
-        self.assertEqual(sanitized['host'], 'localhost')
-        self.assertEqual(sanitized['port'], 5432)
-        self.assertEqual(sanitized['password'], '***REDACTED***')
-        self.assertEqual(sanitized['api_key'], '***REDACTED***')
-        self.assertEqual(sanitized['config']['username'], 'user')
-        self.assertEqual(sanitized['config']['secret'], '***REDACTED***')
+        self.assertEqual(sanitized["host"], "localhost")
+        self.assertEqual(sanitized["port"], 5432)
+        self.assertEqual(sanitized["password"], "***REDACTED***")
+        self.assertEqual(sanitized["api_key"], "***REDACTED***")
+        self.assertEqual(sanitized["config"]["username"], "user")
+        self.assertEqual(sanitized["config"]["secret"], "***REDACTED***")
 
     def test_validate_uri(self):
         """Test URI validation function."""
         from src.utils import validate_uri
 
-        self.assertTrue(validate_uri('https://example.com/'))
-        self.assertTrue(validate_uri('http://localhost:8080/'))
-        self.assertTrue(validate_uri('https://api.example.com/v1/ontology/'))
+        self.assertTrue(validate_uri("https://example.com/"))
+        self.assertTrue(validate_uri("http://localhost:8080/"))
+        self.assertTrue(validate_uri("https://api.example.com/v1/ontology/"))
 
-        self.assertFalse(validate_uri(''))
-        self.assertFalse(validate_uri('not-a-uri'))
-        self.assertFalse(validate_uri('ftp://example.com/'))
+        self.assertFalse(validate_uri(""))
+        self.assertFalse(validate_uri("not-a-uri"))
+        self.assertFalse(validate_uri("ftp://example.com/"))
 
     def test_format_bytes(self):
         """Test bytes formatting function."""
@@ -771,10 +801,11 @@ class TestUtilityFunctions(unittest.TestCase):
         self.assertEqual(format_bytes(1536), "1.5 KB")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Use pytest for better test discovery and reporting if available
     try:
         import pytest
-        pytest.main([__file__, '-v'])
+
+        pytest.main([__file__, "-v"])
     except ImportError:
         unittest.main(verbosity=2)

--- a/tests/test_session_eviction.py
+++ b/tests/test_session_eviction.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.session import SessionData
 from src.main import ServerState
+from src.session import SessionData
 
 
 class TestSessionDataActivity:

--- a/tests/test_shacl_validation.py
+++ b/tests/test_shacl_validation.py
@@ -2,10 +2,9 @@
 
 import pytest
 
-from src.shacl_validator import validate_ontology, shacl_available
+from src.database_manager import ColumnInfo, TableInfo
 from src.ontology_generator import OntologyGenerator
-from src.database_manager import TableInfo, ColumnInfo
-
+from src.shacl_validator import shacl_available, validate_ontology
 
 pytestmark = pytest.mark.skipif(
     not shacl_available(),
@@ -15,30 +14,63 @@ pytestmark = pytest.mark.skipif(
 
 def _ecommerce_ttl() -> str:
     customers = TableInfo(
-        name="customers", schema="public",
+        name="customers",
+        schema="public",
         columns=[
-            ColumnInfo(name="id", data_type="INTEGER", is_nullable=False,
-                       is_primary_key=True, is_foreign_key=False),
-            ColumnInfo(name="name", data_type="VARCHAR(200)", is_nullable=False,
-                       is_primary_key=False, is_foreign_key=False),
-        ],
-        primary_keys=["id"], foreign_keys=[], row_count=100,
-    )
-    orders = TableInfo(
-        name="orders", schema="public",
-        columns=[
-            ColumnInfo(name="id", data_type="INTEGER", is_nullable=False,
-                       is_primary_key=True, is_foreign_key=False),
-            ColumnInfo(name="customer_id", data_type="INTEGER", is_nullable=False,
-                       is_primary_key=False, is_foreign_key=True,
-                       foreign_key_table="customers", foreign_key_column="id"),
+            ColumnInfo(
+                name="id",
+                data_type="INTEGER",
+                is_nullable=False,
+                is_primary_key=True,
+                is_foreign_key=False,
+            ),
+            ColumnInfo(
+                name="name",
+                data_type="VARCHAR(200)",
+                is_nullable=False,
+                is_primary_key=False,
+                is_foreign_key=False,
+            ),
         ],
         primary_keys=["id"],
-        foreign_keys=[{"column": "customer_id", "referenced_table": "customers", "referenced_column": "id"}],
+        foreign_keys=[],
+        row_count=100,
+    )
+    orders = TableInfo(
+        name="orders",
+        schema="public",
+        columns=[
+            ColumnInfo(
+                name="id",
+                data_type="INTEGER",
+                is_nullable=False,
+                is_primary_key=True,
+                is_foreign_key=False,
+            ),
+            ColumnInfo(
+                name="customer_id",
+                data_type="INTEGER",
+                is_nullable=False,
+                is_primary_key=False,
+                is_foreign_key=True,
+                foreign_key_table="customers",
+                foreign_key_column="id",
+            ),
+        ],
+        primary_keys=["id"],
+        foreign_keys=[
+            {
+                "column": "customer_id",
+                "referenced_table": "customers",
+                "referenced_column": "id",
+            }
+        ],
         row_count=1000,
     )
     gen = OntologyGenerator("http://test.com/ontology/")
-    return gen.generate_from_schema([customers, orders], include_inferred_relationships=False)
+    return gen.generate_from_schema(
+        [customers, orders], include_inferred_relationships=False
+    )
 
 
 def test_generated_ontology_conforms():

--- a/tests/test_validate_sql_syntax_integration.py
+++ b/tests/test_validate_sql_syntax_integration.py
@@ -22,9 +22,7 @@ class TestValidateSqlSyntaxIntegration(unittest.TestCase):
     def test_semicolon_inside_string_literal_is_not_multi_statement(self):
         # Regression: the regex ';' split used to wrongly reject this as
         # "multiple statements" before the parser could classify it.
-        result = self.db.validate_sql_syntax(
-            "SELECT a FROM t WHERE name = 'a;b'"
-        )
+        result = self.db.validate_sql_syntax("SELECT a FROM t WHERE name = 'a;b'")
         self.assertNotEqual(result.get("error_type"), "security_error")
         self.assertEqual(result["query_type"], "SELECT")
         self.assertTrue(result["is_valid"])

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -12,29 +12,29 @@ Covers:
 """
 
 import asyncio
-import pytest
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
-from src.database_manager import TableInfo, ColumnInfo
-from src.lifecycle.metadata import (
-    VersionMetadataManager,
-    update_workspace_section,
-    update_workspace_rdf,
-)
-from src.workspace import detect_workspace, format_workspace_summary
-from src.graphrag.retriever import GraphRetriever
-from src.graphrag.community_detector import CommunityDetector
+import pytest
 
 import src.main as main_module
+from src.database_manager import ColumnInfo, TableInfo
+from src.graphrag.community_detector import CommunityDetector
+from src.graphrag.retriever import GraphRetriever
+from src.lifecycle.metadata import (
+    VersionMetadataManager,
+    update_workspace_rdf,
+    update_workspace_section,
+)
 from src.main import mcp
+from src.workspace import detect_workspace, format_workspace_summary
 
 
 def _get_tool_fn(name):
     """Get the underlying function for a tool."""
     obj = getattr(main_module, name)
-    return getattr(obj, 'fn', obj)
+    return getattr(obj, "fn", obj)
 
 
 class TestMetadataWorkspaceExtension:
@@ -53,10 +53,14 @@ class TestMetadataWorkspaceExtension:
     def test_update_workspace_creates_section(self):
         """update_workspace creates workspace section if missing."""
         mgr = VersionMetadataManager(self.connection_id, self.output_dir)
-        mgr.update_workspace("public", "schema", {
-            "schema_file": "schema_public.json",
-            "table_count": 10,
-        })
+        mgr.update_workspace(
+            "public",
+            "schema",
+            {
+                "schema_file": "schema_public.json",
+                "table_count": 10,
+            },
+        )
 
         workspace = mgr.get_workspace()
         assert workspace is not None
@@ -104,10 +108,12 @@ class TestMetadataWorkspaceExtension:
     def test_update_workspace_rdf_store(self):
         """update_workspace_rdf_store sets rdf_store section."""
         mgr = VersionMetadataManager(self.connection_id, self.output_dir)
-        mgr.update_workspace_rdf_store({
-            "initialized": True,
-            "graph_uris": ["http://example.com/g1"],
-        })
+        mgr.update_workspace_rdf_store(
+            {
+                "initialized": True,
+                "graph_uris": ["http://example.com/g1"],
+            }
+        )
 
         workspace = mgr.get_workspace()
         assert workspace["rdf_store"]["initialized"] is True
@@ -165,7 +171,9 @@ class TestAsyncWriteSerialization:
         assert workspace is not None
         assert len(workspace["schemas"]) == 5
         for i in range(5):
-            assert workspace["schemas"][f"schema_{i}"]["schema"]["table_count"] == i * 10
+            assert (
+                workspace["schemas"][f"schema_{i}"]["schema"]["table_count"] == i * 10
+            )
 
     @pytest.mark.asyncio
     async def test_concurrent_rdf_write(self):
@@ -202,19 +210,24 @@ class TestWorkspaceDetection:
         # Set up workspace metadata + actual files
         mgr = VersionMetadataManager(self.connection_id, self.output_dir)
         mgr.update_workspace_connection("postgresql", "testdb")
-        mgr.update_workspace("public", "schema", {
-            "schema_file": "schema_test.json",
-            "table_count": 5,
-            "analyzed_at": "2026-04-14T10:00:00",
-        })
+        mgr.update_workspace(
+            "public",
+            "schema",
+            {
+                "schema_file": "schema_test.json",
+                "table_count": 5,
+                "analyzed_at": "2026-04-14T10:00:00",
+            },
+        )
 
         # Create the actual file in the connection dir
         conn_dir = self.output_dir / self.connection_id
         conn_dir.mkdir(parents=True, exist_ok=True)
         (conn_dir / "schema_test.json").write_text('{"tables": []}')
 
-        with patch("src.workspace.OUTPUT_DIR", self.output_dir), \
-             patch("src.workspace.get_connection_dir", return_value=conn_dir):
+        with patch("src.workspace.OUTPUT_DIR", self.output_dir), patch(
+            "src.workspace.get_connection_dir", return_value=conn_dir
+        ):
             result = detect_workspace(self.connection_id)
 
         assert result is not None
@@ -230,7 +243,11 @@ class TestWorkspaceDetection:
             "schemas": {
                 "public": {
                     "schema": {"available": True, "table_count": 42},
-                    "ontology": {"available": True, "enriched": True, "persisted_to_rdf": True},
+                    "ontology": {
+                        "available": True,
+                        "enriched": True,
+                        "persisted_to_rdf": True,
+                    },
                     "graphrag": {"available": True, "embedding_count": 312},
                 }
             },
@@ -259,10 +276,17 @@ class TestGraphRetrieverLoadGraph:
     def test_load_graph_rebuilds(self):
         """load_graph rebuilds the graph from tables_info."""
         tables = [
-            {"name": "orders", "columns": [], "foreign_keys": [
-                {"column": "customer_id", "referenced_table": "customers",
-                 "referenced_column": "id"}
-            ]},
+            {
+                "name": "orders",
+                "columns": [],
+                "foreign_keys": [
+                    {
+                        "column": "customer_id",
+                        "referenced_table": "customers",
+                        "referenced_column": "id",
+                    }
+                ],
+            },
             {"name": "customers", "columns": [], "foreign_keys": []},
         ]
         retriever = GraphRetriever()
@@ -276,6 +300,7 @@ class TestCommunityDetectorLoadCommunities:
 
     def _make_detector(self):
         import networkx as nx
+
         g = nx.DiGraph()
         g.add_nodes_from(["t1", "t2", "t3"])
         return CommunityDetector(g)
@@ -309,10 +334,20 @@ class TestTableInfoFromDict:
             "name": "users",
             "schema": "public",
             "columns": [
-                {"name": "id", "data_type": "integer", "is_nullable": False,
-                 "is_primary_key": True, "is_foreign_key": False},
-                {"name": "email", "data_type": "varchar", "is_nullable": True,
-                 "is_primary_key": False, "is_foreign_key": False},
+                {
+                    "name": "id",
+                    "data_type": "integer",
+                    "is_nullable": False,
+                    "is_primary_key": True,
+                    "is_foreign_key": False,
+                },
+                {
+                    "name": "email",
+                    "data_type": "varchar",
+                    "is_nullable": True,
+                    "is_primary_key": False,
+                    "is_foreign_key": False,
+                },
             ],
             "primary_keys": ["id"],
             "foreign_keys": [],
@@ -346,8 +381,11 @@ class TestTableInfoFromDict:
     def test_from_dict_with_column_info_instances(self):
         """from_dict handles already-deserialized ColumnInfo objects."""
         col = ColumnInfo(
-            name="id", data_type="int", is_nullable=False,
-            is_primary_key=True, is_foreign_key=False,
+            name="id",
+            data_type="int",
+            is_nullable=False,
+            is_primary_key=True,
+            is_foreign_key=False,
         )
         data = {
             "name": "test",
@@ -407,16 +445,27 @@ class TestGraphRAGManagerLoadState:
         )
 
         tables = [
-            {"name": "orders", "columns": [
-                {"name": "id", "data_type": "int"}
-            ], "foreign_keys": [
-                {"column": "customer_id", "referenced_table": "customers",
-                 "referenced_column": "id"}
-            ], "comment": "Order records"},
-            {"name": "customers", "columns": [
-                {"name": "id", "data_type": "int"},
-                {"name": "name", "data_type": "varchar"},
-            ], "foreign_keys": [], "comment": "Customer accounts"},
+            {
+                "name": "orders",
+                "columns": [{"name": "id", "data_type": "int"}],
+                "foreign_keys": [
+                    {
+                        "column": "customer_id",
+                        "referenced_table": "customers",
+                        "referenced_column": "id",
+                    }
+                ],
+                "comment": "Order records",
+            },
+            {
+                "name": "customers",
+                "columns": [
+                    {"name": "id", "data_type": "int"},
+                    {"name": "name", "data_type": "varchar"},
+                ],
+                "foreign_keys": [],
+                "comment": "Customer accounts",
+            },
         ]
 
         mgr.initialize_from_schema(tables, schema_name="public")
@@ -476,8 +525,9 @@ class TestMultiSchemaSessionState:
 
     def test_graphrag_is_connection_scoped(self):
         """GraphRAG state is connection-scoped (shared across schemas)."""
-        from src.session import SessionData
         from unittest.mock import Mock
+
+        from src.session import SessionData
 
         session = SessionData()
         manager = Mock(name="graphrag_manager")
@@ -513,8 +563,9 @@ class TestMultiSchemaSessionState:
 
     def test_rdf_store_is_connection_scoped(self):
         """RDF store remains connection-scoped (shared across schemas)."""
-        from src.session import SessionData
         from unittest.mock import Mock
+
+        from src.session import SessionData
 
         session = SessionData()
         store = Mock(name="oxigraph_store")

--- a/tests/test_workspace_restore.py
+++ b/tests/test_workspace_restore.py
@@ -28,8 +28,9 @@ class TestWorkspaceRdfRestore(unittest.IsolatedAsyncioTestCase):
         session = SessionData()
         ctx = MagicMock()
 
-        with patch("src.handlers.workspace.VersionMetadataManager") as MgrCls, \
-             patch("src.handlers.workspace.OXIGRAPH_AVAILABLE", True):
+        with patch("src.handlers.workspace.VersionMetadataManager") as MgrCls, patch(
+            "src.handlers.workspace.OXIGRAPH_AVAILABLE", True
+        ):
             MgrCls.return_value.get_workspace.return_value = workspace
             result = await _restore_workspace_core(
                 ctx, session, "conn-123", None, services
@@ -56,8 +57,9 @@ class TestWorkspaceRdfRestore(unittest.IsolatedAsyncioTestCase):
         del bare_function.get_oxigraph_store  # force AttributeError on attr access
         session = SessionData()
 
-        with patch("src.handlers.workspace.VersionMetadataManager") as MgrCls, \
-             patch("src.handlers.workspace.OXIGRAPH_AVAILABLE", True):
+        with patch("src.handlers.workspace.VersionMetadataManager") as MgrCls, patch(
+            "src.handlers.workspace.OXIGRAPH_AVAILABLE", True
+        ):
             MgrCls.return_value.get_workspace.return_value = workspace
             result = await _restore_workspace_core(
                 MagicMock(), session, "conn-123", None, bare_function

--- a/tests/verify_phase1.py
+++ b/tests/verify_phase1.py
@@ -8,10 +8,11 @@ import sys
 from pathlib import Path
 
 # Colors for output
-GREEN = '\033[92m'
-RED = '\033[91m'
-YELLOW = '\033[93m'
-RESET = '\033[0m'
+GREEN = "\033[92m"
+RED = "\033[91m"
+YELLOW = "\033[93m"
+RESET = "\033[0m"
+
 
 def test(name, condition, message=""):
     """Run a test and print result."""
@@ -24,15 +25,16 @@ def test(name, condition, message=""):
             print(f"  {YELLOW}{message}{RESET}")
         return False
 
+
 def main():
     """Run all verification tests."""
     project_root = Path(__file__).parent.parent
     passed = 0
     failed = 0
 
-    print("\n" + "="*60)
+    print("\n" + "=" * 60)
     print("Phase 1 Verification Tests")
-    print("="*60 + "\n")
+    print("=" * 60 + "\n")
 
     # Test 1: Skills directory exists
     skills_dir = project_root / ".claude" / "skills"
@@ -45,7 +47,7 @@ def main():
     expected_skills = [
         "fan-trap-prevention.md",
         "sql-best-practices.md",
-        "chart-examples.md"
+        "chart-examples.md",
     ]
 
     all_skills_present = True
@@ -66,7 +68,9 @@ def main():
         skill_path = skills_dir / skill
         if skill_path.exists() and skill_path.stat().st_size < 1000:
             skills_large_enough = False
-            print(f"  {YELLOW}{skill} too small: {skill_path.stat().st_size} bytes{RESET}")
+            print(
+                f"  {YELLOW}{skill} too small: {skill_path.stat().st_size} bytes{RESET}"
+            )
 
     if test("All skills have sufficient content", skills_large_enough):
         passed += 1
@@ -78,9 +82,9 @@ def main():
     if fan_trap_path.exists():
         content = fan_trap_path.read_text()
         has_key_content = (
-            "What is a Fan-Trap?" in content and
-            "UNION ALL" in content and
-            "Detection Checklist" in content
+            "What is a Fan-Trap?" in content
+            and "UNION ALL" in content
+            and "Detection Checklist" in content
         )
         if test("Fan-trap skill has key content", has_key_content):
             passed += 1
@@ -94,8 +98,7 @@ def main():
     if sql_path.exists():
         content = sql_path.read_text()
         has_key_content = (
-            "Identifier Qualification" in content and
-            "schema.table.column" in content
+            "Identifier Qualification" in content and "schema.table.column" in content
         )
         if test("SQL best practices skill has key content", has_key_content):
             passed += 1
@@ -109,10 +112,10 @@ def main():
     if chart_path.exists():
         content = chart_path.read_text()
         has_key_content = (
-            "bar" in content.lower() and
-            "line" in content.lower() and
-            "scatter" in content.lower() and
-            "generate_chart" in content
+            "bar" in content.lower()
+            and "line" in content.lower()
+            and "scatter" in content.lower()
+            and "generate_chart" in content
         )
         if test("Chart examples skill has key content", has_key_content):
             passed += 1
@@ -159,12 +162,14 @@ def main():
                 print(f"  {GREEN}Instructions: {len(instructions)} chars{RESET}")
             else:
                 failed += 1
-                print(f"  {YELLOW}Instructions: {len(instructions)} chars (expected < 2000){RESET}")
+                print(
+                    f"  {YELLOW}Instructions: {len(instructions)} chars (expected < 2000){RESET}"
+                )
 
             # Check for skill references
             has_skill_refs = (
-                "/fan-trap-prevention" in instructions and
-                "/sql-best-practices" in instructions
+                "/fan-trap-prevention" in instructions
+                and "/sql-best-practices" in instructions
             )
             if test("Server instructions reference skills", has_skill_refs):
                 passed += 1
@@ -196,9 +201,9 @@ def main():
         failed += 1
 
     # Summary
-    print("\n" + "="*60)
+    print("\n" + "=" * 60)
     print(f"Results: {GREEN}{passed} passed{RESET}, {RED}{failed} failed{RESET}")
-    print("="*60 + "\n")
+    print("=" * 60 + "\n")
 
     if failed == 0:
         print(f"{GREEN}✓ All tests passed! Phase 1 deployment successful.{RESET}\n")
@@ -206,6 +211,7 @@ def main():
     else:
         print(f"{RED}✗ Some tests failed. Please review the output above.{RESET}\n")
         return 1
+
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
Dedicated formatting pass on top of #29 — the repo had never been run through black/isort despite both being configured. (Supersedes the auto-closed #30, regenerated cleanly on current `main`.)

- **black** (target py312, matching the pinned `<24`) + **isort** (`profile=black`) over `src/` and `tests/` — 71 files reformatted
- fixes a re-export `# noqa` block in `main.py` that isort merged
- **CI:** promotes `black --check` and `isort --check` from advisory to **blocking** now that the tree is clean; mypy stays the only advisory baseline

No behavior changes — 358 tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)