### PR TITLE
chore(release): v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to OrionBelt Analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] - 2026-07-15
+
+Bug-fix release. Charting broke for anyone installing on pandas 3, which a fresh
+install already resolves — the dependency floors are unbounded, so this affected
+1.7.1 as published. No MCP tool surface changes (still 26 tools, same signatures).
+
+### Fixed
+- **Line-chart datetime axes lost `type="date"` under pandas 3.** The
+  time-series axis enhancement was gated on a literal `datetime64[ns]` dtype;
+  pandas 3 parses to `datetime64[us]`, so the check silently stopped matching and
+  the axis rendered untyped — no error, just a wrong axis. Now matched with
+  `pd.api.types.is_datetime64_any_dtype`, which is resolution-agnostic (and was
+  already used for the same purpose elsewhere). (#54)
+
+### Changed
+- Allow `fastmcp[apps]` 3.4.x (`>=3.3.1,<3.5`). This is the only dependency
+  constraint that moves for installers; the pandas/sqlglot/cryptography floors are
+  unchanged. (#47)
+- Docker image moves to **Python 3.14**. The base image tag is now the single
+  source of truth for the image's interpreter (`UV_PYTHON` pinned to it), so a
+  base bump can no longer leave uv building the virtualenv against a different
+  Python. (#50)
+- OBQC accepts sqlglot 30's `Expr`. `Expr` is a new base class of `Expression`
+  and `parse_one` returns the wider type; the validator helpers now take
+  `exp.Expr`. Types only — no behavior change. (#52)
+- Dependency refresh: sqlglot 30.12.0, pandas 3.0.3, cryptography 49.0.0, plus 20
+  minor/patch bumps. (#45, #49, #52, #55)
+
+### Internal
+- Dependabot now watches uv, GitHub Actions, and Docker. (#42)
+- CI tests on both Python 3.13 and 3.14, covering the supported `requires-python`
+  range rather than a single pinned version. (#50)
+- Docker image changes are gated by a build **and smoke test** (venv interpreter
+  resolves, `src.main` imports, server boots and serves) — the image previously
+  was not built at all until a release tag, so a broken one surfaced as a failed
+  publish. (#51, #53)
+
 ## [1.7.1] - 2026-06-26
 
 Bug-fix release centered on the RDF/SPARQL store, which had broken against the

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center"><strong>The Ontology-based MCP server for your Text-2-SQL convenience.</strong></p>
 
-[![Version 1.7.1](https://img.shields.io/badge/version-1.7.1-purple.svg)](https://github.com/ralforion/orionbelt-analytics/releases)
+[![Version 1.7.2](https://img.shields.io/badge/version-1.7.2-purple.svg)](https://github.com/ralforion/orionbelt-analytics/releases)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-analytics/blob/main/LICENSE)
 [![FastMCP](https://img.shields.io/badge/FastMCP-3.3.1+-blue)](https://github.com/jlowin/fastmcp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-analytics"
-version = "1.7.1"
+version = "1.7.2"
 description = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "info@ralforion.com"}]
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.ralforion/orionbelt-analytics",
   "description": "Ontology-based MCP server for database schema analysis and RDF/OWL ontology generation",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "repository": {
     "url": "https://github.com/ralforion/orionbelt-analytics",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "pypi",
       "identifier": "orionbelt-analytics",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "transport": {
         "type": "stdio"
       }

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """OrionBelt Analytics - Ontology-based MCP server for your Text-2-SQL convenience."""
 
-__version__ = "1.7.1"
+__version__ = "1.7.2"
 __author__ = "OrionBelt Analytics Contributors"
 __email__ = "contributors@example.com"
 __description__ = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"

--- a/uv.lock
+++ b/uv.lock
@@ -2394,7 +2394,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-analytics"
-version = "1.7.1"
+version = "1.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Bug-fix release. No MCP tool surface changes (still 26 tools, same signatures).

## Why this release matters

`pyproject.toml` uses unbounded dependency floors, so the lockfile governs this repo and the Docker image — **not** PyPI consumers. A fresh install of **1.7.1 as published** resolves pandas 3.0.3 today, and is already broken:

```
$ uv pip install orionbelt-analytics==1.7.1
$ python -c "...create_plotly_chart(df, 'line', 'day', 'value', ...)"
RELEASED v1.7.1 + pandas 3.0.3
  xaxis.type = None   <- should be "date"
```

This release ships the fix.

## What consumers actually get

Only one dependency constraint moves for installers: `fastmcp[apps]` `<3.4` → `<3.5`. The pandas/sqlglot/cryptography floors are unchanged, so resolution does not shift — hence a patch, consistent with the 1.7.1 precedent.

| | |
|---|---|
| **Fixed** | Line-chart datetime axes lost `type="date"` under pandas 3 (`datetime64[us]` vs the hardcoded `[ns]`) (#54) |
| **Changed** | fastmcp 3.4.x allowed (#47); Docker image on Python 3.14 (#50); OBQC accepts sqlglot 30's `Expr` — types only (#52); deps refreshed (#45, #49, #52, #55) |
| **Internal** | Dependabot added (#42); CI matrices 3.13 + 3.14 (#50); Docker image build+smoke gated on PRs (#51, #53) |

## Verification

- 378 tests pass; mypy / ruff / black / isort clean
- Version consistent across all 6 spots — `pyproject.toml`, `src/__init__.py`, `server.json` (both fields), README badge, and the `uv.lock` project pin (the lockfile drift `bump-version.sh` exists to prevent)
- `src.__version__` reports `1.7.2`

After merge: tag `v1.7.2` (auto-publishes the multi-arch Docker image), GitHub release, then `uv build` + `uv publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)