### PR TITLE
chore: pin explicit ruff lint select instead of relying on defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,23 @@ dev = [
 ]
 
 # Tool configurations
+[tool.ruff]
+line-length = 88
+# target-version is inferred from requires-python (>=3.13); left implicit so it
+# tracks that single source of truth.
+
+[tool.ruff.lint]
+# Pinned explicitly rather than relying on ruff's built-in defaults, which are
+# not stable across releases: 0.16.0 widened the default set from 118 rules to
+# 826 (adding UP, BLE, DTZ, RUF, ...) and simultaneously dropped E401/E402/E7xx.
+# That turned every routine ruff bump into 1300+ unrelated lint failures and
+# blocked otherwise-fine dependency PRs. This selection reproduces the rule set
+# the codebase was already passing under 0.15.10.
+#
+# Widening this list is a deliberate, separate decision -- add prefixes here and
+# fix the resulting findings in their own PR, not as a side effect of a bump.
+select = ["E4", "E7", "E9", "F"]
+
 [tool.black]
 line-length = 88
 # Highest syntax level the pinned black (>=23.12,<24) understands. The runtime


### PR DESCRIPTION
## Problem

The project has no `[tool.ruff]` config, so `ruff check src/ tests/` runs against whatever ruff's **built-in default rule set** happens to be in the installed version. That default is not stable across releases:

| ruff | rules enabled by default |
|---|---|
| 0.15.10 (current pin) | 118 — `E`, `F` only |
| 0.16.0 (what #59 bumps to) | 826 — adds `UP`, `BLE`, `DTZ`, `RUF`, `PYI`, `B`, `SIM`, `FURB`, … |

0.16.0 also *dropped* `E401`, `E402`, `E7xx` from the default set, which is why the CI log shows `RUF100 Unused noqa directive (non-enabled: E402)` against existing, previously-valid `# noqa: E402` comments.

Net effect: a routine ruff bump produces **1361 lint errors** in untouched code and fails CI. That is currently blocking #59, where ruff 0.16.0 is bundled with 9 unrelated dependency updates (sqlglot, pandas, aiohttp, duckdb, databricks, bigquery, pytest-mock, bandit, safety) that are all fine on their own.

## Change

Adds `[tool.ruff]` / `[tool.ruff.lint]` to `pyproject.toml` pinning `select = ["E4", "E7", "E9", "F"]` — ruff's documented legacy default, i.e. exactly the rule set this codebase already passes under 0.15.10. Also sets `line-length = 88` to match the existing black and isort config.

`target-version` is deliberately left implicit so it keeps tracking `requires-python = ">=3.13"` as the single source of truth.

This is intentionally a **no-behavior-change** pin, not a lint expansion. Widening the selection stays a deliberate, separate decision.

## Verification

Rule set is identical before and after — `--show-settings` reports 118 enabled rules under 0.16.0 with this config, matching 0.15.10:

| | ruff 0.15.10 | ruff 0.16.0 |
|---|---|---|
| before (defaults) | All checks passed | **Found 1361 errors** |
| after (this PR) | All checks passed | All checks passed |

I also checked out #59's actual branch and injected this config: `ruff check` goes from **1361 errors → All checks passed**. So this genuinely unblocks it — #59 should go green on rebase, with no source changes needed.

Local gates on this branch: black 91 files unchanged, isort clean, `pytest` 378 passed.

## Follow-up (not this PR)

Some of what 0.16.0 would newly flag looks genuinely worth adopting — `UP006`/`UP045` (543 + 327 hits) are mechanical and `--fix`-able. Others need judgment: `BLE001` (159 blind `except Exception`) and `DTZ005` (40 naive `datetime.now()`) are real signal about error handling and timezone correctness. Worth its own PR against a stable baseline, which this makes possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)