### PR TITLE
chore(docker): add Docker Hub badges and publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,84 @@
+name: Docker Publish
+
+# Build and push the server image to Docker Hub, and keep the Hub repo
+# overview in sync with README.md.
+#
+# - image       → only on version tags (v1.2.3): publishes :1.2.3, :1.2, :1, :latest
+# - description → on pushes to main and manual runs: syncs README.md to the
+#                 Docker Hub overview. This job never builds an image, so no
+#                 rolling :main / :edge tags are created.
+#
+# Requires two repository secrets:
+#   DOCKERHUB_USERNAME — Docker Hub account / org
+#   DOCKERHUB_TOKEN    — a Docker Hub access token (Account Settings → Security)
+#                        with read/write scope (read-only fails the description sync)
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+
+env:
+  IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/orionbelt-analytics
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    # Build/push only for released version tags — never for branch or PR pushes.
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Derive tags and labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+          labels: |
+            org.opencontainers.image.title=OrionBelt Analytics
+            org.opencontainers.image.description=Ontology-based MCP server for relationship-aware Text-to-SQL.
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  description:
+    runs-on: ubuntu-latest
+    # Sync the README to the Hub overview on main pushes, manual runs, and
+    # releases. Independent of the image build — no image is produced here.
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.IMAGE }}
+          short-description: Ontology-based MCP server for relationship-aware Text-to-SQL.
+          readme-filepath: ./README.md

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@
 [![DuckDB](https://img.shields.io/badge/DuckDB-FFF000.svg?logo=duckdb&logoColor=black)](https://duckdb.org)
 [![MySQL](https://img.shields.io/badge/MySQL-4479A1.svg?logo=mysql&logoColor=white)](https://www.mysql.com)
 
+[![Docker Hub](https://img.shields.io/docker/v/ralforion/orionbelt-analytics?logo=docker&logoColor=white&label=Docker%20Hub&color=2496ED&sort=semver)](https://hub.docker.com/r/ralforion/orionbelt-analytics/tags)
+[![Docker pulls](https://img.shields.io/docker/pulls/ralforion/orionbelt-analytics?logo=docker&logoColor=white&color=2496ED)](https://hub.docker.com/r/ralforion/orionbelt-analytics)
+[![Image size](https://img.shields.io/docker/image-size/ralforion/orionbelt-analytics/latest?logo=docker&logoColor=white&color=2496ED)](https://hub.docker.com/r/ralforion/orionbelt-analytics)
+
 OrionBelt Analytics is an MCP server that analyzes relational database schemas and generates RDF/OWL ontologies with embedded SQL mappings. It provides relationship-aware Text-to-SQL with automatic fan-trap prevention, GraphRAG for intelligent schema discovery, and interactive charting -- all accessible through any MCP-compatible AI client.
 
 ## The OrionBelt Ecosystem


### PR DESCRIPTION
Add Docker Hub badges and a publish workflow.

## Changes
- **README**: new row of Docker Hub badges (version, pulls, image size) pointing at `ralforion/orionbelt-analytics`.
- **`.github/workflows/docker-publish.yml`**: builds/pushes multi-arch (`linux/amd64,linux/arm64`) images to Docker Hub on `v*.*.*` tags (`:1.2.3`, `:1.2`, `:1`, `:latest`) and syncs the README to the Hub overview on main pushes / manual runs.

Uses org-level `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)