### PR TITLE
fix(obqc): accept sqlglot 30's Expr type; bump sqlglot to 30.12.0

### DIFF
--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -432,14 +432,14 @@ class OBQCValidator:
 
         return result
 
-    def _extract_tables(self, parsed: exp.Expression, result: OBQCResult) -> None:
+    def _extract_tables(self, parsed: exp.Expr, result: OBQCResult) -> None:
         """Extract all table references from parsed query."""
         for table in parsed.find_all(exp.Table):
             table_name = table.name
             if table_name and table_name not in result.parsed_tables:
                 result.parsed_tables.append(table_name)
 
-    def _extract_columns(self, parsed: exp.Expression, result: OBQCResult) -> None:
+    def _extract_columns(self, parsed: exp.Expr, result: OBQCResult) -> None:
         """Extract all column references from parsed query."""
         for column in parsed.find_all(exp.Column):
             col_ref = column.name
@@ -448,7 +448,7 @@ class OBQCValidator:
             if col_ref and col_ref not in result.parsed_columns:
                 result.parsed_columns.append(col_ref)
 
-    def _extract_joins(self, parsed: exp.Expression, result: OBQCResult) -> None:
+    def _extract_joins(self, parsed: exp.Expr, result: OBQCResult) -> None:
         """Extract join information from parsed query."""
         for join in parsed.find_all(exp.Join):
             join_info: Dict[str, Any] = {
@@ -467,7 +467,7 @@ class OBQCValidator:
 
             result.parsed_joins.append(join_info)
 
-    def _extract_aggregations(self, parsed: exp.Expression, result: OBQCResult) -> None:
+    def _extract_aggregations(self, parsed: exp.Expr, result: OBQCResult) -> None:
         """Detect aggregate functions and GROUP BY."""
         # Check for aggregate functions
         agg_types = (exp.Sum, exp.Count, exp.Avg, exp.Min, exp.Max)
@@ -651,7 +651,7 @@ class OBQCValidator:
         return None
 
     def _validate_type_compatibility(
-        self, parsed: exp.Expression, result: OBQCResult
+        self, parsed: exp.Expr, result: OBQCResult
     ) -> None:
         """Rule: Check type compatibility in comparisons."""
         comparison_types = (exp.EQ, exp.NEQ, exp.GT, exp.GTE, exp.LT, exp.LTE)
@@ -675,7 +675,7 @@ class OBQCValidator:
                         )
                     )
 
-    def _infer_type(self, expr: exp.Expression) -> Optional[str]:
+    def _infer_type(self, expr: exp.Expr) -> Optional[str]:
         """Infer the XSD type of an expression from ontology."""
         if self._schema_cache is None:
             return None
@@ -740,7 +740,7 @@ class OBQCValidator:
         return cat1 == cat2 or cat1 == "unknown" or cat2 == "unknown"
 
     def _validate_aggregation_context(
-        self, parsed: exp.Expression, result: OBQCResult
+        self, parsed: exp.Expr, result: OBQCResult
     ) -> None:
         """Rule: Validate GROUP BY completeness for aggregation queries."""
         if not result.has_aggregation:

--- a/uv.lock
+++ b/uv.lock
@@ -3909,8 +3909,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -4098,11 +4098,11 @@ wheels = [
 
 [[package]]
 name = "sqlglot"
-version = "28.10.1"
+version = "30.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/66/b2b300f325227044aa6f511ea7c9f3109a1dc74b13a0897931c1754b504e/sqlglot-28.10.1.tar.gz", hash = "sha256:66e0dae43b4bce23314b80e9aef41b8c88fea0e17ada62de095b45262084a8c5", size = 5739510, upload-time = "2026-02-09T23:36:23.671Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/ed/a6c45aec29353b6392ea34548c40af3ac6ffd6bc5572cf23b2ce250876fc/sqlglot-30.12.0.tar.gz", hash = "sha256:6b8369704662d4f654bc934cea4dd31c916c2a571b389210cb9e951a275e5fd9", size = 5905110, upload-time = "2026-06-26T14:09:40.408Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/ff/5a768b34202e1ee485737bfa167bd84592585aa40383f883a8e346d767cc/sqlglot-28.10.1-py3-none-any.whl", hash = "sha256:214aef51fd4ce16407022f81cfc80c173409dab6d0f6ae18c52b43f43b31d4dd", size = 597053, upload-time = "2026-02-09T23:36:21.385Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9e/82a390ecc85f066ff80affa01d195f744e3de60ad4d695b8de31c9a66da3/sqlglot-30.12.0-py3-none-any.whl", hash = "sha256:86cccc610073c645c03e72b55b60ae0518aa3253a7fc3bd56551370d003c6554", size = 707583, upload-time = "2026-06-26T14:09:38.525Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Supersedes #46. Closes #46.

## What sqlglot 30 changed

`Expr` is a **new base class** of `Expression` (`Expression` now subclasses `Expr`), and `parse_one` returns the wider `Expr`:

| | sqlglot 28 | sqlglot 30 |
|---|---|---|
| `exp.Expr` | does not exist | base class of `Expression` |
| `parse_one` returns | `Expression` | `Expr` |

The OBQC helpers annotate their parameter as `Expression`, so `parse_one`'s result no longer type checks — the 8 `arg-type` errors that fail #46:

```
src/obqc_validator.py:415: error: Argument 1 to "_extract_tables" of "OBQCValidator"
  has incompatible type "Expr"; expected "Expression"  [arg-type]
```

This is a typing change, not a runtime one: `parse_one` still returns a `Select` at runtime, which *is* an `Expression`. Nothing was silently broken — mypy is reporting the widened signature accurately.

## The fix

Widen the seven helpers that receive a parsed tree to `exp.Expr`. This reflects what they actually need rather than silencing the error with a cast:

- each only calls `find_all()` on the parameter, which `Expr` provides;
- each narrows to concrete nodes (`exp.Join`, `exp.Select`, `exp.Column`) before touching `.args` or `.table`.

That distinction matters: `args`, `parent`, `arg_key`, `comments`, and `index` exist on `Expression` but **not** on `Expr`, so a blanket widen would be wrong. `_is_inside_aggregate` therefore keeps `Expression` — it is called with already-narrowed nodes.

The bump and the annotations must land in one PR: `exp.Expr` does not exist in sqlglot 28, so the code change alone would fail to import.

## Why not #46's branch

It predates #47, #50, and #51 — merging it would revert the Python 3.14 move and delete `.github/workflows/docker-build.yml`. This branch bumps sqlglot on current `main` instead (`pyproject.toml` pins `sqlglot>=28.10.1`, a floor, so only the lock moves — 5 lines).

## Verification

- `mypy src` — clean (was 8 errors)
- **377 tests pass**, identical to `main`; the 32,475 warnings are pre-existing and unchanged (verified against a `main` baseline)
- **6 fan-trap tests** and **30 OBQC tests** pass — these exercise the retyped paths, so fan-trap detection is confirmed intact on sqlglot 30
- ruff / black / isort clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)