### PR TITLE
chore: add Dependabot config for uv, GitHub Actions and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+
+updates:
+  # Python dependencies (pyproject.toml + uv.lock)
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Zagreb"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      # Patch/minor bumps land as one PR to keep review load down.
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      # fastmcp is pinned to <3.4 in pyproject; majors need a manual migration.
+      - dependency-name: "fastmcp"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Zagreb"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci(deps)"
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Zagreb"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(docker)"


### PR DESCRIPTION
Adds `.github/dependabot.yml`. Dependabot is not a workflow — GitHub runs it natively from this config file and opens PRs, which the existing `ci.yml` then gates.

## Coverage

| Ecosystem | Target | Grouping |
|---|---|---|
| `uv` | `pyproject.toml` + `uv.lock` | minor + patch in one PR; majors individually |
| `github-actions` | `.github/workflows/` | all in one PR |
| `docker` | `Dockerfile` | — |

Weekly, Mondays 06:00 Europe/Zagreb.

## Notes

- Commit prefixes follow the conventional-commit convention in `AGENTS.md` (`chore(deps)`, `ci(deps)`, `chore(docker)`), so PR titles are squash-merge-ready as-is.
- `fastmcp` majors are ignored: `pyproject.toml` pins `>=3.3.1,<3.4`, so a major is a manual migration rather than a dependency bump.
- Dependabot reads its config from the **default branch**, so it stays dormant until this merges. First run kicks off shortly after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)