### PR TITLE
chore: migrate dev deps to PEP 735 dependency-groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,8 +88,8 @@ packages = ["src"]
 [tool.hatch.version]
 path = "src/__init__.py"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     # Testing framework
     "pytest>=7.4.0,<8.0.0",
     "pytest-asyncio>=0.21.0,<1.0.0",


### PR DESCRIPTION
## Summary

Replaces the deprecated `[tool.uv] dev-dependencies` field in `pyproject.toml` with the standard PEP 735 `[dependency-groups] dev` table.

`uv` now emits on every sync:

> warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead

## Changes

- `pyproject.toml`: `[tool.uv] dev-dependencies = [...]` → `[dependency-groups] dev = [...]`

## Verification

- `uv sync` resolves all 260 packages cleanly with no change to the resolved dependency set (`uv.lock` unchanged)
- Deprecation warning is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)