### PR TITLE
fix(ci): correct mcp-xray analyze invocation

### DIFF
--- a/.github/workflows/mcp-audit.yml
+++ b/.github/workflows/mcp-audit.yml
@@ -41,8 +41,9 @@ jobs:
             > tools.json
 
       - name: Run audit
-        # No --model: run the deterministic static checks only, no LLM call.
-        run: uv run mcp-xray analyze tools.json --runs-dir audit-output
+        # --tools-json feeds the offline dump; no --llm flag means the static +
+        # consolidation checks run deterministically with no model / API key.
+        run: uv run mcp-xray analyze --tools-json tools.json --runs-dir audit-output
 
       - name: Render report to job summary
         if: always()


### PR DESCRIPTION
## Problem
The first run of the MCP audit workflow failed at the **Run audit** step:

```
mcp-xray: error: unrecognized arguments: tools.json
```

`continue-on-error: true` masked it as a green job, but no report was produced.

## Cause
`mcp-xray analyze` takes the offline dump via **`--tools-json`**, not as a positional argument (the template assumed `analyze tools.json`).

## Fix
- Use `mcp-xray analyze --tools-json tools.json --runs-dir audit-output`.
- Confirmed locally (v1.4.0): with no `--llm` flag it runs the static + consolidation checks **deterministically, no model / API key**, and writes `report.md` + `report.json` under `audit-output/<hash>/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)