### PR TITLE
chore(release): v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to OrionBelt Analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2026-06-26
+
+Bug-fix release centered on the RDF/SPARQL store, which had broken against the
+resolved pyoxigraph version. No MCP tool surface changes (still 26 tools, same
+signatures).
+
+### Fixed
+- **RDF/SPARQL store repaired for pyoxigraph 0.5.x.** `query_sparql` (SELECT),
+  `query_sparql_ask` (ASK), and `add_triple`/`add_knowledge` raised at runtime
+  because they used 0.3.x APIs removed in the resolved 0.5.x. Migrated to `Quad`,
+  `QuerySolutions.variables`, and `bool(QueryBoolean)`. (#39)
+- **Ontology version cleanup now deletes RDF triples.** Added
+  `OxigraphStoreManager.delete_graph()`; cleanup previously called a nonexistent
+  method and left stale triples in the store. (#39)
+- **Consistent RDF named-graph URIs.** Manual storage, auto-persistence,
+  semantic-name persistence, and export/download now share a single
+  `schema_graph_uri()` helper, so a manually stored ontology is no longer
+  invisible to RDF export. (#39)
+- **`query_sparql` timeout is now enforced (best-effort).** `timeout_seconds`
+  previously had no effect; it now unblocks the caller when the timeout elapses
+  (the underlying query may keep running, as pyoxigraph exposes no native
+  cancellation). (#39)
+- **Safe Oxigraph store open.** A locked store no longer has its RocksDB `LOCK`
+  auto-deleted on open failure (which risked two-process corruption); the error
+  propagates with recovery guidance. (#39)
+- CONSTRUCT serialization uses `RdfFormat.TURTLE` instead of a deprecated MIME
+  string. (#39)
+
+### Changed
+- Pinned `pyoxigraph>=0.5,<0.6` and upgraded to 0.5.9. (#39)
+- `src/` now passes strict mypy; the mypy check is a blocking CI gate (was
+  advisory). (#37)
+- Author email updated to info@ralforion.com. (#33)
+
+### Added
+- Deterministic MCP tool-surface audit workflow (`mcp-xray`) in CI, rendering its
+  report to the run summary. (#35, #36)
+- Docker Hub badges and publish workflow. (#34)
+
 ## [1.7.0] - 2026-06-22
 
 Architecture-review release: correctness fixes, stronger SQL safety, and a large

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center"><strong>The Ontology-based MCP server for your Text-2-SQL convenience.</strong></p>
 
-[![Version 1.7.0](https://img.shields.io/badge/version-1.7.0-purple.svg)](https://github.com/ralforion/orionbelt-analytics/releases)
+[![Version 1.7.1](https://img.shields.io/badge/version-1.7.1-purple.svg)](https://github.com/ralforion/orionbelt-analytics/releases)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-analytics/blob/main/LICENSE)
 [![FastMCP](https://img.shields.io/badge/FastMCP-3.3.1+-blue)](https://github.com/jlowin/fastmcp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-analytics"
-version = "1.7.0"
+version = "1.7.1"
 description = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "info@ralforion.com"}]
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.ralforion/orionbelt-analytics",
   "description": "Ontology-based MCP server for database schema analysis and RDF/OWL ontology generation",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "repository": {
     "url": "https://github.com/ralforion/orionbelt-analytics",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "pypi",
       "identifier": "orionbelt-analytics",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """OrionBelt Analytics - Ontology-based MCP server for your Text-2-SQL convenience."""
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 __author__ = "OrionBelt Analytics Contributors"
 __email__ = "contributors@example.com"
 __description__ = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"

--- a/uv.lock
+++ b/uv.lock
@@ -2473,7 +2473,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-analytics"
-version = "1.7.0"
+version = "1.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release **v1.7.1** — RDF/SPARQL store bug-fix release. No MCP tool surface changes (still 26 tools, same signatures).

Bumps version across `src/__init__.py`, `pyproject.toml`, `server.json`, README badge, and `uv.lock`; fills in the CHANGELOG.

## Highlights (since v1.7.0)
- **Fixed:** RDF/SPARQL store repaired for pyoxigraph 0.5.x (SELECT/ASK/`add_triple` no longer raise); `delete_graph()` added so version cleanup drops triples; consistent named-graph URIs via `schema_graph_uri()`; best-effort `query_sparql` timeout; safe store-open (no LOCK auto-delete); CONSTRUCT uses `RdfFormat.TURTLE`. (#39)
- **Changed:** pinned `pyoxigraph>=0.5,<0.6` (upgraded to 0.5.9); `src/` passes strict mypy and the typecheck gate now blocks CI. (#37, #39)
- **Added:** deterministic MCP tool-surface audit workflow in CI. (#35, #36)

See `CHANGELOG.md` for the full list.

mypy 0 · ruff/black/isort clean · 377 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)