### PR TITLE
fix(chart): match datetime x-axis at any resolution, not just [ns]

### DIFF
--- a/src/chart_utils.py
+++ b/src/chart_utils.py
@@ -606,8 +606,10 @@ def create_plotly_chart(
                 },
             )
 
-        # Enhance for time series
-        if sorted_df[x_column].dtype in ["datetime64[ns]"]:
+        # Enhance for time series. Match on any datetime resolution rather than
+        # a literal "datetime64[ns]": pandas 3 parses to datetime64[us], so an
+        # ns-only comparison silently stops matching and the axis loses type=date.
+        if pd.api.types.is_datetime64_any_dtype(sorted_df[x_column]):
             fig.update_xaxes(title=format_measure_name(x_column), type="date")
     elif chart_type == "scatter":
         fig = px.scatter(

--- a/tests/test_chart_utils.py
+++ b/tests/test_chart_utils.py
@@ -38,6 +38,23 @@ class TestCreatePlotlyChart(unittest.TestCase):
         fig = create_plotly_chart(df, "line", "month", "value", None, "Line", "grouped")
         self.assertIsNotNone(fig)
 
+    def test_line_chart_datetime_x_axis_is_typed_as_date(self):
+        """A datetime x-axis must be marked type='date', at any resolution.
+
+        Asserts the axis config rather than just a non-None figure, which is
+        what let the resolution bug hide. Note this only bites under pandas 3
+        (datetime64[us]); on pandas 2 the line path re-parses x to [ns], so it
+        passes either way.
+        """
+        df = pd.DataFrame(
+            {
+                "day": pd.to_datetime(["2024-01-15", "2024-02-15", "2024-03-15"]),
+                "value": [1, 2, 3],
+            }
+        )
+        fig = create_plotly_chart(df, "line", "day", "value", None, "Line", "grouped")
+        self.assertEqual(fig.layout.xaxis.type, "date")
+
     def test_scatter_chart(self):
         df = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
         fig = create_plotly_chart(df, "scatter", "x", "y", None, "Scatter", "grouped")


### PR DESCRIPTION
Found while assessing #48 (pandas 2.3.3 → 3.0.3). **This is a prerequisite for that bump**, though the fix is correct today and independent of it.

## The bug

`create_plotly_chart` gates the time-series axis enhancement on a literal ns dtype:

```python
if sorted_df[x_column].dtype in ["datetime64[ns]"]:
    fig.update_xaxes(title=..., type="date")
```

pandas 3 parses to **`datetime64[us]`**, so this silently stops matching. Line charts with a datetime x-axis lose `type="date"` — no exception, just a wrong axis.

Verified end-to-end through `generate_chart`:

| | `xaxis.type` |
|---|---|
| pandas 2.3.3 | `"date"` |
| pandas 3.0.3 | `None` |

## Why the test suite missed it

`src/tools/chart.py` has **0% coverage**, and the existing chart tests assert only `assertIsNotNone(fig)` — never the axis config. So "377 tests pass on pandas 3" was not evidence about this code at all. I drove the real code path directly instead.

## The fix

Use `pd.api.types.is_datetime64_any_dtype`, which is resolution-agnostic. `src/tools/chart.py:92` already uses exactly this for the same purpose, so this also removes an inconsistency within the codebase. Correct under pandas 2 as well — it does not depend on the bump.

Adds a regression test asserting `xaxis.type == "date"` rather than non-nullness. Honest caveat: **it only bites under pandas 3.** On pandas 2 the line path re-parses x back to `[ns]`, so it passes either way — it is a forward guard that becomes load-bearing when #48 lands.

## On #48 itself

I swept all 10 chart branches (grouped/stacked bar, month-name x, datetime x, numeric x, single/multi-measure line, scatter, heatmap, explicit sort) under both versions and diffed the output. Aside from this bug, behavior is identical — same traces, same ordering. pandas 3's other visible changes are representational and harmless here:

| | pandas 2 | pandas 3 |
|---|---|---|
| default string dtype | `object` | `str` |
| `.unique()` returns | `ndarray` | `StringArray` |
| datetime resolution | `[ns]` | `[us]` |

One near-miss worth noting: `src/tools/chart.py:101` checks `dtype == "object" or dtype == "string"`. On pandas 3 the dtype is neither `object` nor `str`-as-`object`, but `StringDtype == "string"` returns True, so the branch still works — by luck rather than design.

With this merged, #48 should be safe.

## Verification

- **378 tests pass under both pandas 2.3.3 and 3.0.3**
- Regression test confirmed to fail on pandas 3 without the fix, pass with it
- mypy / ruff / black / isort clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)