### PR TITLE
ci: build and smoke-test the Docker image on PRs that touch it

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,112 @@
+name: Docker Build
+
+# Builds and smoke-tests the image on PRs that can change it. Nothing is pushed.
+#
+# Why this exists: docker-publish.yml only builds on version tags, so until now
+# a Dockerfile change reached us at release time, when a bad one means a broken
+# publish. That is not hypothetical — a base-image bump (#43) passed every check
+# and would have shipped an image whose dependencies could not import.
+#
+# Why it smoke-tests rather than only building: that image BUILT cleanly. uv had
+# quietly fetched its own CPython and the venv symlink dangled in the runtime
+# stage, so the failure only appeared when something ran. A build-only job would
+# have gone green on it. The import and boot steps below are the actual gate.
+
+on:
+  pull_request:
+    paths:
+      # Anything that can change what lands in the image or which interpreter
+      # the venv is built against.
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".python-version"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/docker-build.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: docker-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          # Native amd64 only, and load into the local daemon so the smoke test
+          # can run it. The tag build in docker-publish.yml stays multi-arch;
+          # emulating arm64 here would cost minutes to catch little more.
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: orionbelt-analytics:pr
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify venv interpreter resolves
+        # The venv's python must point at the base image interpreter. When it
+        # dangles, `python` silently falls back to the base python, which cannot
+        # see the venv's site-packages, and every import fails at startup.
+        run: |
+          docker run --rm --entrypoint sh orionbelt-analytics:pr -c '
+            set -eu
+            target=$(readlink -f /opt/venv/bin/python || true)
+            if [ ! -x "$target" ]; then
+              echo "::error::/opt/venv/bin/python does not resolve to an executable."
+              echo "Symlink: $(ls -l /opt/venv/bin/python 2>&1 || echo missing)"
+              echo "Likely cause: uv built the venv against an interpreter outside"
+              echo "/opt/venv, which the runtime stage does not copy. Check that the"
+              echo "base image Python and .python-version agree."
+              exit 1
+            fi
+            echo "venv python -> $target"
+            python -V
+          '
+
+      - name: Import server module
+        # Catches missing runtime deps and dependency/interpreter incompatibility
+        # (e.g. chromadb 1.5.2 raising ConfigError on Python 3.14).
+        run: |
+          docker run --rm --entrypoint python orionbelt-analytics:pr \
+            -c 'import src.main; print("src.main import OK")'
+
+      - name: Boot server and check it serves
+        # A bare 405/406 from /mcp is success: it means the MCP app is mounted and
+        # replying, and only rejects this request for lacking the MCP Accept
+        # header. Anything else (or no listener) means the server did not come up.
+        run: |
+          set -euo pipefail
+          docker run -d --name obpr -p 9000:9000 orionbelt-analytics:pr
+
+          for i in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:9000/mcp || true)
+            if [ "$code" != "000" ]; then
+              echo "Server responded with HTTP $code"
+              case "$code" in
+                4*|2*) echo "Server is serving."; exit 0 ;;
+                *) echo "::error::Unexpected status $code from /mcp"; docker logs obpr; exit 1 ;;
+              esac
+            fi
+            sleep 2
+          done
+
+          echo "::error::Server did not start listening within 60s."
+          docker logs obpr
+          exit 1
+
+      - name: Server logs
+        if: failure()
+        run: docker logs obpr 2>&1 || true
+
+      - name: Clean up
+        if: always()
+        run: docker rm -f obpr 2>/dev/null || true


### PR DESCRIPTION
Closes the gap that let #43 through with three green checks.

## The gap

`docker-publish.yml` builds the image **only on version tags** (`if: startsWith(github.ref, 'refs/tags/v')`). Nothing builds it on a PR, so a Dockerfile change is first exercised at release time — when a bad one means a broken publish rather than a red check.

## Why it smoke-tests, not just builds

A build-only job would **not** have caught #43. That image built cleanly, exit 0. uv had quietly fetched its own CPython, the venv symlinked outside `/opt/venv`, and the runtime stage — which copies only `/opt/venv` — shipped a dangling `python`. The failure only appeared when something ran:

```
ModuleNotFoundError: No module named 'dotenv'
```

So the gate is the running image, not the build.

## Checks

Each is verified against a local reproduction of #43's image (base `3.14-slim`, `.python-version` 3.13, pre-guard), which **builds successfully and fails all three**:

| Check | Catches |
|---|---|
| venv python resolves to an executable | the dangling-symlink class directly |
| `src.main` imports | missing runtime deps; interpreter incompatibility (e.g. chromadb 1.5.2 `ConfigError` on 3.14) |
| server boots and serves `/mcp` | anything that survives import but dies at startup |

The symlink check against #43's image:

```
::error::/opt/venv/bin/python does not resolve to an executable.
Symlink: /opt/venv/bin/python -> /root/.local/share/uv/python/cpython-3.13-linux-aarch64-gnu/bin/python3.13
```

...and against a good image: `venv python -> /usr/local/bin/python3.13`, `Python 3.13.14`.

A 4xx from `/mcp` is success — it means the MCP app is mounted and replying, and rejects the bare request only for lacking the MCP `Accept` header (406 in practice). No listener, or a 5xx, fails the step and dumps container logs.

## Scope

Triggers on PRs touching `Dockerfile`, `.dockerignore`, `.python-version`, `pyproject.toml`, `uv.lock`, or this workflow — i.e. anything that changes what lands in the image or which interpreter the venv is built against. Builds native amd64 only and pushes nothing; the multi-arch build stays in `docker-publish.yml`, since emulating arm64 here would cost minutes to catch little more.

This workflow matches its own path filter, so it self-tests on this PR. Once merged, #50 — which changes the `Dockerfile` and `.python-version` — gets validated by it on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
