### PR TITLE
fix(ci): only accept explicit status codes in the image smoke test

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -80,9 +80,15 @@ jobs:
             -c 'import src.main; print("src.main import OK")'
 
       - name: Boot server and check it serves
-        # A bare 405/406 from /mcp is success: it means the MCP app is mounted and
-        # replying, and only rejects this request for lacking the MCP Accept
-        # header. Anything else (or no listener) means the server did not come up.
+        # Only explicit expected codes count as success. /mcp answers 406 to a
+        # bare GET (it wants the MCP Accept header), 405 if it rejects the method,
+        # 200 if a future handler accepts it — all of which prove the MCP app is
+        # mounted and replying.
+        #
+        # 404 must NOT be accepted: unmatched routes on this server return 404
+        # (verified — `/` and any unknown path do), so an unmounted /mcp would
+        # answer 404 and a broad 4xx match would call that success. That is the
+        # regression this step exists to catch.
         run: |
           set -euo pipefail
           docker run -d --name obpr -p 9000:9000 orionbelt-analytics:pr
@@ -92,8 +98,21 @@ jobs:
             if [ "$code" != "000" ]; then
               echo "Server responded with HTTP $code"
               case "$code" in
-                4*|2*) echo "Server is serving."; exit 0 ;;
-                *) echo "::error::Unexpected status $code from /mcp"; docker logs obpr; exit 1 ;;
+                200|405|406)
+                  echo "Server is serving."
+                  exit 0
+                  ;;
+                404)
+                  echo "::error::/mcp returned 404 — the MCP app is not mounted."
+                  echo "The server is listening but has no /mcp route."
+                  docker logs obpr
+                  exit 1
+                  ;;
+                *)
+                  echo "::error::Unexpected status $code from /mcp"
+                  docker logs obpr
+                  exit 1
+                  ;;
               esac
             fi
             sleep 2


### PR DESCRIPTION
Fixes a false-pass in the smoke test added in #51.

## The bug

The boot probe accepted **any 2xx or 4xx** from `/mcp`:

```bash
case "$code" in
  4*|2*) echo "Server is serving."; exit 0 ;;
```

Unmatched routes on this server return **404**, so an unmounted `/mcp` would answer 404 and the glob would call it serving. That is a false green on precisely the regression this step exists to catch — the check would confirm "the server is up" while the MCP app was missing entirely.

Verified against the running image:

| Path | Status |
|---|---|
| `/mcp` (mounted) | **406** |
| `/` | **404** |
| `/nonexistent-route-xyz` | **404** |

So 404 is not hypothetical here — it is what this server returns for a route that isn't there.

## The fix

Accept only `200`, `405`, `406` — each proves the MCP app is mounted and replying: 406 is what a bare GET gets (it wants the MCP `Accept` header), 405 a method rejection, 200 a future handler accepting it. 404 now fails with a message naming the cause rather than a generic "unexpected status".

## Verification

Logic exercised against the live container and across the status range:

```
/mcp (live):        406 -> PASS (serving)
unmounted route:    404 -> FAIL (MCP app not mounted)

200 -> PASS    404 -> FAIL (MCP app not mounted)
405 -> PASS    500 -> FAIL (unexpected)
406 -> PASS    502 -> FAIL (unexpected)
```

`000` (no listener yet) is still handled by the retry guard above the case, so the loop keeps polling rather than failing early.

Thanks for the catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)