### PR TITLE
chore(release): v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to OrionBelt Analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2026-06-22
+
+Architecture-review release: correctness fixes, stronger SQL safety, and a large
+internal refactor of the registration layer. No MCP tool surface changes (still
+26 tools, same signatures).
+
+### Added
+- **Driver/dialect registry** (`src/drivers/registry.py`) — a single source of
+  truth mapping each `db_type` to its driver class and sqlglot dialect.
+  `SUPPORTED_DB_TYPES`, the driver classes, and OBQC's dialect map now all derive
+  from `constants.DB_SQLGLOT_DIALECTS`, so they can no longer drift apart.
+- **Parser-based SQL safety gate** (`security.analyze_sql_statement`) — sqlglot
+  validation is now the primary read-only/single-statement check, run ahead of
+  the regex first-filter.
+- **Typed `HandlerContext`** — handlers receive one request-scoped services
+  object instead of many helper keyword arguments.
+- CI workflow enforcing ruff, black, isort and pytest (mypy advisory).
+
+### Changed
+- **OBQC dialect parity** — `bigquery`, `duckdb`, `databricks` and `mysql` are
+  now validated with their own sqlglot dialect instead of silently falling back
+  to the PostgreSQL dialect.
+- SQL validation now catches write/DDL operations hidden after a CTE
+  (`WITH x AS (...) INSERT ...`) and no longer mis-flags a semicolon inside a
+  string literal (`WHERE name = 'a;b'`) as multiple statements.
+- **Refactor (no behavior change):** split the 1,237-line `main.py` into
+  `server_state.py`, `resources.py` and `tool_types.py`; decomposed the
+  1,466-line `handlers/ontology.py` into focused
+  generation/semantic/io/artifacts modules.
+- Repository formatted with black + isort; tooling aligned to Python 3.13.
+
+### Fixed
+- **AUTO_ONTOLOGY** background generation called a non-existent generator method
+  and silently produced nothing; it now generates the ontology correctly.
+- Artifact downloads (`download_artifact`) honor an explicit `schema_name` and
+  read that schema's per-schema state instead of the currently active schema.
+- RDF-store auto-restore on `connect_database` no longer fails with an
+  AttributeError on RDF-enabled workspaces.
+- Startup banner reports the real registered tool count (was a stale `23`).
+
 ## [1.6.0] - 2026-06-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center"><strong>The Ontology-based MCP server for your Text-2-SQL convenience.</strong></p>
 
-[![Version 1.6.0](https://img.shields.io/badge/version-1.6.0-purple.svg)](https://github.com/ralforion/orionbelt-analytics/releases)
+[![Version 1.7.0](https://img.shields.io/badge/version-1.7.0-purple.svg)](https://github.com/ralforion/orionbelt-analytics/releases)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-analytics/blob/main/LICENSE)
 [![FastMCP](https://img.shields.io/badge/FastMCP-3.3.1+-blue)](https://github.com/jlowin/fastmcp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-analytics"
-version = "1.6.0"
+version = "1.7.0"
 description = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "ralf.becher@web.de"}]
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.ralforion/orionbelt-analytics",
   "description": "Ontology-based MCP server for database schema analysis and RDF/OWL ontology generation",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "repository": {
     "url": "https://github.com/ralforion/orionbelt-analytics",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "pypi",
       "identifier": "orionbelt-analytics",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """OrionBelt Analytics - Ontology-based MCP server for your Text-2-SQL convenience."""
 
-__version__ = "1.6.0"
+__version__ = "1.7.0"
 __author__ = "OrionBelt Analytics Contributors"
 __email__ = "contributors@example.com"
 __description__ = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"

--- a/uv.lock
+++ b/uv.lock
@@ -2473,7 +2473,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-analytics"
-version = "1.6.0"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release v1.7.0 (minor) — architecture-review changes. No MCP tool surface changes (26 tools, same signatures).

Bundles #28, #29, #31:
- **Driver/dialect registry** — single source of truth for db_type → driver + dialect
- **OBQC dialect parity** — bigquery/duckdb/databricks/mysql now validated with their own sqlglot dialect (no more Postgres fallback)
- **Parser-based SQL safety gate** — catches DML hidden after a CTE; no longer mis-flags `;`-in-strings
- **Refactors** — split main.py; decompose ontology handler; typed HandlerContext
- **Fixes** — AUTO_ONTOLOGY background generation, artifact schema isolation, RDF auto-restore, startup tool count
- **Tooling** — black/isort applied + enforced in CI; aligned to Python 3.13

Version bumped via `scripts/bump-version.sh 1.7.0` (incl. `uv.lock`). Build verified: sdist + wheel produced, ships `ontology/oba.ttl` + `oba-shacl.ttl`, metadata version 1.7.0. 358 tests pass, ruff/black/isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)