### PR TITLE
refactor: adopt ruff modernization rules and fix all findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,17 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
+      # server.py is the entry point and lives at the repo root -- keep it in
+      # every lint/format gate, otherwise it silently drifts out of adoption
+      # whenever a rule set changes.
       - name: Lint (ruff)
-        run: uv run ruff check src/ tests/
+        run: uv run ruff check src/ tests/ server.py
 
       - name: Format check (black)
-        run: uv run black --check src/ tests/
+        run: uv run black --check src/ tests/ server.py
 
       - name: Import order (isort)
-        run: uv run isort --check-only src/ tests/
+        run: uv run isort --check-only src/ tests/ server.py
 
       - name: Tests
         run: uv run pytest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ uv run pytest tests/test_obqc_validator.py -v          # single file
 uv run pytest tests/test_obqc_validator.py::test_name -v   # single test
 uv run pytest -k "ontology and not server"             # keyword expression
 
-black src/ tests/ && isort src/ tests/   # format
-ruff check src/ tests/                   # lint
+black src/ tests/ server.py && isort src/ tests/ server.py   # format
+ruff check src/ tests/ server.py         # lint (server.py is the root entry point)
 mypy src/                                # strict type check (disallow_untyped_defs etc.)
 bandit -r src/                           # security scan (run for SQL/credential changes)
 pre-commit run --all-files               # all of the above as configured hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,16 +119,39 @@ line-length = 88
 # tracks that single source of truth.
 
 [tool.ruff.lint]
-# Pinned explicitly rather than relying on ruff's built-in defaults, which are
+# Selected explicitly rather than relying on ruff's built-in defaults, which are
 # not stable across releases: 0.16.0 widened the default set from 118 rules to
-# 826 (adding UP, BLE, DTZ, RUF, ...) and simultaneously dropped E401/E402/E7xx.
-# That turned every routine ruff bump into 1300+ unrelated lint failures and
-# blocked otherwise-fine dependency PRs. This selection reproduces the rule set
-# the codebase was already passing under 0.15.10.
-#
-# Widening this list is a deliberate, separate decision -- add prefixes here and
-# fix the resulting findings in their own PR, not as a side effect of a bump.
-select = ["E4", "E7", "E9", "F"]
+# 826 while dropping E401/E402/E7xx, turning routine ruff bumps into thousands
+# of unrelated failures. Everything enabled here is enabled on purpose.
+select = [
+    "E4",     # import formatting
+    "E7",     # statement-level errors
+    "E9",     # syntax / IO errors
+    "F",      # pyflakes
+    "UP",     # pyupgrade -- PEP 585/604 typing, modern idioms
+    "C4",     # flake8-comprehensions
+    "SIM",    # flake8-simplify
+    "PIE",    # flake8-pie -- unnecessary code
+    "PERF",   # perflint
+    "EXE",    # shebang correctness
+    "PYI",    # stub/typing correctness
+    "RUF",    # ruff-specific
+]
+
+ignore = [
+    # Deferred, NOT dismissed. Every SIM105 site is also an S110 site (blind
+    # `except Exception: pass` in the drivers). Rewriting them to
+    # contextlib.suppress would delete the S110 signal without anyone deciding
+    # whether swallowing is correct there -- suppression wearing a fix's
+    # clothing. These are handled in the error-handling audit that enables
+    # BLE/S110/G/DTZ/ASYNC, where each swallow is judged on merit.
+    "SIM105",
+]
+
+# Tests legitimately hold mutable class-level fixtures; that is noise there
+# rather than signal.
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["RUF012"]
 
 [tool.black]
 line-length = 88

--- a/server.py
+++ b/server.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """Startup script for OrionBelt Analytics."""
 
-import json
-import sys
-import signal
-import shutil
 import asyncio
-from pathlib import Path
+import json
+import shutil
+import signal
+import sys
 from datetime import datetime, timedelta
+from pathlib import Path
 
 # Add src directory to path for imports
 src_path = Path(__file__).parent / "src"
@@ -15,14 +15,18 @@ sys.path.insert(0, str(src_path))
 
 import atexit  # noqa: E402
 
-from src.main import mcp, cleanup_server  # noqa: E402
+from src import __name__ as SERVER_NAME  # noqa: E402
+from src import __version__  # noqa: E402
 from src.config import config_manager  # noqa: E402
+from src.main import cleanup_server, mcp  # noqa: E402
 from src.utils import setup_logging  # noqa: E402
-from src import __version__, __name__ as SERVER_NAME  # noqa: E402
 
 # Setup logging
 config = config_manager.get_server_config()
-logger = setup_logging(config.log_level, structured=False)  # Use simple format for startup
+logger = setup_logging(
+    config.log_level, structured=False
+)  # Use simple format for startup
+
 
 def setup_signal_handlers():
     """Setup signal handlers for graceful shutdown."""
@@ -43,13 +47,16 @@ def setup_signal_handlers():
 
     return shutdown_event
 
+
 def print_startup_info():
     """Print server startup information."""
-    logger.info("="*60)
+    logger.info("=" * 60)
     logger.info(f"{SERVER_NAME} v{__version__}")
-    logger.info("MCP server for database ad hoc analysis with ontology support and interactive charting")
-    logger.info("="*60)
-    
+    logger.info(
+        "MCP server for database ad hoc analysis with ontology support and interactive charting"
+    )
+    logger.info("=" * 60)
+
     # Count comes straight from the registry so the banner can never drift
     # from the tools actually registered in src/main.py.
     from src.main import get_registered_tool_names
@@ -104,7 +111,11 @@ def print_startup_info():
             logger.info(f"    • {tool}")
 
     # Warn loudly if the curated banner ever drifts from the real registry.
-    listed = {entry.split(" - ", 1)[0].strip() for tools in tool_groups.values() for entry in tools}
+    listed = {
+        entry.split(" - ", 1)[0].strip()
+        for tools in tool_groups.values()
+        for entry in tools
+    }
     missing = sorted(set(registered) - listed)
     extra = sorted(listed - set(registered))
     if missing or extra:
@@ -114,7 +125,9 @@ def print_startup_info():
         )
 
     logger.info("")
-    logger.info("🗄️ Supported Databases: PostgreSQL, MySQL, Snowflake, ClickHouse, Dremio, BigQuery, DuckDB/MotherDuck, Databricks")
+    logger.info(
+        "🗄️ Supported Databases: PostgreSQL, MySQL, Snowflake, ClickHouse, Dremio, BigQuery, DuckDB/MotherDuck, Databricks"
+    )
     logger.info("🧠 LLM Enrichment: Available via MCP prompts and tools")
     logger.info("🔒 Security: Credential handling and input validation")
     logger.info("⚡ Performance: Connection pooling and parallel processing")
@@ -127,6 +140,7 @@ def print_startup_info():
     logger.info(f"  • Host: {config.mcp_server_host}")
     logger.info(f"  • Port: {config.mcp_server_port}")
     logger.info("")
+
 
 def cleanup_tmp_folder():
     """Clean up stale top-level files from tmp/, preserving workspace data.
@@ -143,6 +157,7 @@ def cleanup_tmp_folder():
     - "all": removes ALL workspace directories (fresh start)
     """
     import os
+
     tmp_dir = Path(__file__).parent / "tmp"
 
     if not tmp_dir.exists():
@@ -192,7 +207,9 @@ def cleanup_tmp_folder():
 
     if cleanup_mode == "all":
         # Remove ALL workspace directories (fresh start)
-        logger.info(f"Full cleanup enabled, removing {len(workspace_dirs)} workspace(s)...")
+        logger.info(
+            f"Full cleanup enabled, removing {len(workspace_dirs)} workspace(s)..."
+        )
         cleaned = 0
         for conn_dir in workspace_dirs:
             try:
@@ -222,12 +239,14 @@ def cleanup_tmp_folder():
                 cleaned += 1
                 logger.info(f"Removed orphaned workspace directory: {conn_dir.name}")
             except Exception as e:
-                logger.warning(f"Failed to remove orphaned directory {conn_dir.name}: {e}")
+                logger.warning(
+                    f"Failed to remove orphaned directory {conn_dir.name}: {e}"
+                )
             continue
 
         # Check workspace age from metadata
         try:
-            with open(metadata_file, "r") as f:
+            with open(metadata_file) as f:
                 metadata = json.load(f)
             workspace = metadata.get("workspace", {})
             updated_at = workspace.get("updated_at")
@@ -249,6 +268,7 @@ def cleanup_tmp_folder():
     else:
         logger.info("Retention cleanup: all workspaces within retention period")
 
+
 def main():
     """Start the OrionBelt Analytics MCP server."""
     try:
@@ -268,15 +288,24 @@ def main():
         print_startup_info()
 
         transport_name = "streamable-http" if config.mcp_transport == "http" else "SSE"
-        logger.info(f"🚀 Starting OrionBelt Analytics v{__version__} MCP server with {transport_name} transport...")
+        logger.info(
+            f"🚀 Starting OrionBelt Analytics v{__version__} MCP server with {transport_name} transport..."
+        )
         logger.info("📡 Server ready for MCP protocol messages")
 
         # Configure FastMCP with shorter shutdown timeout for cleaner exits
         # This reduces the timeout window for SSE connections during shutdown
         import os
-        os.environ.setdefault("MCP_SHUTDOWN_TIMEOUT", "2")  # 2 seconds instead of default 5
 
-        mcp.run(transport=config.mcp_transport, host=config.mcp_server_host, port=config.mcp_server_port)
+        os.environ.setdefault(
+            "MCP_SHUTDOWN_TIMEOUT", "2"
+        )  # 2 seconds instead of default 5
+
+        mcp.run(
+            transport=config.mcp_transport,
+            host=config.mcp_server_host,
+            port=config.mcp_server_port,
+        )
 
     except KeyboardInterrupt:
         logger.info("⏹️  Server stopped by user (Ctrl+C)")
@@ -293,6 +322,7 @@ def main():
         logger.info("✅ Server shutdown complete")
 
     return 0
+
 
 if __name__ == "__main__":
     exit_code = main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -15,14 +15,14 @@ from .ontology_generator import OntologyGenerator
 from .session import SessionData
 
 __all__ = [
-    "DatabaseManager",
-    "TableInfo",
+    "SUPPORTED_DB_TYPES",
     "ColumnInfo",
+    "DatabaseManager",
     "OntologyGenerator",
     "SessionData",
-    "config_manager",
-    "SUPPORTED_DB_TYPES",
-    "__version__",
-    "__name__",
+    "TableInfo",
     "__description__",
+    "__name__",
+    "__version__",
+    "config_manager",
 ]

--- a/src/async_utils.py
+++ b/src/async_utils.py
@@ -6,17 +6,16 @@ replacing the 8+ duplicated ThreadPoolExecutor patterns in database_manager.py.
 
 import asyncio
 import logging
+from collections.abc import Coroutine
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Coroutine, TypeVar
+from typing import Any
 
 from .constants import CONNECTION_TIMEOUT
 
 logger = logging.getLogger(__name__)
 
-T = TypeVar("T")
 
-
-def run_async(coro: Coroutine[Any, Any, T], timeout: int = CONNECTION_TIMEOUT) -> T:
+def run_async[T](coro: Coroutine[Any, Any, T], timeout: int = CONNECTION_TIMEOUT) -> T:
     """Run an async coroutine from a synchronous context.
 
     Handles the common case in MCP servers where tool handlers are sync

--- a/src/chart_utils.py
+++ b/src/chart_utils.py
@@ -1,7 +1,8 @@
 """Chart generation utilities for OrionBelt Analytics."""
 
 import logging
-from typing import Any, Callable, List, Optional, Tuple, cast
+from collections.abc import Callable
+from typing import Any, cast
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ def format_measure_name(measure: str) -> str:
     return measure.replace("_", " ").title()
 
 
-def get_quarter_sort_order(values: Any, ascending: bool = True) -> Optional[List[str]]:
+def get_quarter_sort_order(values: Any, ascending: bool = True) -> list[str] | None:
     """Get chronological sort order for quarterly values.
 
     Supports multiple formats:
@@ -48,7 +49,7 @@ def get_quarter_sort_order(values: Any, ascending: bool = True) -> Optional[List
         r"^(\d{4})\s*[\-/]?\s*Q([1-4])$",  # 2024 Q1, 2024-Q1, 2024/Q1
     ]
 
-    def parse_quarter(q_str: Any) -> Optional[Tuple[int, int, str]]:
+    def parse_quarter(q_str: Any) -> tuple[int, int, str] | None:
         """Parse quarter string and return (year, quarter, original_string)."""
         q_str_clean = str(q_str).strip()
 
@@ -81,11 +82,11 @@ def get_quarter_sort_order(values: Any, ascending: bool = True) -> Optional[List
 
 def _get_ordinal_sort_key(
     values: Any,
-) -> Optional[Tuple[Callable[[Any], int], bool]]:
+) -> tuple[Callable[[Any], int], bool] | None:
     """Return a sort-key function if values are weekday names or time-of-day labels.
 
     Supports:
-    - Weekdays: Monday–Sunday (full or 3-letter abbreviations, case-insensitive)
+    - Weekdays: Monday-Sunday (full or 3-letter abbreviations, case-insensitive)
     - 12h times: 9AM, 12PM, 3PM, 6 PM, 9:00AM, 12:00 PM, etc.
 
     Returns (key_func, default_ascending) or None if values are not ordinal.
@@ -118,7 +119,7 @@ def _get_ordinal_sort_key(
     # --- 12-hour time detection ---
     time_pat = re.compile(r"^(\d{1,2})(?::(\d{2}))?\s*(am|pm)$", re.IGNORECASE)
 
-    def parse_12h(v: Any) -> Optional[int]:
+    def parse_12h(v: Any) -> int | None:
         m = time_pat.match(str(v).strip())
         if not m:
             return None
@@ -169,13 +170,13 @@ def create_plotly_chart(
     # str (single measure), list[str] (multi-measure), or None (heatmap);
     # dispatched at runtime via isinstance / truthiness checks below.
     y_column: Any,
-    color_column: Optional[str],
+    color_column: str | None,
     title: str,
-    chart_style: Optional[str],
+    chart_style: str | None,
     width: int = 800,
     height: int = 600,
-    sort_by: Optional[str] = None,
-    sort_order: Optional[str] = None,
+    sort_by: str | None = None,
+    sort_order: str | None = None,
 ) -> Any:
     """Create Plotly chart based on type.
 
@@ -462,7 +463,7 @@ def create_plotly_chart(
 
         if is_quarter_column and effective_sort_by == x_column:
             # Extract quarter and year for proper sorting
-            def parse_quarter(q_str: Any) -> Tuple[int, int]:
+            def parse_quarter(q_str: Any) -> tuple[int, int]:
                 match = re.match(
                     r"^Q([1-4])\s*(\d{4})$", str(q_str).strip(), re.IGNORECASE
                 )
@@ -556,7 +557,7 @@ def create_plotly_chart(
                         mode="lines+markers",
                         name=format_measure_name(measure),
                         yaxis="y2" if value_measures else "y",
-                        line=dict(dash="dash") if value_measures else None,
+                        line={"dash": "dash"} if value_measures else None,
                         showlegend=True,
                     )
                 )
@@ -570,18 +571,20 @@ def create_plotly_chart(
 
             if pct_measures and value_measures:
                 # Dual y-axis configuration
-                layout_config["yaxis"] = dict(
-                    title=", ".join([format_measure_name(m) for m in value_measures]),
-                    side="left",
-                )
-                layout_config["yaxis2"] = dict(
-                    title=", ".join([format_measure_name(m) for m in pct_measures]),
-                    side="right",
-                    overlaying="y",
-                    titlefont=dict(color="gray"),
-                    tickfont=dict(color="gray"),
-                    ticksuffix="%",
-                )
+                layout_config["yaxis"] = {
+                    "title": ", ".join(
+                        [format_measure_name(m) for m in value_measures]
+                    ),
+                    "side": "left",
+                }
+                layout_config["yaxis2"] = {
+                    "title": ", ".join([format_measure_name(m) for m in pct_measures]),
+                    "side": "right",
+                    "overlaying": "y",
+                    "titlefont": {"color": "gray"},
+                    "tickfont": {"color": "gray"},
+                    "ticksuffix": "%",
+                }
             elif pct_measures:
                 layout_config["yaxis_title"] = ", ".join(
                     [format_measure_name(m) for m in pct_measures]
@@ -709,27 +712,31 @@ def create_plotly_chart(
     )
 
     if show_legend:
-        legend_config = dict(
-            orientation="v", yanchor="middle", y=0.5, xanchor="left", x=1.02
-        )
-        margin_config = dict(b=100, t=60, l=60, r=200)
+        legend_config = {
+            "orientation": "v",
+            "yanchor": "middle",
+            "y": 0.5,
+            "xanchor": "left",
+            "x": 1.02,
+        }
+        margin_config = {"b": 100, "t": 60, "l": 60, "r": 200}
     else:
-        legend_config = dict()
-        margin_config = dict(b=100, t=60, l=60, r=60)
+        legend_config = {}
+        margin_config = {"b": 100, "t": 60, "l": 60, "r": 60}
 
     fig.update_layout(
-        font=dict(size=12),
+        font={"size": 12},
         plot_bgcolor="white",
         paper_bgcolor="white",
         margin=margin_config,
         showlegend=show_legend,
         legend=legend_config,
-        modebar=dict(
-            bgcolor="white",
-            color="gray",
-            activecolor="black",
-            orientation="h",
-        ),
+        modebar={
+            "bgcolor": "white",
+            "color": "gray",
+            "activecolor": "black",
+            "orientation": "h",
+        },
         width=width,
         height=height,
     )
@@ -742,7 +749,7 @@ def save_image_to_tmp(
     chart_id: str,
     format: str,
     connection_id: str,
-) -> Optional[str]:
+) -> str | None:
     """Save image bytes to connection-scoped charts directory and return file path.
 
     Args:

--- a/src/config.py
+++ b/src/config.py
@@ -3,7 +3,7 @@
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any
 
 from dotenv import load_dotenv
 
@@ -52,37 +52,37 @@ class DatabaseConfig:
     """Database connection configuration."""
 
     # PostgreSQL settings
-    postgres_host: Optional[str] = None
+    postgres_host: str | None = None
     postgres_port: int = DEFAULT_POSTGRES_PORT
-    postgres_database: Optional[str] = None
-    postgres_username: Optional[str] = None
-    postgres_password: Optional[str] = None
+    postgres_database: str | None = None
+    postgres_username: str | None = None
+    postgres_password: str | None = None
 
     # Snowflake settings
-    snowflake_account: Optional[str] = None
-    snowflake_username: Optional[str] = None
-    snowflake_password: Optional[str] = None
-    snowflake_warehouse: Optional[str] = None
-    snowflake_database: Optional[str] = None
+    snowflake_account: str | None = None
+    snowflake_username: str | None = None
+    snowflake_password: str | None = None
+    snowflake_warehouse: str | None = None
+    snowflake_database: str | None = None
     snowflake_schema: str = DEFAULT_SNOWFLAKE_SCHEMA
     snowflake_role: str = "PUBLIC"
 
     # Dremio settings (following official dremio-mcp approach)
-    dremio_uri: Optional[
-        str
-    ] = None  # Full API endpoint like https://api.dremio.cloud or https://host:port
-    dremio_pat: Optional[str] = None  # Personal Access Token
+    dremio_uri: str | None = (
+        None  # Full API endpoint like https://api.dremio.cloud or https://host:port
+    )
+    dremio_pat: str | None = None  # Personal Access Token
     # Legacy settings for backward compatibility
-    dremio_host: Optional[str] = None
+    dremio_host: str | None = None
     dremio_port: int = DEFAULT_DREMIO_PORT
-    dremio_username: Optional[str] = None
-    dremio_password: Optional[str] = None
+    dremio_username: str | None = None
+    dremio_password: str | None = None
     dremio_ssl: bool = False
 
     # ClickHouse settings
-    clickhouse_host: Optional[str] = None
+    clickhouse_host: str | None = None
     clickhouse_port: int = DEFAULT_CLICKHOUSE_PORT
-    clickhouse_database: Optional[str] = None
+    clickhouse_database: str | None = None
     clickhouse_username: str = "default"
     clickhouse_password: str = ""
     clickhouse_protocol: str = "http"
@@ -97,8 +97,8 @@ class ConfigManager:
         # Load .env from project root (one level up from src)
         env_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), ".env")
         load_dotenv(env_path)
-        self._server_config: Optional[ServerConfig] = None
-        self._db_config: Optional[DatabaseConfig] = None
+        self._server_config: ServerConfig | None = None
+        self._db_config: DatabaseConfig | None = None
 
     def get_server_config(self) -> ServerConfig:
         """Get server configuration."""
@@ -198,7 +198,7 @@ class ConfigManager:
 
         logger.info("Server configuration validated successfully")
 
-    def validate_db_config(self, db_type: str) -> Dict[str, Any]:
+    def validate_db_config(self, db_type: str) -> dict[str, Any]:
         """Validate database configuration for a specific type."""
         config = self.get_database_config()
         missing_params = []

--- a/src/database_manager.py
+++ b/src/database_manager.py
@@ -9,9 +9,10 @@ import hashlib
 import logging
 import re
 import time
+from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Dict, Iterator, List, Optional, cast
+from typing import Any, cast
 
 from sqlalchemy import text
 from sqlalchemy.engine import Connection, Engine
@@ -44,9 +45,9 @@ class ColumnInfo:
     is_nullable: bool
     is_primary_key: bool
     is_foreign_key: bool
-    foreign_key_table: Optional[str] = None
-    foreign_key_column: Optional[str] = None
-    comment: Optional[str] = None
+    foreign_key_table: str | None = None
+    foreign_key_column: str | None = None
+    comment: str | None = None
 
 
 @dataclass
@@ -55,15 +56,15 @@ class TableInfo:
 
     name: str
     schema: str
-    columns: List[ColumnInfo]
-    primary_keys: List[str]
-    foreign_keys: List[Dict[str, str]]
-    comment: Optional[str] = None
-    row_count: Optional[int] = None
-    sample_data: Optional[List[Dict[str, Any]]] = None
+    columns: list[ColumnInfo]
+    primary_keys: list[str]
+    foreign_keys: list[dict[str, str]]
+    comment: str | None = None
+    row_count: int | None = None
+    sample_data: list[dict[str, Any]] | None = None
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "TableInfo":
+    def from_dict(cls, data: dict[str, Any]) -> "TableInfo":
         """Deserialize a TableInfo from a dict (e.g. saved schema JSON).
 
         Args:
@@ -110,22 +111,22 @@ class DatabaseManager:
 
     def __init__(self) -> None:
         # Driver holds the active database-specific implementation
-        self._driver: Optional[Any] = None  # DatabaseDriver from .drivers.base
+        self._driver: Any | None = None  # DatabaseDriver from .drivers.base
 
         # Legacy attributes kept for backward compatibility with get_connection()
-        self.engine: Optional[Engine] = None
+        self.engine: Engine | None = None
         self.metadata = None
-        self.connection_info: Dict[str, Any] = {}
+        self.connection_info: dict[str, Any] = {}
         self._connection_pool_size = 5
         self._max_overflow = 10
-        self._dremio_rest_connection: Optional[Dict[str, Any]] = None
-        self._last_connection_params: Optional[Dict[str, Any]] = None
+        self._dremio_rest_connection: dict[str, Any] | None = None
+        self._last_connection_params: dict[str, Any] | None = None
 
         # Security and performance
         self._credential_manager = SecureCredentialManager()
-        self._metadata_cache: Dict[str, Any] = {}
+        self._metadata_cache: dict[str, Any] = {}
         self._cache_ttl = 300  # 5 minutes
-        self._connection_id: Optional[str] = None
+        self._connection_id: str | None = None
 
     # ------------------------------------------------------------------
     # Cache helpers
@@ -135,11 +136,11 @@ class DatabaseManager:
         """Generate cache key for metadata operations."""
         return f"{operation}:{':'.join(str(arg) for arg in args)}"
 
-    def _is_cache_valid(self, cache_entry: Dict[str, Any]) -> bool:
+    def _is_cache_valid(self, cache_entry: dict[str, Any]) -> bool:
         """Check if cache entry is still valid."""
         return bool(time.time() - cache_entry.get("timestamp", 0) < self._cache_ttl)
 
-    def _get_from_cache(self, cache_key: str) -> Optional[Any]:
+    def _get_from_cache(self, cache_key: str) -> Any | None:
         """Get value from cache if valid."""
         if cache_key in self._metadata_cache:
             entry = self._metadata_cache[cache_key]
@@ -159,9 +160,7 @@ class DatabaseManager:
     # SQL / identifier helpers
     # ------------------------------------------------------------------
 
-    def _log_sql_query(
-        self, query: str, params: Optional[Dict[str, Any]] = None
-    ) -> None:
+    def _log_sql_query(self, query: str, params: dict[str, Any] | None = None) -> None:
         """Log SQL query with parameters for debugging."""
         db_type = self.connection_info.get("type", "unknown")
         if params:
@@ -241,7 +240,7 @@ class DatabaseManager:
         """Escape a value for safe use inside a single-quoted SQL literal."""
         return value.replace("'", "''")
 
-    def _quote_dremio_identifier(self, identifier: Optional[str]) -> str:
+    def _quote_dremio_identifier(self, identifier: str | None) -> str:
         """Quote and escape a Dremio identifier or path safely."""
         if identifier is None:
             return ""
@@ -600,13 +599,13 @@ class DatabaseManager:
 
     def connect_dremio(
         self,
-        host: Optional[str] = None,
-        port: Optional[int] = None,
-        username: Optional[str] = None,
-        password: Optional[str] = None,
+        host: str | None = None,
+        port: int | None = None,
+        username: str | None = None,
+        password: str | None = None,
         ssl: bool = False,
-        uri: Optional[str] = None,
-        pat: Optional[str] = None,
+        uri: str | None = None,
+        pat: str | None = None,
     ) -> bool:
         """Connect to Dremio using REST API instead of PostgreSQL protocol."""
         from .drivers.dremio import DremioDriver
@@ -677,8 +676,8 @@ class DatabaseManager:
         self,
         project_id: str,
         dataset: str = "",
-        credentials_path: Optional[str] = None,
-        credentials_json: Optional[str] = None,
+        credentials_path: str | None = None,
+        credentials_json: str | None = None,
     ) -> bool:
         """Connect to Google BigQuery."""
         from .drivers.bigquery import BigQueryDriver
@@ -719,7 +718,7 @@ class DatabaseManager:
     def connect_duckdb(
         self,
         database_path: str = ":memory:",
-        motherduck_token: Optional[str] = None,
+        motherduck_token: str | None = None,
         read_only: bool = False,
     ) -> bool:
         """Connect to DuckDB or MotherDuck."""
@@ -878,17 +877,17 @@ class DatabaseManager:
     # Schema introspection (delegated to driver)
     # ------------------------------------------------------------------
 
-    def get_schemas(self) -> List[str]:
+    def get_schemas(self) -> list[str]:
         """Get list of available schemas."""
         if self._driver:
-            return cast(List[str], self._driver.get_schemas())
+            return cast(list[str], self._driver.get_schemas())
 
         # Fallback: should not happen if connected through connect_* methods
         if not self.engine and not self._dremio_rest_connection:
             raise RuntimeError("No database connection established")
         raise RuntimeError("No driver available - use connect_* methods first")
 
-    def get_tables(self, schema_name: Optional[str] = None) -> List[str]:
+    def get_tables(self, schema_name: str | None = None) -> list[str]:
         """Get list of tables in a schema with caching for performance."""
         logger.debug(
             f"get_tables: Starting, has_engine: {self.has_engine()}, "
@@ -898,7 +897,7 @@ class DatabaseManager:
         cache_key = self._get_cache_key("get_tables", schema_name or "default")
         cached_result = self._get_from_cache(cache_key)
         if cached_result is not None:
-            return cast(List[str], cached_result)
+            return cast(list[str], cached_result)
 
         # Ensure connection
         if not self._dremio_rest_connection:
@@ -913,7 +912,7 @@ class DatabaseManager:
         )
 
         if self._driver:
-            tables: List[str] = self._driver.get_tables(schema_name)
+            tables: list[str] = self._driver.get_tables(schema_name)
             self._store_in_cache(cache_key, tables)
             return tables
 
@@ -941,8 +940,8 @@ class DatabaseManager:
             )
 
     def analyze_table(
-        self, table_name: str, schema_name: Optional[str] = None
-    ) -> Optional[TableInfo]:
+        self, table_name: str, schema_name: str | None = None
+    ) -> TableInfo | None:
         """Analyze a specific table and return detailed information."""
         logger.debug(
             f"analyze_table: Starting analysis of {table_name}, "
@@ -975,7 +974,7 @@ class DatabaseManager:
                 log_sql=self._log_sql_query,
             )
         return cast(
-            Optional[TableInfo],
+            TableInfo | None,
             self._driver.analyze_table(table_name, schema_name),
         )
 
@@ -986,9 +985,9 @@ class DatabaseManager:
     def sample_table_data(
         self,
         table_name: str,
-        schema_name: Optional[str] = None,
+        schema_name: str | None = None,
         limit: int = DEFAULT_SAMPLE_LIMIT,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Sample data from a table for analysis with enhanced validation."""
         # Dremio REST bypasses engine check
         if not self._dremio_rest_connection:
@@ -1005,11 +1004,11 @@ class DatabaseManager:
             raise RuntimeError("No driver available")
 
         return cast(
-            List[Dict[str, Any]],
+            list[dict[str, Any]],
             self._driver.sample_table_data(table_name, schema_name, limit),
         )
 
-    def validate_sql_syntax(self, sql_query: str) -> Dict[str, Any]:
+    def validate_sql_syntax(self, sql_query: str) -> dict[str, Any]:
         """Validate SQL query syntax with enhanced security checks.
 
         Uses both security validation and database-level validation to provide
@@ -1188,13 +1187,13 @@ class DatabaseManager:
                     )
 
         except Exception as e:
-            validation_result["error"] = f"Validation system error: {str(e)}"
+            validation_result["error"] = f"Validation system error: {e!s}"
             validation_result["error_type"] = "internal_error"
             logger.error(f"SQL validation error: {e}")
 
         return validation_result
 
-    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> Dict[str, Any]:
+    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> dict[str, Any]:
         """Execute a validated SQL query and return results safely."""
         if not self._driver:
             if self._dremio_rest_connection or self.engine:
@@ -1257,7 +1256,7 @@ class DatabaseManager:
                     f"Result set may be truncated at {limit} rows"
                 )
 
-        return cast(Dict[str, Any], result_data)
+        return cast(dict[str, Any], result_data)
 
     # ------------------------------------------------------------------
     # Connection status & lifecycle

--- a/src/dremio_client.py
+++ b/src/dremio_client.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import time
 from types import TracebackType
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Self
 
 import aiohttp
 
@@ -16,13 +16,9 @@ logger = logging.getLogger(__name__)
 class DremioAuthError(Exception):
     """Authentication error with Dremio."""
 
-    pass
-
 
 class DremioQueryError(Exception):
     """Query execution error in Dremio."""
-
-    pass
 
 
 def _sanitize_sql_for_logging(sql: str, max_length: int = 200) -> str:
@@ -42,19 +38,19 @@ class DremioClient:
     def __init__(
         self,
         uri: str,
-        username: Optional[str] = None,
-        password: Optional[str] = None,
-        token: Optional[str] = None,
-        pat: Optional[str] = None,
+        username: str | None = None,
+        password: str | None = None,
+        token: str | None = None,
+        pat: str | None = None,
     ):
         self.uri = uri.rstrip("/")
         self.username = username
         self.password = password
         self.token = token
         self.pat = pat  # Personal Access Token (preferred)
-        self.session: Optional[aiohttp.ClientSession] = None
+        self.session: aiohttp.ClientSession | None = None
 
-    async def __aenter__(self) -> "DremioClient":
+    async def __aenter__(self) -> Self:
         self.session = aiohttp.ClientSession()
         if self.pat:
             # Use PAT directly as token (following official dremio-mcp approach)
@@ -67,9 +63,9 @@ class DremioClient:
 
     async def __aexit__(
         self,
-        _exc_type: Optional[Type[BaseException]],
-        _exc_val: Optional[BaseException],
-        _exc_tb: Optional[TracebackType],
+        _exc_type: type[BaseException] | None,
+        _exc_val: BaseException | None,
+        _exc_tb: TracebackType | None,
     ) -> None:
         if self.session:
             await self.session.close()
@@ -108,7 +104,7 @@ class DremioClient:
 
     async def _make_request(
         self, method: str, endpoint: str, **kwargs: Any
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Make authenticated request to Dremio API."""
         if not self.token:
             raise DremioAuthError("No authentication token available")
@@ -134,7 +130,7 @@ class DremioClient:
                 if response.status == 401:
                     raise DremioAuthError("Authentication token expired or invalid")
 
-                data: Dict[str, Any]
+                data: dict[str, Any]
                 if response.content_type == "application/json":
                     data = await response.json()
                 else:
@@ -149,7 +145,7 @@ class DremioClient:
             logger.error(f"Network error during API request: {e}")
             raise DremioQueryError(f"Network error: {e}")
 
-    async def execute_query(self, sql: str, limit: int = 1000) -> Dict[str, Any]:
+    async def execute_query(self, sql: str, limit: int = 1000) -> dict[str, Any]:
         """Execute SQL query and return results."""
         try:
             # Log the SQL query being executed
@@ -227,7 +223,7 @@ class DremioClient:
             logger.error(f"Query execution failed: {e}")
             return {"success": False, "error": str(e), "error_type": type(e).__name__}
 
-    async def get_catalogs(self) -> List[Dict[str, Any]]:
+    async def get_catalogs(self) -> list[dict[str, Any]]:
         """Get list of catalogs (schemas)."""
         try:
             catalogs = await self._make_request("GET", "/api/v3/catalog")
@@ -256,7 +252,7 @@ class DremioClient:
             logger.error(f"Failed to get catalogs: {e}")
             return []
 
-    async def get_catalog_info(self, path: Union[List[str], str]) -> Dict[str, Any]:
+    async def get_catalog_info(self, path: list[str] | str) -> dict[str, Any]:
         """Get information about a catalog item."""
         try:
             # For nested paths, join with slashes (Dremio REST API requirement)
@@ -273,7 +269,7 @@ class DremioClient:
             logger.error(f"Failed to get catalog info for {path}: {e}")
             return {}
 
-    async def test_connection(self) -> Dict[str, Any]:
+    async def test_connection(self) -> dict[str, Any]:
         """Test the connection to Dremio."""
         try:
             # Simple query to test connection
@@ -293,19 +289,19 @@ class DremioClient:
         except Exception as e:
             return {
                 "success": False,
-                "error": f"Connection test failed: {str(e)}",
+                "error": f"Connection test failed: {e!s}",
                 "error_type": type(e).__name__,
             }
 
 
 async def create_dremio_client(
-    host: Optional[str] = None,
+    host: str | None = None,
     port: int = 9047,
-    username: Optional[str] = None,
-    password: Optional[str] = None,
-    token: Optional[str] = None,
-    pat: Optional[str] = None,
-    uri: Optional[str] = None,
+    username: str | None = None,
+    password: str | None = None,
+    token: str | None = None,
+    pat: str | None = None,
+    uri: str | None = None,
     ssl: bool = True,
 ) -> DremioClient:
     """Create and authenticate Dremio client.

--- a/src/drivers/__init__.py
+++ b/src/drivers/__init__.py
@@ -25,20 +25,20 @@ from .registry import (
 from .snowflake import SnowflakeDriver
 
 __all__ = [
-    "DatabaseDriver",
     # Registry (single source of truth for db_type -> driver/dialect)
     "DATABASE_REGISTRY",
+    "BigQueryDriver",
+    "ClickHouseDriver",
+    "DatabaseDriver",
+    "DatabricksDriver",
+    "DremioDriver",
     "DriverMeta",
-    "dialect_for",
-    "get_driver_class",
-    "supported_db_types",
+    "DuckDBDriver",
+    "MySQLDriver",
     # Concrete drivers
     "PostgreSQLDriver",
     "SnowflakeDriver",
-    "ClickHouseDriver",
-    "DremioDriver",
-    "BigQueryDriver",
-    "DuckDBDriver",
-    "DatabricksDriver",
-    "MySQLDriver",
+    "dialect_for",
+    "get_driver_class",
+    "supported_db_types",
 ]

--- a/src/drivers/base.py
+++ b/src/drivers/base.py
@@ -1,7 +1,7 @@
 """Abstract base class for database drivers."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from ..database_manager import TableInfo
 
@@ -31,23 +31,23 @@ class DatabaseDriver(ABC):
         """
 
     @abstractmethod
-    def get_schemas(self) -> List[str]:
+    def get_schemas(self) -> list[str]:
         """Return a list of user-visible schema names."""
 
     @abstractmethod
-    def get_tables(self, schema_name: Optional[str] = None) -> List[str]:
+    def get_tables(self, schema_name: str | None = None) -> list[str]:
         """Return a list of table names in the given schema."""
 
     @abstractmethod
     def analyze_table(
-        self, table_name: str, schema_name: Optional[str] = None
-    ) -> Optional[TableInfo]:
+        self, table_name: str, schema_name: str | None = None
+    ) -> TableInfo | None:
         """Analyze a table and return its metadata."""
 
     @abstractmethod
     def validate_sql_syntax(
-        self, sql_query: str, validation_result: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, sql_query: str, validation_result: dict[str, Any]
+    ) -> dict[str, Any]:
         """Perform database-level SQL syntax validation.
 
         Args:
@@ -61,16 +61,16 @@ class DatabaseDriver(ABC):
         """
 
     @abstractmethod
-    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> Dict[str, Any]:
+    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> dict[str, Any]:
         """Execute a SQL query and return structured results."""
 
     @abstractmethod
     def sample_table_data(
         self,
         table_name: str,
-        schema_name: Optional[str] = None,
+        schema_name: str | None = None,
         limit: int = 10,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Return sample rows from a table."""
 
     @abstractmethod

--- a/src/drivers/bigquery.py
+++ b/src/drivers/bigquery.py
@@ -1,7 +1,7 @@
 """Google BigQuery database driver."""
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from sqlalchemy import MetaData, create_engine, inspect, text
 from sqlalchemy.engine import Engine
@@ -38,13 +38,13 @@ class BigQueryDriver(DatabaseDriver):
     db_type = "bigquery"
 
     def __init__(self, pool_size: int = 5, max_overflow: int = 10):
-        self.engine: Optional[Engine] = None
-        self.metadata: Optional[MetaData] = None
+        self.engine: Engine | None = None
+        self.metadata: MetaData | None = None
         self._pool_size = pool_size
         self._max_overflow = max_overflow
         self._credential_manager = SecureCredentialManager()
-        self._project_id: Optional[str] = None
-        self._dataset: Optional[str] = None
+        self._project_id: str | None = None
+        self._dataset: str | None = None
 
     # ------------------------------------------------------------------
     # Connection
@@ -144,7 +144,7 @@ class BigQueryDriver(DatabaseDriver):
     # Schema introspection
     # ------------------------------------------------------------------
 
-    def get_schemas(self) -> List[str]:
+    def get_schemas(self) -> list[str]:
         """Get datasets in the BigQuery project.
 
         In BigQuery terminology, datasets are equivalent to schemas.
@@ -167,7 +167,7 @@ class BigQueryDriver(DatabaseDriver):
             logger.error(f"Failed to get BigQuery datasets: {e}")
             return []
 
-    def get_tables(self, schema_name: Optional[str] = None) -> List[str]:
+    def get_tables(self, schema_name: str | None = None) -> list[str]:
         """Get tables in a dataset.
 
         Args:
@@ -196,8 +196,8 @@ class BigQueryDriver(DatabaseDriver):
             return []
 
     def analyze_table(
-        self, table_name: str, schema_name: Optional[str] = None
-    ) -> Optional[TableInfo]:
+        self, table_name: str, schema_name: str | None = None
+    ) -> TableInfo | None:
         """Analyze a BigQuery table and return its metadata.
 
         BigQuery doesn't support traditional foreign keys, so FK detection is limited.
@@ -221,8 +221,8 @@ class BigQueryDriver(DatabaseDriver):
 
                 # BigQuery doesn't have traditional primary keys or foreign keys
                 # but we can check for clustering/partitioning
-                primary_keys: List[str] = []
-                foreign_keys: List[Dict[str, Any]] = []
+                primary_keys: list[str] = []
+                foreign_keys: list[dict[str, Any]] = []
 
                 columns = []
                 for col_info in table_columns:
@@ -266,8 +266,8 @@ class BigQueryDriver(DatabaseDriver):
     # ------------------------------------------------------------------
 
     def validate_sql_syntax(
-        self, sql_query: str, validation_result: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, sql_query: str, validation_result: dict[str, Any]
+    ) -> dict[str, Any]:
         """Validate BigQuery SQL syntax using dry run."""
         try:
             assert self.engine is not None
@@ -307,11 +307,11 @@ class BigQueryDriver(DatabaseDriver):
 
         return validation_result
 
-    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> Dict[str, Any]:
+    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> dict[str, Any]:
         """Execute BigQuery SQL query."""
         import time as time_mod
 
-        result_data: Dict[str, Any] = {
+        result_data: dict[str, Any] = {
             "success": False,
             "data": [],
             "columns": [],
@@ -372,7 +372,7 @@ class BigQueryDriver(DatabaseDriver):
             result_data["error_type"] = "execution_error"
             logger.error(f"BigQuery SQL execution failed: {e}")
         except Exception as e:
-            result_data["error"] = f"Unexpected execution error: {str(e)}"
+            result_data["error"] = f"Unexpected execution error: {e!s}"
             result_data["error_type"] = "internal_error"
             logger.error(f"Unexpected BigQuery SQL execution error: {e}")
 
@@ -381,9 +381,9 @@ class BigQueryDriver(DatabaseDriver):
     def sample_table_data(
         self,
         table_name: str,
-        schema_name: Optional[str] = None,
+        schema_name: str | None = None,
         limit: int = DEFAULT_SAMPLE_LIMIT,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Sample data from a BigQuery table."""
         if not isinstance(limit, int) or limit < MIN_SAMPLE_LIMIT:
             limit = DEFAULT_SAMPLE_LIMIT

--- a/src/drivers/clickhouse.py
+++ b/src/drivers/clickhouse.py
@@ -1,7 +1,7 @@
 """ClickHouse database driver."""
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 from urllib.parse import quote_plus
 
 from sqlalchemy import MetaData, create_engine, inspect, text
@@ -29,8 +29,8 @@ class ClickHouseDriver(DatabaseDriver):
     db_type = "clickhouse"
 
     def __init__(self, pool_size: int = 5, max_overflow: int = 10):
-        self.engine: Optional[Engine] = None
-        self.metadata: Optional[MetaData] = None
+        self.engine: Engine | None = None
+        self.metadata: MetaData | None = None
         self._pool_size = pool_size
         self._max_overflow = max_overflow
 
@@ -115,7 +115,7 @@ class ClickHouseDriver(DatabaseDriver):
     # Schema introspection
     # ------------------------------------------------------------------
 
-    def get_schemas(self) -> List[str]:
+    def get_schemas(self) -> list[str]:
         excluded_schemas = "', '".join(CLICKHOUSE_SYSTEM_SCHEMAS)
         query = text(
             f"""
@@ -134,7 +134,7 @@ class ClickHouseDriver(DatabaseDriver):
             logger.error(f"Failed to get schemas: {e}")
             return []
 
-    def get_tables(self, schema_name: Optional[str] = None) -> List[str]:
+    def get_tables(self, schema_name: str | None = None) -> list[str]:
         try:
             assert self.engine is not None
             with self.engine.connect() as conn:
@@ -176,8 +176,8 @@ class ClickHouseDriver(DatabaseDriver):
     def analyze_table(
         self,
         table_name: str,
-        schema_name: Optional[str] = None,
-    ) -> Optional[TableInfo]:
+        schema_name: str | None = None,
+    ) -> TableInfo | None:
         try:
             assert self.engine is not None
             with self.engine.connect() as conn:
@@ -218,7 +218,7 @@ class ClickHouseDriver(DatabaseDriver):
                         logger.info(f"  FK: {fk}")
 
                 columns = []
-                foreign_keys: List[Dict[str, Any]] = []
+                foreign_keys: list[dict[str, Any]] = []
                 for col_info in table_columns:
                     column_name = col_info["name"]
                     is_pk = column_name.upper() in primary_keys_upper
@@ -331,8 +331,8 @@ class ClickHouseDriver(DatabaseDriver):
     # ------------------------------------------------------------------
 
     def validate_sql_syntax(
-        self, sql_query: str, validation_result: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, sql_query: str, validation_result: dict[str, Any]
+    ) -> dict[str, Any]:
         try:
             assert self.engine is not None
             with self.engine.connect() as conn:
@@ -374,10 +374,10 @@ class ClickHouseDriver(DatabaseDriver):
 
         return validation_result
 
-    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> Dict[str, Any]:
+    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> dict[str, Any]:
         import time as time_mod
 
-        result_data: Dict[str, Any] = {
+        result_data: dict[str, Any] = {
             "success": False,
             "data": [],
             "columns": [],
@@ -438,7 +438,7 @@ class ClickHouseDriver(DatabaseDriver):
             result_data["error_type"] = "execution_error"
             logger.error(f"SQL execution failed: {e}")
         except Exception as e:
-            result_data["error"] = f"Unexpected execution error: {str(e)}"
+            result_data["error"] = f"Unexpected execution error: {e!s}"
             result_data["error_type"] = "internal_error"
             logger.error(f"Unexpected SQL execution error: {e}")
 
@@ -447,9 +447,9 @@ class ClickHouseDriver(DatabaseDriver):
     def sample_table_data(
         self,
         table_name: str,
-        schema_name: Optional[str] = None,
+        schema_name: str | None = None,
         limit: int = DEFAULT_SAMPLE_LIMIT,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         if not isinstance(limit, int) or limit < MIN_SAMPLE_LIMIT:
             limit = DEFAULT_SAMPLE_LIMIT
         elif limit > MAX_SAMPLE_LIMIT:

--- a/src/drivers/databricks.py
+++ b/src/drivers/databricks.py
@@ -1,7 +1,7 @@
 """Databricks SQL database driver."""
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 from urllib.parse import quote_plus
 
 from sqlalchemy import MetaData, create_engine, inspect, text
@@ -46,15 +46,15 @@ class DatabricksDriver(DatabaseDriver):
     db_type = "databricks"
 
     def __init__(self, pool_size: int = 5, max_overflow: int = 10):
-        self.engine: Optional[Engine] = None
-        self.metadata: Optional[MetaData] = None
+        self.engine: Engine | None = None
+        self.metadata: MetaData | None = None
         self._pool_size = pool_size
         self._max_overflow = max_overflow
         self._credential_manager = SecureCredentialManager()
-        self._server_hostname: Optional[str] = None
-        self._http_path: Optional[str] = None
-        self._catalog: Optional[str] = None
-        self._schema: Optional[str] = None
+        self._server_hostname: str | None = None
+        self._http_path: str | None = None
+        self._catalog: str | None = None
+        self._schema: str | None = None
 
     # ------------------------------------------------------------------
     # Connection
@@ -166,7 +166,7 @@ class DatabricksDriver(DatabaseDriver):
     # Schema introspection
     # ------------------------------------------------------------------
 
-    def get_schemas(self) -> List[str]:
+    def get_schemas(self) -> list[str]:
         """Get schemas (databases) in the Databricks catalog.
 
         In Databricks Unity Catalog, schemas are also known as databases.
@@ -204,7 +204,7 @@ class DatabricksDriver(DatabaseDriver):
                 logger.error(f"Fallback schema query also failed: {fallback_error}")
                 return []
 
-    def get_tables(self, schema_name: Optional[str] = None) -> List[str]:
+    def get_tables(self, schema_name: str | None = None) -> list[str]:
         """Get tables in a schema."""
         try:
             schema = schema_name or self._schema
@@ -246,8 +246,8 @@ class DatabricksDriver(DatabaseDriver):
                 return []
 
     def analyze_table(
-        self, table_name: str, schema_name: Optional[str] = None
-    ) -> Optional[TableInfo]:
+        self, table_name: str, schema_name: str | None = None
+    ) -> TableInfo | None:
         """Analyze a Databricks table and return its metadata.
 
         Databricks Unity Catalog supports primary keys and foreign keys (constraints),
@@ -285,7 +285,7 @@ class DatabricksDriver(DatabaseDriver):
                 )
 
                 columns = []
-                foreign_keys: List[Dict[str, Any]] = []
+                foreign_keys: list[dict[str, Any]] = []
                 for col_info in table_columns:
                     column_name = col_info["name"]
                     is_pk = column_name.upper() in primary_keys_upper
@@ -352,8 +352,8 @@ class DatabricksDriver(DatabaseDriver):
     # ------------------------------------------------------------------
 
     def validate_sql_syntax(
-        self, sql_query: str, validation_result: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, sql_query: str, validation_result: dict[str, Any]
+    ) -> dict[str, Any]:
         """Validate Databricks SQL syntax using EXPLAIN."""
         try:
             assert self.engine is not None
@@ -395,11 +395,11 @@ class DatabricksDriver(DatabaseDriver):
 
         return validation_result
 
-    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> Dict[str, Any]:
+    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> dict[str, Any]:
         """Execute Databricks SQL query."""
         import time as time_mod
 
-        result_data: Dict[str, Any] = {
+        result_data: dict[str, Any] = {
             "success": False,
             "data": [],
             "columns": [],
@@ -460,7 +460,7 @@ class DatabricksDriver(DatabaseDriver):
             result_data["error_type"] = "execution_error"
             logger.error(f"Databricks SQL execution failed: {e}")
         except Exception as e:
-            result_data["error"] = f"Unexpected execution error: {str(e)}"
+            result_data["error"] = f"Unexpected execution error: {e!s}"
             result_data["error_type"] = "internal_error"
             logger.error(f"Unexpected Databricks SQL execution error: {e}")
 
@@ -469,9 +469,9 @@ class DatabricksDriver(DatabaseDriver):
     def sample_table_data(
         self,
         table_name: str,
-        schema_name: Optional[str] = None,
+        schema_name: str | None = None,
         limit: int = DEFAULT_SAMPLE_LIMIT,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Sample data from a Databricks table."""
         if not isinstance(limit, int) or limit < MIN_SAMPLE_LIMIT:
             limit = DEFAULT_SAMPLE_LIMIT

--- a/src/drivers/dremio.py
+++ b/src/drivers/dremio.py
@@ -1,7 +1,8 @@
 """Dremio database driver (REST API)."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Coroutine, Dict, List, Optional, Set
+from collections.abc import Coroutine
+from typing import TYPE_CHECKING, Any
 
 from ..async_utils import run_async
 from ..constants import (
@@ -27,7 +28,7 @@ class DremioDriver(DatabaseDriver):
     db_type = "dremio"
 
     def __init__(self) -> None:
-        self._rest_connection: Optional[Dict[str, Any]] = None
+        self._rest_connection: dict[str, Any] | None = None
 
     # ------------------------------------------------------------------
     # Dremio client factory (replaces 8 duplicated patterns)
@@ -68,7 +69,7 @@ class DremioDriver(DatabaseDriver):
         return value.replace("'", "''")
 
     @staticmethod
-    def _quote_dremio_identifier(identifier: Optional[str]) -> str:
+    def _quote_dremio_identifier(identifier: str | None) -> str:
         """Quote and escape a Dremio identifier or path safely."""
         if identifier is None:
             return ""
@@ -132,7 +133,7 @@ class DremioDriver(DatabaseDriver):
                 }
 
             # Test connection via factory
-            async def test_dremio_connection() -> Dict[str, Any]:
+            async def test_dremio_connection() -> dict[str, Any]:
                 async with await self._create_dremio_client() as client:
                     return await client.test_connection()
 
@@ -179,12 +180,12 @@ class DremioDriver(DatabaseDriver):
     # Schema introspection
     # ------------------------------------------------------------------
 
-    def get_schemas(self) -> List[str]:
-        async def fetch_schemas() -> List[str]:
+    def get_schemas(self) -> list[str]:
+        async def fetch_schemas() -> list[str]:
             try:
                 async with await self._create_dremio_client() as client:
                     catalogs = await client.get_catalogs()
-                    schemas: Set[str] = set()
+                    schemas: set[str] = set()
 
                     logger.debug(f"Dremio catalogs response: {catalogs}")
 
@@ -225,7 +226,7 @@ class DremioDriver(DatabaseDriver):
                             ):
                                 schemas.add(catalog_name)
 
-                    schema_list = sorted(list(schemas))
+                    schema_list = sorted(schemas)
 
                     if not schema_list:
                         logger.info("No catalogs found, using default Dremio spaces")
@@ -246,8 +247,8 @@ class DremioDriver(DatabaseDriver):
     async def _add_dremio_children_recursive(
         self,
         client: "DremioClient",
-        path: List[str],
-        schemas: Set[str],
+        path: list[str],
+        schemas: set[str],
         max_depth: int = 3,
         current_depth: int = 0,
     ) -> None:
@@ -304,8 +305,8 @@ class DremioDriver(DatabaseDriver):
         except Exception as e:
             logger.warning(f"Failed to get children for path {'.'.join(path)}: {e}")
 
-    def get_tables(self, schema_name: Optional[str] = None) -> List[str]:
-        async def fetch_tables() -> List[str]:
+    def get_tables(self, schema_name: str | None = None) -> list[str]:
+        async def fetch_tables() -> list[str]:
             try:
                 async with await self._create_dremio_client() as client:
                     if not schema_name:
@@ -339,7 +340,7 @@ class DremioDriver(DatabaseDriver):
                                     )
                             if table_name:
                                 tables.append(table_name)
-                        return sorted(list(set(tables)))
+                        return sorted(set(tables))
                     else:
                         logger.error(
                             f"Failed to get Dremio tables: {result.get('error')}"
@@ -353,9 +354,9 @@ class DremioDriver(DatabaseDriver):
         return run_async(fetch_tables(), timeout=CONNECTION_TIMEOUT)
 
     def analyze_table(
-        self, table_name: str, schema_name: Optional[str] = None
-    ) -> Optional[TableInfo]:
-        async def fetch_table_info() -> Optional[TableInfo]:
+        self, table_name: str, schema_name: str | None = None
+    ) -> TableInfo | None:
+        async def fetch_table_info() -> TableInfo | None:
             try:
                 nonlocal table_name, schema_name
                 async with await self._create_dremio_client() as client:
@@ -429,9 +430,9 @@ class DremioDriver(DatabaseDriver):
     # ------------------------------------------------------------------
 
     def validate_sql_syntax(
-        self, sql_query: str, validation_result: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        async def validate_query() -> Dict[str, Any]:
+        self, sql_query: str, validation_result: dict[str, Any]
+    ) -> dict[str, Any]:
+        async def validate_query() -> dict[str, Any]:
             try:
                 async with await self._create_dremio_client() as client:
                     explain_sql = f"EXPLAIN PLAN FOR {sql_query}"
@@ -476,14 +477,14 @@ class DremioDriver(DatabaseDriver):
         except Exception as e:
             validation_result["is_valid"] = True
             validation_result["warnings"].append(
-                f"Could not validate syntax via Dremio: {str(e)}"
+                f"Could not validate syntax via Dremio: {e!s}"
             )
             return validation_result
 
-    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> Dict[str, Any]:
+    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> dict[str, Any]:
         import time as time_mod
 
-        result_data: Dict[str, Any] = {
+        result_data: dict[str, Any] = {
             "success": False,
             "data": [],
             "columns": [],
@@ -498,7 +499,7 @@ class DremioDriver(DatabaseDriver):
         try:
             start_time = time_mod.time()
 
-            async def run_dremio_query() -> Dict[str, Any]:
+            async def run_dremio_query() -> dict[str, Any]:
                 async with await self._create_dremio_client() as client:
                     return await client.execute_query(sql_query, limit)
 
@@ -533,7 +534,7 @@ class DremioDriver(DatabaseDriver):
                 logger.error(f"Dremio query failed: {result_data['error']}")
 
         except Exception as e:
-            result_data["error"] = f"Dremio execution error: {str(e)}"
+            result_data["error"] = f"Dremio execution error: {e!s}"
             result_data["error_type"] = "dremio_connection_error"
             logger.error(f"Dremio query execution failed: {e}")
 
@@ -542,16 +543,16 @@ class DremioDriver(DatabaseDriver):
     def sample_table_data(
         self,
         table_name: str,
-        schema_name: Optional[str] = None,
+        schema_name: str | None = None,
         limit: int = DEFAULT_SAMPLE_LIMIT,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         if not isinstance(limit, int) or limit < MIN_SAMPLE_LIMIT:
             limit = DEFAULT_SAMPLE_LIMIT
         elif limit > MAX_SAMPLE_LIMIT:
             limit = MAX_SAMPLE_LIMIT
             logger.warning(f"Sample limit capped at {MAX_SAMPLE_LIMIT}")
 
-        async def fetch_sample() -> List[Dict[str, Any]]:
+        async def fetch_sample() -> list[dict[str, Any]]:
             try:
                 async with await self._create_dremio_client() as client:
                     if schema_name:
@@ -566,7 +567,7 @@ class DremioDriver(DatabaseDriver):
                     result = await client.execute_query(query, limit)
 
                     if result.get("success"):
-                        sample_rows: List[Dict[str, Any]] = result.get("data", [])
+                        sample_rows: list[dict[str, Any]] = result.get("data", [])
                         return sample_rows
                     else:
                         error_msg = result.get("error", "Unknown error")
@@ -580,7 +581,7 @@ class DremioDriver(DatabaseDriver):
 
             except Exception as e:
                 logger.error(f"Error sampling Dremio table {table_name}: {e}")
-                raise RuntimeError(f"Error sampling Dremio table: {str(e)}")
+                raise RuntimeError(f"Error sampling Dremio table: {e!s}")
 
         return run_async(fetch_sample(), timeout=CONNECTION_TIMEOUT)
 
@@ -592,7 +593,7 @@ class DremioDriver(DatabaseDriver):
         if not self._rest_connection:
             return False
 
-        async def test_dremio() -> Dict[str, Any]:
+        async def test_dremio() -> dict[str, Any]:
             async with await self._create_dremio_client() as client:
                 return await client.test_connection()
 

--- a/src/drivers/duckdb.py
+++ b/src/drivers/duckdb.py
@@ -1,7 +1,7 @@
 """DuckDB/MotherDuck database driver."""
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from sqlalchemy import MetaData, create_engine, inspect, text
 from sqlalchemy.engine import Engine
@@ -42,12 +42,12 @@ class DuckDBDriver(DatabaseDriver):
     db_type = "duckdb"
 
     def __init__(self, pool_size: int = 5, max_overflow: int = 10):
-        self.engine: Optional[Engine] = None
-        self.metadata: Optional[MetaData] = None
+        self.engine: Engine | None = None
+        self.metadata: MetaData | None = None
         self._pool_size = pool_size
         self._max_overflow = max_overflow
         self._credential_manager = SecureCredentialManager()
-        self._database_path: Optional[str] = None
+        self._database_path: str | None = None
         self._is_motherduck: bool = False
 
     # ------------------------------------------------------------------
@@ -82,17 +82,16 @@ class DuckDBDriver(DatabaseDriver):
                     connection_string = "duckdb:///md:"
 
                 database_name = database_path[3:]  # Remove "md:" prefix
-                if database_name:
-                    if not identifier_validator.validate_identifier(database_name):
-                        audit_log_security_event(
-                            "invalid_identifier_attempt",
-                            {"identifier": database_name[:50]},
-                            SecurityLevel.MEDIUM,
-                        )
-                        logger.error(
-                            f"Invalid MotherDuck database name: {database_name}"
-                        )
-                        return False
+                if database_name and not identifier_validator.validate_identifier(
+                    database_name
+                ):
+                    audit_log_security_event(
+                        "invalid_identifier_attempt",
+                        {"identifier": database_name[:50]},
+                        SecurityLevel.MEDIUM,
+                    )
+                    logger.error(f"Invalid MotherDuck database name: {database_name}")
+                    return False
             else:
                 # Local DuckDB connection
                 if database_path == ":memory:":
@@ -104,10 +103,7 @@ class DuckDBDriver(DatabaseDriver):
 
             # DuckDB uses StaticPool for in-memory, NullPool for file-based
             poolclass: type[Pool]
-            if database_path == ":memory:":
-                poolclass = StaticPool
-            else:
-                poolclass = NullPool
+            poolclass = StaticPool if database_path == ":memory:" else NullPool
 
             self.engine = create_engine(
                 connection_string,
@@ -157,7 +153,7 @@ class DuckDBDriver(DatabaseDriver):
     # Schema introspection
     # ------------------------------------------------------------------
 
-    def get_schemas(self) -> List[str]:
+    def get_schemas(self) -> list[str]:
         """Get schemas in DuckDB database.
 
         DuckDB uses 'main' as the default schema. Additional schemas can be created
@@ -185,7 +181,7 @@ class DuckDBDriver(DatabaseDriver):
             logger.error(f"Failed to get DuckDB schemas: {e}")
             return ["main"]  # Return default schema on error
 
-    def get_tables(self, schema_name: Optional[str] = None) -> List[str]:
+    def get_tables(self, schema_name: str | None = None) -> list[str]:
         """Get tables in a schema."""
         try:
             schema = schema_name or "main"
@@ -208,8 +204,8 @@ class DuckDBDriver(DatabaseDriver):
             return []
 
     def analyze_table(
-        self, table_name: str, schema_name: Optional[str] = None
-    ) -> Optional[TableInfo]:
+        self, table_name: str, schema_name: str | None = None
+    ) -> TableInfo | None:
         """Analyze a DuckDB table and return its metadata."""
         try:
             schema = schema_name or "main"
@@ -238,7 +234,7 @@ class DuckDBDriver(DatabaseDriver):
                 )
 
                 columns = []
-                foreign_keys: List[Dict[str, Any]] = []
+                foreign_keys: list[dict[str, Any]] = []
                 for col_info in table_columns:
                     column_name = col_info["name"]
                     is_pk = column_name.upper() in primary_keys_upper
@@ -305,8 +301,8 @@ class DuckDBDriver(DatabaseDriver):
     # ------------------------------------------------------------------
 
     def validate_sql_syntax(
-        self, sql_query: str, validation_result: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, sql_query: str, validation_result: dict[str, Any]
+    ) -> dict[str, Any]:
         """Validate DuckDB SQL syntax using EXPLAIN."""
         try:
             assert self.engine is not None
@@ -338,11 +334,11 @@ class DuckDBDriver(DatabaseDriver):
 
         return validation_result
 
-    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> Dict[str, Any]:
+    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> dict[str, Any]:
         """Execute DuckDB SQL query."""
         import time as time_mod
 
-        result_data: Dict[str, Any] = {
+        result_data: dict[str, Any] = {
             "success": False,
             "data": [],
             "columns": [],
@@ -404,7 +400,7 @@ class DuckDBDriver(DatabaseDriver):
             result_data["error_type"] = "execution_error"
             logger.error(f"DuckDB SQL execution failed: {e}")
         except Exception as e:
-            result_data["error"] = f"Unexpected execution error: {str(e)}"
+            result_data["error"] = f"Unexpected execution error: {e!s}"
             result_data["error_type"] = "internal_error"
             logger.error(f"Unexpected DuckDB SQL execution error: {e}")
 
@@ -413,9 +409,9 @@ class DuckDBDriver(DatabaseDriver):
     def sample_table_data(
         self,
         table_name: str,
-        schema_name: Optional[str] = None,
+        schema_name: str | None = None,
         limit: int = DEFAULT_SAMPLE_LIMIT,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Sample data from a DuckDB table."""
         if not isinstance(limit, int) or limit < MIN_SAMPLE_LIMIT:
             limit = DEFAULT_SAMPLE_LIMIT

--- a/src/drivers/mysql.py
+++ b/src/drivers/mysql.py
@@ -5,7 +5,7 @@ MySQL 5.7 reached EOL in October 2023 and is not supported.
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 from urllib.parse import quote_plus
 
 from sqlalchemy import MetaData, create_engine, inspect, text
@@ -39,8 +39,8 @@ class MySQLDriver(DatabaseDriver):
     db_type = "mysql"
 
     def __init__(self, pool_size: int = 5, max_overflow: int = 10):
-        self.engine: Optional[Engine] = None
-        self.metadata: Optional[MetaData] = None
+        self.engine: Engine | None = None
+        self.metadata: MetaData | None = None
         self._pool_size = pool_size
         self._max_overflow = max_overflow
         self._credential_manager = SecureCredentialManager()
@@ -133,7 +133,7 @@ class MySQLDriver(DatabaseDriver):
     # Schema introspection
     # ------------------------------------------------------------------
 
-    def get_schemas(self) -> List[str]:
+    def get_schemas(self) -> list[str]:
         excluded_schemas = "', '".join(MYSQL_SYSTEM_SCHEMAS)
         query = text(
             f"""
@@ -152,7 +152,7 @@ class MySQLDriver(DatabaseDriver):
             logger.error(f"Failed to get schemas: {e}")
             return []
 
-    def get_tables(self, schema_name: Optional[str] = None) -> List[str]:
+    def get_tables(self, schema_name: str | None = None) -> list[str]:
         try:
             assert self.engine is not None
             with self.engine.connect() as conn:
@@ -183,8 +183,8 @@ class MySQLDriver(DatabaseDriver):
             return []
 
     def analyze_table(
-        self, table_name: str, schema_name: Optional[str] = None
-    ) -> Optional[TableInfo]:
+        self, table_name: str, schema_name: str | None = None
+    ) -> TableInfo | None:
         try:
             assert self.engine is not None
             with self.engine.connect():
@@ -225,7 +225,7 @@ class MySQLDriver(DatabaseDriver):
                         logger.info(f"  FK: {fk}")
 
                 columns = []
-                foreign_keys: List[Dict[str, Any]] = []
+                foreign_keys: list[dict[str, Any]] = []
                 for col_info in table_columns:
                     column_name = col_info["name"]
                     is_pk = column_name.upper() in primary_keys_upper
@@ -296,8 +296,8 @@ class MySQLDriver(DatabaseDriver):
     # ------------------------------------------------------------------
 
     def validate_sql_syntax(
-        self, sql_query: str, validation_result: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, sql_query: str, validation_result: dict[str, Any]
+    ) -> dict[str, Any]:
         try:
             assert self.engine is not None
             with self.engine.connect() as conn:
@@ -335,11 +335,11 @@ class MySQLDriver(DatabaseDriver):
 
         return validation_result
 
-    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> Dict[str, Any]:
+    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> dict[str, Any]:
         """Execute query - delegated from DatabaseManager which handles validation."""
         import time as time_mod
 
-        result_data: Dict[str, Any] = {
+        result_data: dict[str, Any] = {
             "success": False,
             "data": [],
             "columns": [],
@@ -401,7 +401,7 @@ class MySQLDriver(DatabaseDriver):
             result_data["error_type"] = "execution_error"
             logger.error(f"SQL execution failed: {e}")
         except Exception as e:
-            result_data["error"] = f"Unexpected execution error: {str(e)}"
+            result_data["error"] = f"Unexpected execution error: {e!s}"
             result_data["error_type"] = "internal_error"
             logger.error(f"Unexpected SQL execution error: {e}")
 
@@ -410,9 +410,9 @@ class MySQLDriver(DatabaseDriver):
     def sample_table_data(
         self,
         table_name: str,
-        schema_name: Optional[str] = None,
+        schema_name: str | None = None,
         limit: int = DEFAULT_SAMPLE_LIMIT,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         if not isinstance(limit, int) or limit < MIN_SAMPLE_LIMIT:
             limit = DEFAULT_SAMPLE_LIMIT
         elif limit > MAX_SAMPLE_LIMIT:

--- a/src/drivers/postgresql.py
+++ b/src/drivers/postgresql.py
@@ -1,7 +1,7 @@
 """PostgreSQL database driver."""
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 from urllib.parse import quote_plus
 
 from sqlalchemy import MetaData, create_engine, inspect, text
@@ -35,8 +35,8 @@ class PostgreSQLDriver(DatabaseDriver):
     db_type = "postgresql"
 
     def __init__(self, pool_size: int = 5, max_overflow: int = 10):
-        self.engine: Optional[Engine] = None
-        self.metadata: Optional[MetaData] = None
+        self.engine: Engine | None = None
+        self.metadata: MetaData | None = None
         self._pool_size = pool_size
         self._max_overflow = max_overflow
         self._credential_manager = SecureCredentialManager()
@@ -131,7 +131,7 @@ class PostgreSQLDriver(DatabaseDriver):
     # Schema introspection
     # ------------------------------------------------------------------
 
-    def get_schemas(self) -> List[str]:
+    def get_schemas(self) -> list[str]:
         excluded_schemas = "', '".join(POSTGRES_SYSTEM_SCHEMAS)
         query = text(
             f"""
@@ -152,7 +152,7 @@ class PostgreSQLDriver(DatabaseDriver):
             logger.error(f"Failed to get schemas: {e}")
             return []
 
-    def get_tables(self, schema_name: Optional[str] = None) -> List[str]:
+    def get_tables(self, schema_name: str | None = None) -> list[str]:
         try:
             assert self.engine is not None
             with self.engine.connect() as conn:
@@ -183,8 +183,8 @@ class PostgreSQLDriver(DatabaseDriver):
             return []
 
     def analyze_table(
-        self, table_name: str, schema_name: Optional[str] = None
-    ) -> Optional[TableInfo]:
+        self, table_name: str, schema_name: str | None = None
+    ) -> TableInfo | None:
         try:
             assert self.engine is not None
             with self.engine.connect():
@@ -225,7 +225,7 @@ class PostgreSQLDriver(DatabaseDriver):
                         logger.info(f"  FK: {fk}")
 
                 columns = []
-                foreign_keys: List[Dict[str, Any]] = []
+                foreign_keys: list[dict[str, Any]] = []
                 for col_info in table_columns:
                     column_name = col_info["name"]
                     is_pk = column_name.upper() in primary_keys_upper
@@ -296,8 +296,8 @@ class PostgreSQLDriver(DatabaseDriver):
     # ------------------------------------------------------------------
 
     def validate_sql_syntax(
-        self, sql_query: str, validation_result: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, sql_query: str, validation_result: dict[str, Any]
+    ) -> dict[str, Any]:
         try:
             assert self.engine is not None
             with self.engine.connect() as conn:
@@ -337,11 +337,11 @@ class PostgreSQLDriver(DatabaseDriver):
 
         return validation_result
 
-    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> Dict[str, Any]:
+    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> dict[str, Any]:
         """Execute query - delegated from DatabaseManager which handles validation."""
         import time as time_mod
 
-        result_data: Dict[str, Any] = {
+        result_data: dict[str, Any] = {
             "success": False,
             "data": [],
             "columns": [],
@@ -403,7 +403,7 @@ class PostgreSQLDriver(DatabaseDriver):
             result_data["error_type"] = "execution_error"
             logger.error(f"SQL execution failed: {e}")
         except Exception as e:
-            result_data["error"] = f"Unexpected execution error: {str(e)}"
+            result_data["error"] = f"Unexpected execution error: {e!s}"
             result_data["error_type"] = "internal_error"
             logger.error(f"Unexpected SQL execution error: {e}")
 
@@ -412,9 +412,9 @@ class PostgreSQLDriver(DatabaseDriver):
     def sample_table_data(
         self,
         table_name: str,
-        schema_name: Optional[str] = None,
+        schema_name: str | None = None,
         limit: int = DEFAULT_SAMPLE_LIMIT,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         if not isinstance(limit, int) or limit < MIN_SAMPLE_LIMIT:
             limit = DEFAULT_SAMPLE_LIMIT
         elif limit > MAX_SAMPLE_LIMIT:

--- a/src/drivers/registry.py
+++ b/src/drivers/registry.py
@@ -14,7 +14,6 @@ top.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Type
 
 from ..constants import DB_SQLGLOT_DIALECTS
 from .base import DatabaseDriver
@@ -33,13 +32,13 @@ class DriverMeta:
     """Metadata describing one supported database."""
 
     db_type: str
-    driver_cls: Type[DatabaseDriver]
+    driver_cls: type[DatabaseDriver]
     dialect: str  # sqlglot dialect name
 
 
 # Map of db_type -> driver class. The single place the driver classes are
 # enumerated; everything else derives from this plus DB_SQLGLOT_DIALECTS.
-_DRIVER_CLASSES: Dict[str, Type[DatabaseDriver]] = {
+_DRIVER_CLASSES: dict[str, type[DatabaseDriver]] = {
     "postgresql": PostgreSQLDriver,
     "snowflake": SnowflakeDriver,
     "dremio": DremioDriver,
@@ -50,7 +49,7 @@ _DRIVER_CLASSES: Dict[str, Type[DatabaseDriver]] = {
     "mysql": MySQLDriver,
 }
 
-DATABASE_REGISTRY: Dict[str, DriverMeta] = {
+DATABASE_REGISTRY: dict[str, DriverMeta] = {
     db_type: DriverMeta(
         db_type=db_type,
         driver_cls=driver_cls,
@@ -60,12 +59,12 @@ DATABASE_REGISTRY: Dict[str, DriverMeta] = {
 }
 
 
-def supported_db_types() -> List[str]:
+def supported_db_types() -> list[str]:
     """Return the supported db_type identifiers, in registration order."""
     return list(DATABASE_REGISTRY)
 
 
-def get_driver_class(db_type: str) -> Type[DatabaseDriver]:
+def get_driver_class(db_type: str) -> type[DatabaseDriver]:
     """Return the driver class for ``db_type``.
 
     Args:

--- a/src/drivers/snowflake.py
+++ b/src/drivers/snowflake.py
@@ -1,7 +1,8 @@
 """Snowflake database driver."""
 
 import logging
-from typing import Any, Callable, Dict, List, Optional
+from collections.abc import Callable
+from typing import Any
 from urllib.parse import quote_plus
 
 from sqlalchemy import MetaData, create_engine, inspect, text
@@ -29,8 +30,8 @@ class SnowflakeDriver(DatabaseDriver):
     db_type = "snowflake"
 
     def __init__(self, pool_size: int = 5, max_overflow: int = 10):
-        self.engine: Optional[Engine] = None
-        self.metadata: Optional[MetaData] = None
+        self.engine: Engine | None = None
+        self.metadata: MetaData | None = None
         self._pool_size = pool_size
         self._max_overflow = max_overflow
 
@@ -112,7 +113,7 @@ class SnowflakeDriver(DatabaseDriver):
     # Schema introspection
     # ------------------------------------------------------------------
 
-    def get_schemas(self) -> List[str]:
+    def get_schemas(self) -> list[str]:
         excluded_schemas = "', '".join(SNOWFLAKE_SYSTEM_SCHEMAS)
         query = text(
             f"""
@@ -131,7 +132,7 @@ class SnowflakeDriver(DatabaseDriver):
             logger.error(f"Failed to get schemas: {e}")
             return []
 
-    def get_tables(self, schema_name: Optional[str] = None) -> List[str]:
+    def get_tables(self, schema_name: str | None = None) -> list[str]:
         try:
             assert self.engine is not None
             with self.engine.connect() as conn:
@@ -168,7 +169,7 @@ class SnowflakeDriver(DatabaseDriver):
     def prefetch_schema_constraints(
         self,
         schema_name: str,
-        connection_info: Dict[str, Any],
+        connection_info: dict[str, Any],
         cache_get: Callable[..., Any],
         cache_store: Callable[..., Any],
         log_sql: Callable[..., Any],
@@ -205,7 +206,7 @@ class SnowflakeDriver(DatabaseDriver):
             assert self.engine is not None
             with self.engine.connect() as conn:
                 # --- Primary keys ---
-                pk_by_table: Dict[str, List[str]] = {}
+                pk_by_table: dict[str, list[str]] = {}
                 pk_success = False
                 try:
                     pk_query = text(f"SHOW PRIMARY KEYS IN SCHEMA {full_schema_path}")
@@ -230,7 +231,7 @@ class SnowflakeDriver(DatabaseDriver):
                     cache_store(pk_cache_key, pk_by_table)
 
                 # --- Foreign keys ---
-                fk_by_table: Dict[str, List[Dict]] = {}
+                fk_by_table: dict[str, list[dict]] = {}
                 fk_success = False
                 try:
                     fk_query = text(f"SHOW IMPORTED KEYS IN SCHEMA {full_schema_path}")
@@ -269,7 +270,7 @@ class SnowflakeDriver(DatabaseDriver):
 
                 # --- Columns ---
                 cols_cache_key = f"schema_cols:{schema_name}"
-                cols_by_table: Dict[str, List[Dict]] = {}
+                cols_by_table: dict[str, list[dict]] = {}
                 cols_success = False
                 try:
                     cols_query = text(
@@ -324,10 +325,10 @@ class SnowflakeDriver(DatabaseDriver):
     def analyze_table(
         self,
         table_name: str,
-        schema_name: Optional[str] = None,
-        cache_get: Optional[Callable[..., Any]] = None,
-        log_sql: Optional[Callable[..., Any]] = None,
-    ) -> Optional[TableInfo]:
+        schema_name: str | None = None,
+        cache_get: Callable[..., Any] | None = None,
+        log_sql: Callable[..., Any] | None = None,
+    ) -> TableInfo | None:
         """Analyze a Snowflake table.
 
         If ``cache_get`` is provided, uses prefetched constraint data.
@@ -338,7 +339,7 @@ class SnowflakeDriver(DatabaseDriver):
                 inspector = inspect(self.engine)
 
                 table_columns = None
-                primary_keys: List[str] = []
+                primary_keys: list[str] = []
                 table_fks: list = []
 
                 if schema_name and cache_get is not None:
@@ -504,7 +505,7 @@ class SnowflakeDriver(DatabaseDriver):
                         logger.info(f"  FK: {fk}")
 
                 columns = []
-                foreign_keys: List[Dict[str, Any]] = []
+                foreign_keys: list[dict[str, Any]] = []
                 for col_info in table_columns:
                     column_name = col_info["name"]
                     is_pk = column_name.upper() in primary_keys_upper
@@ -575,8 +576,8 @@ class SnowflakeDriver(DatabaseDriver):
     # ------------------------------------------------------------------
 
     def validate_sql_syntax(
-        self, sql_query: str, validation_result: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, sql_query: str, validation_result: dict[str, Any]
+    ) -> dict[str, Any]:
         try:
             assert self.engine is not None
             with self.engine.connect() as conn:
@@ -613,10 +614,10 @@ class SnowflakeDriver(DatabaseDriver):
 
         return validation_result
 
-    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> Dict[str, Any]:
+    def execute_sql_query(self, sql_query: str, limit: int = 1000) -> dict[str, Any]:
         import time as time_mod
 
-        result_data: Dict[str, Any] = {
+        result_data: dict[str, Any] = {
             "success": False,
             "data": [],
             "columns": [],
@@ -677,7 +678,7 @@ class SnowflakeDriver(DatabaseDriver):
             result_data["error_type"] = "execution_error"
             logger.error(f"SQL execution failed: {e}")
         except Exception as e:
-            result_data["error"] = f"Unexpected execution error: {str(e)}"
+            result_data["error"] = f"Unexpected execution error: {e!s}"
             result_data["error_type"] = "internal_error"
             logger.error(f"Unexpected SQL execution error: {e}")
 
@@ -686,9 +687,9 @@ class SnowflakeDriver(DatabaseDriver):
     def sample_table_data(
         self,
         table_name: str,
-        schema_name: Optional[str] = None,
+        schema_name: str | None = None,
         limit: int = DEFAULT_SAMPLE_LIMIT,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         if not isinstance(limit, int) or limit < MIN_SAMPLE_LIMIT:
             limit = DEFAULT_SAMPLE_LIMIT
         elif limit > MAX_SAMPLE_LIMIT:

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -4,11 +4,10 @@ Provides structured error handling with consistent error types
 that replace ad-hoc string-based error_type fields.
 """
 
-from enum import Enum
-from typing import List, Optional
+from enum import StrEnum
 
 
-class ErrorType(str, Enum):
+class ErrorType(StrEnum):
     """Enumeration of all error types for consistent error reporting."""
 
     VALIDATION = "validation_error"
@@ -33,8 +32,8 @@ class OrionBeltError(Exception):
     def __init__(
         self,
         message: str,
-        details: Optional[str] = None,
-        suggestions: Optional[List[str]] = None,
+        details: str | None = None,
+        suggestions: list[str] | None = None,
     ):
         self.message = message
         self.details = details

--- a/src/graphrag/__init__.py
+++ b/src/graphrag/__init__.py
@@ -26,9 +26,9 @@ from .retriever import GraphRetriever
 from .vector_store import VectorStore
 
 __all__ = [
-    "GraphRAGManager",
-    "SchemaEmbedder",
-    "GraphRetriever",
-    "VectorStore",
     "CommunityDetector",
+    "GraphRAGManager",
+    "GraphRetriever",
+    "SchemaEmbedder",
+    "VectorStore",
 ]

--- a/src/graphrag/community_detector.py
+++ b/src/graphrag/community_detector.py
@@ -7,7 +7,7 @@ helping organize large schemas into understandable domains.
 
 import logging
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Set
+from typing import Any
 
 import networkx as nx
 
@@ -25,10 +25,10 @@ class CommunityDetector:
             graph: NetworkX graph of schema relationships
         """
         self.graph = graph
-        self.communities: Dict[int, Set[str]] = {}
-        self.table_to_community: Dict[str, int] = {}
+        self.communities: dict[int, set[str]] = {}
+        self.table_to_community: dict[str, int] = {}
 
-    def detect_communities(self, method: str = "louvain") -> Dict[int, Set[str]]:
+    def detect_communities(self, method: str = "louvain") -> dict[int, set[str]]:
         """
         Detect communities in the schema graph.
 
@@ -47,7 +47,7 @@ class CommunityDetector:
         else:
             raise ValueError(f"Unknown method: {method}")
 
-    def _detect_louvain(self) -> Dict[int, Set[str]]:
+    def _detect_louvain(self) -> dict[int, set[str]]:
         """
         Detect communities using Louvain method.
 
@@ -82,7 +82,7 @@ class CommunityDetector:
             )
             return self._detect_connected_components()
 
-    def _detect_connected_components(self) -> Dict[int, Set[str]]:
+    def _detect_connected_components(self) -> dict[int, set[str]]:
         """
         Detect communities using connected components.
 
@@ -108,7 +108,7 @@ class CommunityDetector:
 
         return self.communities
 
-    def _detect_label_propagation(self) -> Dict[int, Set[str]]:
+    def _detect_label_propagation(self) -> dict[int, set[str]]:
         """
         Detect communities using label propagation.
 
@@ -135,7 +135,7 @@ class CommunityDetector:
 
         return self.communities
 
-    def load_communities(self, data: Dict[str, Any]) -> bool:
+    def load_communities(self, data: dict[str, Any]) -> bool:
         """Restore communities from previously saved state.
 
         Args:
@@ -161,7 +161,7 @@ class CommunityDetector:
         logger.info(f"Restored {len(self.communities)} communities from saved state")
         return True
 
-    def get_community(self, table_name: str) -> Optional[int]:
+    def get_community(self, table_name: str) -> int | None:
         """
         Get community ID for a table.
 
@@ -173,7 +173,7 @@ class CommunityDetector:
         """
         return self.table_to_community.get(table_name)
 
-    def get_community_tables(self, community_id: int) -> Set[str]:
+    def get_community_tables(self, community_id: int) -> set[str]:
         """
         Get all tables in a community.
 
@@ -185,7 +185,7 @@ class CommunityDetector:
         """
         return self.communities.get(community_id, set())
 
-    def get_community_summary(self, community_id: int) -> Dict[str, Any]:
+    def get_community_summary(self, community_id: int) -> dict[str, Any]:
         """
         Get summary information about a community.
 
@@ -213,13 +213,13 @@ class CommunityDetector:
         return {
             "community_id": community_id,
             "table_count": len(tables),
-            "tables": sorted(list(tables)),
+            "tables": sorted(tables),
             "internal_relationships": internal_edges,
             "central_table": central_table,
             "avg_connections": sum(degrees.values()) / len(degrees) if degrees else 0,
         }
 
-    def get_all_summaries(self) -> List[Dict[str, Any]]:
+    def get_all_summaries(self) -> list[dict[str, Any]]:
         """
         Get summaries for all communities.
 
@@ -233,7 +233,7 @@ class CommunityDetector:
 
         return summaries
 
-    def suggest_domain_names(self) -> Dict[int, str]:
+    def suggest_domain_names(self) -> dict[int, str]:
         """
         Suggest domain names for communities based on table names.
 

--- a/src/graphrag/embedder.py
+++ b/src/graphrag/embedder.py
@@ -9,7 +9,7 @@ Uses a lightweight embedding model to create semantic representations of:
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import numpy as np
 
@@ -24,8 +24,8 @@ class SchemaElement:
     element_id: str
     name: str
     description: str
-    metadata: Dict[str, Any]
-    embedding: Optional[np.ndarray] = None
+    metadata: dict[str, Any]
+    embedding: np.ndarray | None = None
 
 
 class SchemaEmbedder:
@@ -68,9 +68,9 @@ class SchemaEmbedder:
     def create_table_embedding(
         self,
         table_name: str,
-        columns: List[Dict[str, Any]],
-        comment: Optional[str] = None,
-        foreign_keys: Optional[List[Dict[str, Any]]] = None,
+        columns: list[dict[str, Any]],
+        comment: str | None = None,
+        foreign_keys: list[dict[str, Any]] | None = None,
     ) -> SchemaElement:
         """
         Create embedding for a table.
@@ -129,8 +129,8 @@ class SchemaEmbedder:
         data_type: str,
         is_primary_key: bool = False,
         is_foreign_key: bool = False,
-        foreign_key_table: Optional[str] = None,
-        comment: Optional[str] = None,
+        foreign_key_table: str | None = None,
+        comment: str | None = None,
     ) -> SchemaElement:
         """
         Create embedding for a column.
@@ -187,7 +187,7 @@ class SchemaEmbedder:
         self,
         from_table: str,
         to_table: str,
-        join_columns: List[tuple],
+        join_columns: list[tuple],
         relationship_type: str = "one_to_many",
     ) -> SchemaElement:
         """
@@ -250,8 +250,8 @@ class SchemaEmbedder:
             return np.asarray(embedding)
 
     def batch_embed_tables(
-        self, tables_info: List[Dict[str, Any]]
-    ) -> List[SchemaElement]:
+        self, tables_info: list[dict[str, Any]]
+    ) -> list[SchemaElement]:
         """
         Create embeddings for multiple tables in batch.
 
@@ -276,8 +276,8 @@ class SchemaEmbedder:
         return elements
 
     def batch_embed_schema(
-        self, tables_info: List[Dict[str, Any]]
-    ) -> Dict[str, List[SchemaElement]]:
+        self, tables_info: list[dict[str, Any]]
+    ) -> dict[str, list[SchemaElement]]:
         """
         Create embeddings for entire schema (tables, columns, relationships).
 
@@ -287,7 +287,7 @@ class SchemaEmbedder:
         Returns:
             Dictionary with 'tables', 'columns', 'relationships' lists
         """
-        result: Dict[str, List[SchemaElement]] = {
+        result: dict[str, list[SchemaElement]] = {
             "tables": [],
             "columns": [],
             "relationships": [],
@@ -300,8 +300,10 @@ class SchemaEmbedder:
                 text_parts = [table["name"]]
                 if table.get("comment"):
                     text_parts.append(table["comment"])
-                for col in table.get("columns", []):
-                    text_parts.append(f"{col['name']} {col['data_type']}")
+                text_parts.extend(
+                    f"{col['name']} {col['data_type']}"
+                    for col in table.get("columns", [])
+                )
                 all_texts.append(" ".join(text_parts))
 
             if all_texts:

--- a/src/graphrag/manager.py
+++ b/src/graphrag/manager.py
@@ -8,7 +8,7 @@ to provide intelligent schema navigation and context-aware query generation.
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from .community_detector import CommunityDetector
 from .embedder import SchemaEmbedder
@@ -42,8 +42,8 @@ class GraphRAGManager:
         self,
         embedding_model: str = "tfidf",
         embedding_dimension: int = 384,
-        connection_id: Optional[str] = None,
-        schema_name: Optional[str] = None,
+        connection_id: str | None = None,
+        schema_name: str | None = None,
     ):
         """
         Initialize GraphRAG manager.
@@ -56,8 +56,11 @@ class GraphRAGManager:
         """
         self.embedder = SchemaEmbedder(embedding_model=embedding_model)
 
-        # Use ChromaDB if available, otherwise fallback to JSON-based storage
-        self.vector_store: Union["ChromaDBVectorStore", "VectorStore"]
+        # Use ChromaDB if available, otherwise fallback to JSON-based storage.
+        # Quoted deliberately: neither name is guaranteed bound at runtime --
+        # ChromaDBVectorStore is unbound if the import above raised ImportError,
+        # and VectorStore is TYPE_CHECKING-only plus locally imported below.
+        self.vector_store: "ChromaDBVectorStore | VectorStore"  # noqa: UP037
         if CHROMADB_AVAILABLE:
             self.vector_store = ChromaDBVectorStore(
                 connection_id=connection_id or "default",
@@ -72,15 +75,15 @@ class GraphRAGManager:
             logger.warning("Using JSON-based vector store (ChromaDB not available)")
 
         self.graph_retriever = GraphRetriever()
-        self.community_detector: Optional[CommunityDetector] = None
+        self.community_detector: CommunityDetector | None = None
 
         self._initialized = False
-        self._schema_name: Optional[str] = schema_name
-        self._schema_names: List[str] = []
+        self._schema_name: str | None = schema_name
+        self._schema_names: list[str] = []
         self._connection_id: str = connection_id or "default"
 
     def initialize_from_schema(
-        self, tables_info: List[Dict[str, Any]], schema_name: str = "default"
+        self, tables_info: list[dict[str, Any]], schema_name: str = "default"
     ) -> None:
         """
         Initialize GraphRAG from schema metadata.
@@ -121,7 +124,7 @@ class GraphRAGManager:
         logger.info("GraphRAG initialization complete")
 
     def accumulate_schema(
-        self, tables_info: List[Dict[str, Any]], schema_name: str = "default"
+        self, tables_info: list[dict[str, Any]], schema_name: str = "default"
     ) -> None:
         """Add a schema's tables to an already-initialized GraphRAG (accumulative).
 
@@ -168,8 +171,8 @@ class GraphRAGManager:
         )
 
     def search_schema(
-        self, query: str, top_k: int = 5, element_type: Optional[str] = None
-    ) -> List[Dict[str, Any]]:
+        self, query: str, top_k: int = 5, element_type: str | None = None
+    ) -> list[dict[str, Any]]:
         """
         Search schema using natural language.
 
@@ -213,7 +216,7 @@ class GraphRAGManager:
         top_k: int = 5,
         include_related: bool = True,
         max_related_distance: int = 1,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Find tables relevant to a natural language query.
 
@@ -234,7 +237,7 @@ class GraphRAGManager:
 
         primary_tables = [r["element"]["name"] for r in table_results]
 
-        result: Dict[str, Any] = {
+        result: dict[str, Any] = {
             "primary_tables": table_results,
             "related_tables": {},
             "communities": {},
@@ -298,7 +301,7 @@ class GraphRAGManager:
 
     def get_query_context(
         self, query: str, max_tables: int = 5, max_columns: int = 20
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Get optimized context for SQL query generation.
 
@@ -372,7 +375,7 @@ class GraphRAGManager:
 
         return context
 
-    def get_schema_overview(self) -> Dict[str, Any]:
+    def get_schema_overview(self) -> dict[str, Any]:
         """
         Get high-level schema overview.
 
@@ -382,7 +385,7 @@ class GraphRAGManager:
         if not self._initialized:
             raise RuntimeError("GraphRAG not initialized")
 
-        overview: Dict[str, Any] = {
+        overview: dict[str, Any] = {
             "schema_name": self._schema_name,
             "vector_store_stats": self.vector_store.get_statistics(),
             "graph_summary": self.graph_retriever.get_graph_summary(),
@@ -516,7 +519,7 @@ class GraphRAGManager:
 
         if graph_path.exists():
             try:
-                with open(graph_path, "r") as f:
+                with open(graph_path) as f:
                     graph_data = json.load(f)
 
                 tables_info = graph_data.get("tables_info")
@@ -551,7 +554,7 @@ class GraphRAGManager:
 
         if communities_path.exists():
             try:
-                with open(communities_path, "r") as f:
+                with open(communities_path) as f:
                     communities_data = json.load(f)
 
                 self.community_detector = CommunityDetector(self.graph_retriever.graph)

--- a/src/graphrag/retriever.py
+++ b/src/graphrag/retriever.py
@@ -7,7 +7,8 @@ of foreign key relationships and semantic similarity.
 
 import logging
 from collections import defaultdict, deque
-from typing import Any, Callable, Dict, List, Optional
+from collections.abc import Callable
+from typing import Any
 
 import networkx as nx
 
@@ -20,9 +21,9 @@ class GraphRetriever:
     def __init__(self) -> None:
         """Initialize the graph retriever."""
         self.graph = nx.DiGraph()
-        self._tables_info: Dict[str, Dict[str, Any]] = {}
+        self._tables_info: dict[str, dict[str, Any]] = {}
 
-    def build_graph(self, tables_info: List[Dict[str, Any]]) -> None:
+    def build_graph(self, tables_info: list[dict[str, Any]]) -> None:
         """
         Build graph from schema information.
 
@@ -66,7 +67,7 @@ class GraphRetriever:
             f"and {self.graph.number_of_edges()} edges"
         )
 
-    def add_to_graph(self, tables_info: List[Dict[str, Any]]) -> None:
+    def add_to_graph(self, tables_info: list[dict[str, Any]]) -> None:
         """Add tables and relationships to the existing graph (accumulative).
 
         Unlike build_graph(), this does NOT clear the graph first.
@@ -115,7 +116,7 @@ class GraphRetriever:
 
     def find_join_path(
         self, from_table: str, to_table: str, max_hops: int = 12
-    ) -> Optional[List[Dict[str, Any]]]:
+    ) -> list[dict[str, Any]] | None:
         """
         Find join path between two tables.
 
@@ -219,7 +220,7 @@ class GraphRetriever:
 
     def get_related_tables(
         self, table_name: str, max_distance: int = 1, direction: str = "both"
-    ) -> Dict[int, List[str]]:
+    ) -> dict[int, list[str]]:
         """
         Get tables related to a given table.
 
@@ -234,7 +235,7 @@ class GraphRetriever:
         if table_name not in self.graph:
             return {}
 
-        related: defaultdict[int, List[str]] = defaultdict(list)
+        related: defaultdict[int, list[str]] = defaultdict(list)
 
         if direction in ["outgoing", "both"]:
             # Tables this table references (FK from)
@@ -287,9 +288,9 @@ class GraphRetriever:
     def _directed_closure(
         self,
         table_name: str,
-        max_hops: Optional[int],
+        max_hops: int | None,
         neighbor_fn: Callable[[str], Any],
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Cycle-safe directed transitive closure from a table.
 
         Edges in the FK DiGraph point finer grain -> coarser grain (a table to
@@ -309,8 +310,8 @@ class GraphRetriever:
             return {"exists": False, "tables": [], "by_hop": {}}
 
         visited = {table_name}
-        order: List[str] = []
-        by_hop: Dict[int, List[str]] = {}
+        order: list[str] = []
+        by_hop: dict[int, list[str]] = {}
         queue = deque([(table_name, 0)])
 
         while queue:
@@ -327,8 +328,8 @@ class GraphRetriever:
         return {"exists": True, "tables": order, "by_hop": by_hop}
 
     def reachable_from(
-        self, table_name: str, max_hops: Optional[int] = None
-    ) -> Dict[str, Any]:
+        self, table_name: str, max_hops: int | None = None
+    ) -> dict[str, Any]:
         """Dimension-capable tables for a query anchored on ``table_name``.
 
         Directed many-to-one closure (``successors``): coarser-grain tables that
@@ -338,8 +339,8 @@ class GraphRetriever:
         return self._directed_closure(table_name, max_hops, self.graph.successors)
 
     def measurable_from(
-        self, table_name: str, max_hops: Optional[int] = None
-    ) -> Dict[str, Any]:
+        self, table_name: str, max_hops: int | None = None
+    ) -> dict[str, Any]:
         """Measure-capable tables for a query anchored on ``table_name``.
 
         Directed one-to-many closure (``predecessors``): finer-grain tables that
@@ -348,7 +349,7 @@ class GraphRetriever:
         """
         return self._directed_closure(table_name, max_hops, self.graph.predecessors)
 
-    def detect_fan_traps(self, tables: List[str]) -> List[Dict[str, Any]]:
+    def detect_fan_traps(self, tables: list[str]) -> list[dict[str, Any]]:
         """
         Detect potential fan-trap scenarios in a set of tables.
 
@@ -379,7 +380,7 @@ class GraphRetriever:
 
         return warnings
 
-    def get_table_metadata(self, table_name: str) -> Optional[Dict[str, Any]]:
+    def get_table_metadata(self, table_name: str) -> dict[str, Any] | None:
         """
         Get full metadata for a table.
 
@@ -391,7 +392,7 @@ class GraphRetriever:
         """
         return self._tables_info.get(table_name)
 
-    def get_graph_summary(self) -> Dict[str, Any]:
+    def get_graph_summary(self) -> dict[str, Any]:
         """
         Get summary statistics of the schema graph.
 
@@ -428,7 +429,7 @@ class GraphRetriever:
             / max(self.graph.number_of_nodes(), 1),
         }
 
-    def load_graph(self, tables_info: List[Dict[str, Any]]) -> bool:
+    def load_graph(self, tables_info: list[dict[str, Any]]) -> bool:
         """Rebuild graph from previously saved tables_info.
 
         This is equivalent to build_graph() but named distinctly to indicate
@@ -445,33 +446,31 @@ class GraphRetriever:
         self.build_graph(tables_info)
         return True
 
-    def export_graph_for_visualization(self) -> Dict[str, Any]:
+    def export_graph_for_visualization(self) -> dict[str, Any]:
         """
         Export graph in format suitable for visualization.
 
         Returns:
             Dictionary with nodes and edges
         """
-        nodes = []
-        for node in self.graph.nodes(data=True):
-            nodes.append(
-                {
-                    "id": node[0],
-                    "label": node[0],
-                    "type": "table",
-                    "column_count": node[1].get("column_count", 0),
-                }
-            )
+        nodes = [
+            {
+                "id": node[0],
+                "label": node[0],
+                "type": "table",
+                "column_count": node[1].get("column_count", 0),
+            }
+            for node in self.graph.nodes(data=True)
+        ]
 
-        edges = []
-        for edge in self.graph.edges(data=True):
-            edges.append(
-                {
-                    "from": edge[0],
-                    "to": edge[1],
-                    "label": f"{edge[2].get('column')} → {edge[2].get('referenced_column')}",
-                    "type": "foreign_key",
-                }
-            )
+        edges = [
+            {
+                "from": edge[0],
+                "to": edge[1],
+                "label": f"{edge[2].get('column')} → {edge[2].get('referenced_column')}",
+                "type": "foreign_key",
+            }
+            for edge in self.graph.edges(data=True)
+        ]
 
         return {"nodes": nodes, "edges": edges}

--- a/src/graphrag/vector_store.py
+++ b/src/graphrag/vector_store.py
@@ -9,7 +9,7 @@ import json
 import logging
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import numpy as np
 
@@ -24,8 +24,8 @@ class StoredElement:
     element_id: str
     name: str
     description: str
-    metadata: Dict[str, Any]
-    embedding: List[float]  # Stored as list for JSON serialization
+    metadata: dict[str, Any]
+    embedding: list[float]  # Stored as list for JSON serialization
 
 
 class VectorStore:
@@ -39,8 +39,8 @@ class VectorStore:
             dimension: Embedding dimension
         """
         self.dimension = dimension
-        self.elements: List[StoredElement] = []
-        self.embeddings_matrix: Optional[np.ndarray] = None
+        self.elements: list[StoredElement] = []
+        self.embeddings_matrix: np.ndarray | None = None
         self._index_built = False
 
     def add_element(
@@ -50,7 +50,7 @@ class VectorStore:
         name: str,
         description: str,
         embedding: np.ndarray,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         """
         Add a schema element to the store.
@@ -82,7 +82,7 @@ class VectorStore:
         self.elements.append(element)
         self._index_built = False  # Invalidate index
 
-    def add_elements_batch(self, elements: List[Any]) -> None:
+    def add_elements_batch(self, elements: list[Any]) -> None:
         """
         Add multiple schema elements in batch.
 
@@ -115,9 +115,9 @@ class VectorStore:
         self,
         query_embedding: np.ndarray,
         top_k: int = 5,
-        element_type: Optional[str] = None,
+        element_type: str | None = None,
         threshold: float = 0.0,
-    ) -> List[Tuple[StoredElement, float]]:
+    ) -> list[tuple[StoredElement, float]]:
         """
         Search for similar elements.
 
@@ -170,10 +170,11 @@ class VectorStore:
         top_indices = np.argsort(similarities)[::-1][:top_k]
 
         # Filter out -inf scores
-        results = []
-        for idx in top_indices:
-            if similarities[idx] > -np.inf:
-                results.append((self.elements[idx], float(similarities[idx])))
+        results = [
+            (self.elements[idx], float(similarities[idx]))
+            for idx in top_indices
+            if similarities[idx] > -np.inf
+        ]
 
         return results
 
@@ -182,8 +183,8 @@ class VectorStore:
         query_text: str,
         embedder: Any,
         top_k: int = 5,
-        element_type: Optional[str] = None,
-    ) -> List[Tuple[StoredElement, float]]:
+        element_type: str | None = None,
+    ) -> list[tuple[StoredElement, float]]:
         """
         Search using natural language query.
 
@@ -199,7 +200,7 @@ class VectorStore:
         query_embedding = embedder._embed_text(query_text)
         return self.search(query_embedding, top_k=top_k, element_type=element_type)
 
-    def get_by_id(self, element_id: str) -> Optional[StoredElement]:
+    def get_by_id(self, element_id: str) -> StoredElement | None:
         """
         Get element by ID.
 
@@ -214,7 +215,7 @@ class VectorStore:
                 return elem
         return None
 
-    def get_by_type(self, element_type: str) -> List[StoredElement]:
+    def get_by_type(self, element_type: str) -> list[StoredElement]:
         """
         Get all elements of a specific type.
 
@@ -252,7 +253,7 @@ class VectorStore:
         Args:
             filepath: Input file path (JSON)
         """
-        with open(filepath, "r") as f:
+        with open(filepath) as f:
             data = json.load(f)
 
         self.dimension = data["dimension"]
@@ -266,14 +267,14 @@ class VectorStore:
             f"Loaded vector store with {len(self.elements)} elements from {filepath}"
         )
 
-    def get_statistics(self) -> Dict[str, Any]:
+    def get_statistics(self) -> dict[str, Any]:
         """
         Get store statistics.
 
         Returns:
             Statistics dictionary
         """
-        type_counts: Dict[str, int] = {}
+        type_counts: dict[str, int] = {}
         for elem in self.elements:
             type_counts[elem.element_type] = type_counts.get(elem.element_type, 0) + 1
 

--- a/src/graphrag/vector_store_chromadb.py
+++ b/src/graphrag/vector_store_chromadb.py
@@ -14,7 +14,7 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, cast
 
 import numpy as np
 
@@ -40,8 +40,8 @@ class StoredElement:
     element_id: str
     name: str
     description: str
-    metadata: Dict[str, Any]
-    embedding: List[float]  # Stored as list for JSON serialization
+    metadata: dict[str, Any]
+    embedding: list[float]  # Stored as list for JSON serialization
 
 
 class ChromaDBVectorStore:
@@ -116,7 +116,7 @@ class ChromaDBVectorStore:
         name: str,
         description: str,
         embedding: np.ndarray,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
         """
         Add a schema element to the store.
@@ -130,7 +130,7 @@ class ChromaDBVectorStore:
             metadata: Optional metadata dictionary
         """
         # Prepare metadata (ChromaDB requires strings, ints, floats, or bools)
-        chroma_metadata: Dict[str, Any] = {
+        chroma_metadata: dict[str, Any] = {
             "element_type": element_type,
             "name": name,
             "description": description,
@@ -163,7 +163,7 @@ class ChromaDBVectorStore:
             logger.error(f"Failed to add element {element_id}: {e}")
             raise
 
-    def add_elements_batch(self, elements: List[Any]) -> None:
+    def add_elements_batch(self, elements: list[Any]) -> None:
         """
         Add multiple schema elements in batch.
 
@@ -173,13 +173,13 @@ class ChromaDBVectorStore:
         if not elements:
             return
 
-        ids: List[Any] = []
-        embeddings: List[Any] = []
-        metadatas: List[Any] = []
+        ids: list[Any] = []
+        embeddings: list[Any] = []
+        metadatas: list[Any] = []
 
         for elem in elements:
             # Prepare metadata
-            chroma_metadata: Dict[str, Any] = {
+            chroma_metadata: dict[str, Any] = {
                 "element_type": elem.element_type,
                 "name": elem.name,
                 "description": elem.description,
@@ -225,9 +225,9 @@ class ChromaDBVectorStore:
         self,
         query_embedding: np.ndarray,
         top_k: int = 5,
-        element_type: Optional[str] = None,
+        element_type: str | None = None,
         threshold: float = 0.0,
-    ) -> List[Tuple[StoredElement, float]]:
+    ) -> list[tuple[StoredElement, float]]:
         """
         Search for similar elements using ChromaDB.
 
@@ -259,8 +259,8 @@ class ChromaDBVectorStore:
 
         # Query ChromaDB
         try:
-            results: Dict[str, Any] = cast(
-                Dict[str, Any],
+            results: dict[str, Any] = cast(
+                dict[str, Any],
                 self.collection.query(
                     query_embeddings=[query_embedding.tolist()],
                     n_results=top_k,
@@ -273,7 +273,7 @@ class ChromaDBVectorStore:
             return []
 
         # Convert results to StoredElement format
-        stored_elements: List[Tuple[StoredElement, float]] = []
+        stored_elements: list[tuple[StoredElement, float]] = []
 
         if not results["ids"] or not results["ids"][0]:
             return []
@@ -297,9 +297,7 @@ class ChromaDBVectorStore:
             for key, value in metadata.items():
                 if key not in ["element_type", "name", "description"]:
                     # Try to parse JSON strings back to objects
-                    if isinstance(value, str) and (
-                        value.startswith("{") or value.startswith("[")
-                    ):
+                    if isinstance(value, str) and (value.startswith(("{", "["))):
                         try:
                             elem_metadata[key] = json.loads(value)
                         except (json.JSONDecodeError, ValueError):
@@ -325,8 +323,8 @@ class ChromaDBVectorStore:
         query_text: str,
         embedder: Any,
         top_k: int = 5,
-        element_type: Optional[str] = None,
-    ) -> List[Tuple[StoredElement, float]]:
+        element_type: str | None = None,
+    ) -> list[tuple[StoredElement, float]]:
         """
         Search using natural language query.
 
@@ -342,7 +340,7 @@ class ChromaDBVectorStore:
         query_embedding = embedder._embed_text(query_text)
         return self.search(query_embedding, top_k=top_k, element_type=element_type)
 
-    def get_by_id(self, element_id: str) -> Optional[StoredElement]:
+    def get_by_id(self, element_id: str) -> StoredElement | None:
         """
         Get element by ID from ChromaDB.
 
@@ -353,8 +351,8 @@ class ChromaDBVectorStore:
             StoredElement or None if not found
         """
         try:
-            result: Dict[str, Any] = cast(
-                Dict[str, Any],
+            result: dict[str, Any] = cast(
+                dict[str, Any],
                 self.collection.get(
                     ids=[element_id], include=["metadatas", "embeddings"]
                 ),
@@ -370,9 +368,7 @@ class ChromaDBVectorStore:
             elem_metadata = {}
             for key, value in metadata.items():
                 if key not in ["element_type", "name", "description"]:
-                    if isinstance(value, str) and (
-                        value.startswith("{") or value.startswith("[")
-                    ):
+                    if isinstance(value, str) and (value.startswith(("{", "["))):
                         try:
                             elem_metadata[key] = json.loads(value)
                         except (json.JSONDecodeError, ValueError):
@@ -392,7 +388,7 @@ class ChromaDBVectorStore:
             logger.error(f"Failed to get element {element_id}: {e}")
             return None
 
-    def get_by_type(self, element_type: str) -> List[StoredElement]:
+    def get_by_type(self, element_type: str) -> list[StoredElement]:
         """
         Get all elements of a specific type.
 
@@ -403,8 +399,8 @@ class ChromaDBVectorStore:
             List of matching elements
         """
         try:
-            results: Dict[str, Any] = cast(
-                Dict[str, Any],
+            results: dict[str, Any] = cast(
+                dict[str, Any],
                 self.collection.get(
                     where={"element_type": element_type},
                     include=["metadatas", "embeddings"],
@@ -420,9 +416,7 @@ class ChromaDBVectorStore:
                 elem_metadata = {}
                 for key, value in metadata.items():
                     if key not in ["element_type", "name", "description"]:
-                        if isinstance(value, str) and (
-                            value.startswith("{") or value.startswith("[")
-                        ):
+                        if isinstance(value, str) and (value.startswith(("{", "["))):
                             try:
                                 elem_metadata[key] = json.loads(value)
                             except (json.JSONDecodeError, ValueError):
@@ -455,8 +449,8 @@ class ChromaDBVectorStore:
         """
         try:
             # Get all data from ChromaDB
-            results: Dict[str, Any] = cast(
-                Dict[str, Any],
+            results: dict[str, Any] = cast(
+                dict[str, Any],
                 self.collection.get(include=["metadatas", "embeddings"]),
             )
 
@@ -469,9 +463,7 @@ class ChromaDBVectorStore:
                 elem_metadata = {}
                 for key, value in metadata.items():
                     if key not in ["element_type", "name", "description"]:
-                        if isinstance(value, str) and (
-                            value.startswith("{") or value.startswith("[")
-                        ):
+                        if isinstance(value, str) and (value.startswith(("{", "["))):
                             try:
                                 elem_metadata[key] = json.loads(value)
                             except (json.JSONDecodeError, ValueError):
@@ -519,20 +511,20 @@ class ChromaDBVectorStore:
             filepath: Input file path (JSON)
         """
         try:
-            with open(filepath, "r") as f:
+            with open(filepath) as f:
                 data = json.load(f)
 
             # Clear existing data
             self.clear()
 
             # Batch import
-            ids: List[Any] = []
-            embeddings: List[Any] = []
-            metadatas: List[Any] = []
+            ids: list[Any] = []
+            embeddings: list[Any] = []
+            metadatas: list[Any] = []
 
             for elem_dict in data.get("elements", []):
                 # Prepare metadata
-                chroma_metadata: Dict[str, Any] = {
+                chroma_metadata: dict[str, Any] = {
                     "element_type": elem_dict.get("element_type", "unknown"),
                     "name": elem_dict.get("name", ""),
                     "description": elem_dict.get("description", ""),
@@ -560,7 +552,7 @@ class ChromaDBVectorStore:
             logger.error(f"Failed to import vector store: {e}")
             raise
 
-    def get_statistics(self) -> Dict[str, Any]:
+    def get_statistics(self) -> dict[str, Any]:
         """
         Get store statistics.
 

--- a/src/handler_context.py
+++ b/src/handler_context.py
@@ -18,8 +18,9 @@ provide. This keeps the fields statically callable (no ``Optional[Callable]``
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
 
 
 def _unset_service(*_args: Any, **_kwargs: Any) -> Any:

--- a/src/handlers/__init__.py
+++ b/src/handlers/__init__.py
@@ -17,12 +17,12 @@ Modules:
 from . import chart, connection, graphrag, ontology, query, rdf, schema, workspace
 
 __all__ = [
+    "chart",
     "connection",
-    "schema",
+    "graphrag",
     "ontology",
     "query",
-    "chart",
     "rdf",
-    "graphrag",
+    "schema",
     "workspace",
 ]

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -1,7 +1,7 @@
 """Chart generation handler implementation."""
 
 import logging
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, cast
 from uuid import uuid4
 
 from fastmcp import Context
@@ -21,18 +21,18 @@ PNG_HEIGHT = 600
 
 async def generate_chart(
     ctx: Context,
-    data_source: Union[List[Dict[str, Any]], str],
+    data_source: list[dict[str, Any]] | str,
     chart_type: str,
     x_column: str,
-    y_column: Optional[Union[str, List[str]]],
-    color_column: Optional[str],
-    title: Optional[str],
+    y_column: str | list[str] | None,
+    color_column: str | None,
+    title: str | None,
     chart_style: str,
-    sort_by: Optional[str],
-    sort_order: Optional[str],
+    sort_by: str | None,
+    sort_order: str | None,
     output_format: str,
     services: "HandlerContext",
-) -> Union[str, List[Union[str, Image]]]:
+) -> str | list[str | Image]:
     """Generate interactive or static charts from query results.
 
     This handler delegates to tools.chart.generate_chart for the core charting
@@ -69,7 +69,7 @@ async def generate_chart(
                     f"data_source must be valid JSON (array of objects), not a string. "
                     f"Received string: {raw_data_source[:100]}... "
                     f"Expected format: [{{'key': 'value'}}, ...] "
-                    f"Parse error: {str(e)}"
+                    f"Parse error: {e!s}"
                 )
 
     # Parse y_column if it's a JSON string list
@@ -85,7 +85,7 @@ async def generate_chart(
     logger.info(
         f"generate_chart called with output_format={output_format}, chart_type={chart_type}"
     )
-    chart_data = cast(List[Dict[str, Any]], data_source)
+    chart_data = cast(list[dict[str, Any]], data_source)
     result = generate_chart_impl(
         chart_data,
         chart_type,

--- a/src/handlers/connection.py
+++ b/src/handlers/connection.py
@@ -3,7 +3,7 @@
 import logging
 import os
 from datetime import datetime
-from typing import List, cast
+from typing import cast
 
 from fastmcp import Context
 
@@ -356,7 +356,7 @@ async def connect_database(
         )
 
 
-async def list_schemas(ctx: Context, services: "HandlerContext") -> List[str]:
+async def list_schemas(ctx: Context, services: "HandlerContext") -> list[str]:
     """Get a list of available schemas from the connected database.
 
     Args:

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -4,7 +4,7 @@ import logging
 import os
 import time
 from datetime import datetime
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, cast
 
 from fastmcp import Context
 
@@ -19,7 +19,7 @@ from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
 logger = logging.getLogger(__name__)
 
 
-def _table_info_to_dict(table_info: Any) -> Dict[str, Any]:
+def _table_info_to_dict(table_info: Any) -> dict[str, Any]:
     """Convert a TableInfo object to a dictionary for GraphRAG/ontology consumption."""
     return {
         "name": table_info.name,
@@ -53,7 +53,7 @@ def _table_info_to_dict(table_info: Any) -> Dict[str, Any]:
 
 async def _auto_generate_ontology_background(
     schema_name: str,
-    tables_info: List[Any],
+    tables_info: list[Any],
     session: Any,
     ctx: Context,
 ) -> None:
@@ -113,7 +113,7 @@ async def _auto_generate_ontology_background(
 
 async def _auto_initialize_graphrag_background(
     schema_name: str,
-    tables_info: List[Any],
+    tables_info: list[Any],
     session: Any,
     ctx: Context,
 ) -> None:
@@ -200,7 +200,7 @@ async def _auto_initialize_graphrag_background(
 
 async def initialize_graphrag(
     ctx: Context,
-    schema_name: Optional[str],
+    schema_name: str | None,
     embedding_model: str,
     services: "HandlerContext",
 ) -> str:
@@ -252,7 +252,7 @@ async def initialize_graphrag(
             return cast(
                 str,
                 services.create_error_response(
-                    f"Failed to fetch schema: {str(e)}", "database_error"
+                    f"Failed to fetch schema: {e!s}", "database_error"
                 ),
             )
 
@@ -339,7 +339,7 @@ async def initialize_graphrag(
         return cast(
             str,
             services.create_error_response(
-                f"GraphRAG initialization failed: {str(e)}", "graphrag_error"
+                f"GraphRAG initialization failed: {e!s}", "graphrag_error"
             ),
         )
 
@@ -348,14 +348,14 @@ async def graphrag_search(
     ctx: Context,
     query: str,
     top_k: int,
-    element_type: Optional[str],
+    element_type: str | None,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Search schema using natural language via GraphRAG semantic search."""
     session = services.get_session_data(ctx)
 
     if not session.graphrag_initialized or session.graphrag_manager is None:
-        err: Dict[str, Any] = services.create_error_response(
+        err: dict[str, Any] = services.create_error_response(
             "GraphRAG not initialized. Please call discover_schema() first.",
             "graphrag_not_initialized",
         )
@@ -378,7 +378,7 @@ async def graphrag_search(
     except Exception as e:
         logger.error(f"GraphRAG search failed: {e}", exc_info=True)
         err = services.create_error_response(
-            f"GraphRAG search failed: {str(e)}", "graphrag_error"
+            f"GraphRAG search failed: {e!s}", "graphrag_error"
         )
         return err
 
@@ -389,12 +389,12 @@ async def graphrag_query_context(
     max_tables: int,
     max_columns: int,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get optimized context for SQL query generation using GraphRAG."""
     session = services.get_session_data(ctx)
 
     if not session.graphrag_initialized or session.graphrag_manager is None:
-        err: Dict[str, Any] = services.create_error_response(
+        err: dict[str, Any] = services.create_error_response(
             "GraphRAG not initialized. Please call discover_schema() first.",
             "graphrag_not_initialized",
         )
@@ -424,7 +424,7 @@ async def graphrag_query_context(
     except Exception as e:
         logger.error(f"GraphRAG query context failed: {e}", exc_info=True)
         err = services.create_error_response(
-            f"GraphRAG query context failed: {str(e)}", "graphrag_error"
+            f"GraphRAG query context failed: {e!s}", "graphrag_error"
         )
         return err
 
@@ -435,12 +435,12 @@ async def graphrag_find_join_path(
     to_table: str,
     max_hops: int,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Find join path between two tables using GraphRAG graph traversal."""
     session = services.get_session_data(ctx)
 
     if not session.graphrag_initialized or session.graphrag_manager is None:
-        err: Dict[str, Any] = services.create_error_response(
+        err: dict[str, Any] = services.create_error_response(
             "GraphRAG not initialized. Please call discover_schema() first.",
             "graphrag_not_initialized",
         )
@@ -480,7 +480,7 @@ async def graphrag_find_join_path(
     except Exception as e:
         logger.error(f"GraphRAG find join path failed: {e}", exc_info=True)
         err = services.create_error_response(
-            f"GraphRAG find join path failed: {str(e)}", "graphrag_error"
+            f"GraphRAG find join path failed: {e!s}", "graphrag_error"
         )
         return err
 
@@ -488,14 +488,14 @@ async def graphrag_find_join_path(
 async def reachable_from(
     ctx: Context,
     table: str,
-    max_hops: Optional[int],
+    max_hops: int | None,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Dimension-capable tables for a query anchored on ``table`` (many-to-one closure)."""
     session = services.get_session_data(ctx)
 
     if not session.graphrag_initialized or session.graphrag_manager is None:
-        err: Dict[str, Any] = services.create_error_response(
+        err: dict[str, Any] = services.create_error_response(
             "GraphRAG not initialized. Please call discover_schema() first.",
             "graphrag_not_initialized",
         )
@@ -531,7 +531,7 @@ async def reachable_from(
     except Exception as e:
         logger.error(f"reachable_from failed: {e}", exc_info=True)
         err = services.create_error_response(
-            f"reachable_from failed: {str(e)}", "graphrag_error"
+            f"reachable_from failed: {e!s}", "graphrag_error"
         )
         return err
 
@@ -539,14 +539,14 @@ async def reachable_from(
 async def measurable_from(
     ctx: Context,
     table: str,
-    max_hops: Optional[int],
+    max_hops: int | None,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Measure-capable tables for a query anchored on ``table`` (one-to-many closure)."""
     session = services.get_session_data(ctx)
 
     if not session.graphrag_initialized or session.graphrag_manager is None:
-        err: Dict[str, Any] = services.create_error_response(
+        err: dict[str, Any] = services.create_error_response(
             "GraphRAG not initialized. Please call discover_schema() first.",
             "graphrag_not_initialized",
         )
@@ -582,17 +582,17 @@ async def measurable_from(
     except Exception as e:
         logger.error(f"measurable_from failed: {e}", exc_info=True)
         err = services.create_error_response(
-            f"measurable_from failed: {str(e)}", "graphrag_error"
+            f"measurable_from failed: {e!s}", "graphrag_error"
         )
         return err
 
 
 async def plan_composite_query(
     ctx: Context,
-    facts: List[str],
-    dimensions: Optional[List[str]],
+    facts: list[str],
+    dimensions: list[str] | None,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Advise a Composite Fact Layer (CFL) decomposition for a multi-fact query.
 
     Detects whether the requested facts are independent grains (disjoint
@@ -604,7 +604,7 @@ async def plan_composite_query(
     session = services.get_session_data(ctx)
 
     if not session.graphrag_initialized or session.graphrag_manager is None:
-        err: Dict[str, Any] = services.create_error_response(
+        err: dict[str, Any] = services.create_error_response(
             "GraphRAG not initialized. Please call discover_schema() first.",
             "graphrag_not_initialized",
         )
@@ -709,12 +709,12 @@ async def plan_composite_query(
 async def graphrag_overview(
     ctx: Context,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get GraphRAG schema overview with statistics and communities."""
     session = services.get_session_data(ctx)
 
     if not session.graphrag_initialized or session.graphrag_manager is None:
-        err: Dict[str, Any] = services.create_error_response(
+        err: dict[str, Any] = services.create_error_response(
             "GraphRAG not initialized. Please call discover_schema() first.",
             "graphrag_not_initialized",
         )
@@ -730,6 +730,6 @@ async def graphrag_overview(
     except Exception as e:
         logger.error(f"GraphRAG overview failed: {e}", exc_info=True)
         err = services.create_error_response(
-            f"GraphRAG overview failed: {str(e)}", "graphrag_error"
+            f"GraphRAG overview failed: {e!s}", "graphrag_error"
         )
         return err

--- a/src/handlers/ontology.py
+++ b/src/handlers/ontology.py
@@ -20,12 +20,12 @@ from .ontology_io import load_my_ontology
 from .ontology_semantic import apply_semantic_names, suggest_semantic_names
 
 __all__ = [
-    "generate_ontology",
-    "suggest_semantic_names",
+    "OUTPUT_DIR",
     "apply_semantic_names",
-    "load_my_ontology",
     "download_ontology",
     "download_r2rml",
-    "OUTPUT_DIR",
     "ensure_output_dir",
+    "generate_ontology",
+    "load_my_ontology",
+    "suggest_semantic_names",
 ]

--- a/src/handlers/ontology_artifacts.py
+++ b/src/handlers/ontology_artifacts.py
@@ -2,7 +2,7 @@
 
 import logging
 import re
-from typing import Any, Dict, Optional
+from typing import Any
 
 from fastmcp import Context
 
@@ -15,10 +15,10 @@ logger = logging.getLogger(__name__)
 
 async def download_ontology(
     ctx: Context,
-    schema_name: Optional[str],
+    schema_name: str | None,
     source: str,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Download ontology as TTL file from RDF store or tmp folder."""
     try:
         session = services.get_session_data(ctx)
@@ -98,7 +98,7 @@ async def download_ontology(
                 logger.error(f"Failed to export from RDF store: {e}")
                 return {
                     "success": False,
-                    "error": f"Failed to export from RDF store: {str(e)}",
+                    "error": f"Failed to export from RDF store: {e!s}",
                     "error_type": "rdf_error",
                     "hint": "Try source='file' to read from tmp folder instead",
                 }
@@ -134,7 +134,7 @@ async def download_ontology(
                     "error_type": "file_not_found",
                 }
 
-            with open(ontology_file_path, "r", encoding="utf-8") as f:
+            with open(ontology_file_path, encoding="utf-8") as f:
                 ontology_ttl = f.read()
 
             file_stat = ontology_file_path.stat()
@@ -161,16 +161,16 @@ async def download_ontology(
         logger.error(f"Error downloading ontology: {e}")
         return {
             "success": False,
-            "error": f"Failed to download ontology: {str(e)}",
+            "error": f"Failed to download ontology: {e!s}",
             "error_type": "internal_error",
         }
 
 
 async def download_r2rml(
     ctx: Context,
-    schema_name: Optional[str],
+    schema_name: str | None,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Download R2RML mapping file from tmp folder."""
     try:
         session = services.get_session_data(ctx)
@@ -220,7 +220,7 @@ async def download_r2rml(
                 "hint": "Run discover_schema() to generate R2RML mapping",
             }
 
-        with open(r2rml_file_path, "r", encoding="utf-8") as f:
+        with open(r2rml_file_path, encoding="utf-8") as f:
             r2rml_content = f.read()
 
         file_stat = r2rml_file_path.stat()
@@ -253,6 +253,6 @@ async def download_r2rml(
         logger.error(f"Error downloading R2RML: {e}")
         return {
             "success": False,
-            "error": f"Failed to download R2RML: {str(e)}",
+            "error": f"Failed to download R2RML: {e!s}",
             "error_type": "internal_error",
         }

--- a/src/handlers/ontology_generation.py
+++ b/src/handlers/ontology_generation.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 from datetime import datetime
-from typing import Any, Dict, Optional, Union
+from typing import Any
 
 from fastmcp import Context
 
@@ -76,11 +76,9 @@ def _build_minimal_graph_summary(ontology_ttl: str) -> str:
 
     lines = ["\n## Minimal Graph Summary\n"]
     lines.append(f"### Classes ({len(class_names)})")
-    for cn in sorted(class_names):
-        lines.append(f"  - {cn}")
+    lines.extend(f"  - {cn}" for cn in sorted(class_names))
     lines.append(f"\n### Relationships ({len(rels)})")
-    for r in sorted(set(rels)):
-        lines.append(r)
+    lines.extend(sorted(set(rels)))
     lines.append(
         '\nUse download_artifact(artifact_type="ontology") to retrieve the full Turtle serialization.'
     )
@@ -89,13 +87,13 @@ def _build_minimal_graph_summary(ontology_ttl: str) -> str:
 
 async def generate_ontology(
     ctx: Context,
-    schema_info: Optional[str],
-    schema_name: Optional[str],
+    schema_info: str | None,
+    schema_name: str | None,
     base_uri: str,
     auto_persist: bool,
-    graph_uri: Optional[str],
+    graph_uri: str | None,
     services: "HandlerContext",
-) -> Union[str, Dict[str, Any]]:
+) -> str | dict[str, Any]:
     """Generate an RDF ontology from database schema.
 
     Extracts implementation from main.py's generate_ontology tool.
@@ -174,8 +172,8 @@ async def generate_ontology(
             logger.info(f"Using provided schema info: {len(tables_info)} tables")
 
         except Exception as e:
-            err: Dict[str, Any] = services.create_error_response(
-                f"Failed to parse schema_info parameter: {str(e)}", "parameter_error"
+            err: dict[str, Any] = services.create_error_response(
+                f"Failed to parse schema_info parameter: {e!s}", "parameter_error"
             )
             return err
     else:
@@ -231,7 +229,7 @@ async def generate_ontology(
 
             except Exception as e:
                 err = services.create_error_response(
-                    f"Failed to get tables from database: {str(e)}", "database_error"
+                    f"Failed to get tables from database: {e!s}", "database_error"
                 )
                 return err
 

--- a/src/handlers/ontology_io.py
+++ b/src/handlers/ontology_io.py
@@ -2,9 +2,10 @@
 
 import logging
 import os
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional
+from typing import Any
 
 from fastmcp import Context
 
@@ -21,7 +22,7 @@ def _check_ontology_db_compatibility(
     ctx: Context,
     get_session_db_manager: Callable[..., Any],
     session: Any,
-) -> Optional[Dict[str, Any]]:
+) -> dict[str, Any] | None:
     """Compare ontology tables/columns against the connected database.
 
     Returns a compatibility dict or None if no database is connected.
@@ -72,10 +73,7 @@ def _check_ontology_db_compatibility(
         total_onto = len(onto_tables)
         match_count = len(matched)
 
-        if total_onto == 0:
-            pct = 0
-        else:
-            pct = round(100 * match_count / total_onto)
+        pct = 0 if total_onto == 0 else round(100 * match_count / total_onto)
 
         if pct == 100:
             status = "full_match"
@@ -125,11 +123,11 @@ async def load_my_ontology(
     ctx: Context,
     import_folder: str,
     auto_persist: bool,
-    graph_uri: Optional[str],
+    graph_uri: str | None,
     services: "HandlerContext",
-    ontology_content: Optional[str] = None,
-    file_name: Optional[str] = None,
-) -> Dict[str, Any]:
+    ontology_content: str | None = None,
+    file_name: str | None = None,
+) -> dict[str, Any]:
     """Load an ontology from inline content or the newest .ttl file from the import folder."""
     try:
         from rdflib import Graph
@@ -192,7 +190,7 @@ async def load_my_ontology(
             ttl_files.sort(key=lambda f: f.stat().st_mtime, reverse=True)
             newest_file = ttl_files[0]
 
-            with open(newest_file, "r", encoding="utf-8") as f:
+            with open(newest_file, encoding="utf-8") as f:
                 ontology_content = f.read()
 
             file_stat = newest_file.stat()
@@ -203,7 +201,7 @@ async def load_my_ontology(
         except Exception as parse_error:
             return {
                 "success": False,
-                "error": f"Failed to parse ontology file: {str(parse_error)}",
+                "error": f"Failed to parse ontology file: {parse_error!s}",
                 "error_type": "parse_error",
                 "file_path": str(newest_file),
                 "suggestion": "Ensure the file is valid Turtle format",
@@ -276,7 +274,7 @@ async def load_my_ontology(
                 f"Ontology loaded with {classes_count} classes; ready for SQL generation"
             )
 
-        response: Dict[str, Any] = {
+        response: dict[str, Any] = {
             "success": True,
             "source": "chat_upload" if from_chat else "import_folder",
             "file_path": str(newest_file),
@@ -336,6 +334,6 @@ async def load_my_ontology(
         logger.error(f"Error loading ontology: {e}")
         return {
             "success": False,
-            "error": f"Failed to load ontology: {str(e)}",
+            "error": f"Failed to load ontology: {e!s}",
             "error_type": "internal_error",
         }

--- a/src/handlers/ontology_semantic.py
+++ b/src/handlers/ontology_semantic.py
@@ -4,7 +4,7 @@ import json
 import logging
 import re
 from datetime import datetime
-from typing import Any, Dict, Optional, Union
+from typing import Any
 
 from fastmcp import Context
 
@@ -23,9 +23,9 @@ logger = logging.getLogger(__name__)
 async def _maybe_sample_rename_suggestions(
     ctx: Context,
     cryptic_classes: list,
-    cryptic_props_by_table: Dict[str, list],
+    cryptic_props_by_table: dict[str, list],
     cryptic_relationships: list,
-) -> Optional[Dict[str, Any]]:
+) -> dict[str, Any] | None:
     """Ask the host LLM (via MCP sampling) for ontology-shaped rename suggestions.
 
     Returns the structured payload that ``apply_semantic_names`` consumes
@@ -51,14 +51,10 @@ async def _maybe_sample_rename_suggestions(
     if not (cryptic_classes or cryptic_props_by_table or cryptic_relationships):
         return {"classes": [], "properties": [], "relationships": []}
 
-    items: list[str] = []
-    for c in cryptic_classes:
-        items.append(f"CLASS  {c}")
+    items: list[str] = [f"CLASS  {c}" for c in cryptic_classes]
     for table, cols in cryptic_props_by_table.items():
-        for col in cols:
-            items.append(f"PROP   {table}.{col}")
-    for r in cryptic_relationships:
-        items.append(f"REL    {r}")
+        items.extend(f"PROP   {table}.{col}" for col in cols)
+    items.extend(f"REL    {r}" for r in cryptic_relationships)
 
     logger.info(
         "MCP sampling: requesting rename suggestions for %d items "
@@ -191,26 +187,24 @@ def _build_rename_prompt(items: list[str]) -> str:
     )
 
 
-def _normalize_structured_suggestions(
-    parsed: Optional[Dict[str, Any]]
-) -> Dict[str, list]:
+def _normalize_structured_suggestions(parsed: dict[str, Any] | None) -> dict[str, list]:
     """Validate and clean a structured suggestions payload.
 
     Drops items missing required fields, strips suggestions that match the
     original verbatim, and guarantees the three top-level keys exist.
     """
-    out: Dict[str, list] = {"classes": [], "properties": [], "relationships": []}
+    out: dict[str, list] = {"classes": [], "properties": [], "relationships": []}
     if not isinstance(parsed, dict):
         return out
 
-    def _clean_item(item: Any, *, require_table: bool) -> Optional[Dict[str, str]]:
+    def _clean_item(item: Any, *, require_table: bool) -> dict[str, str] | None:
         if not isinstance(item, dict):
             return None
         original = str(item.get("original_name") or "").strip()
         suggested = str(item.get("suggested_name") or "").strip()
         if not original or not suggested or original == suggested:
             return None
-        cleaned: Dict[str, str] = {
+        cleaned: dict[str, str] = {
             "original_name": original,
             "suggested_name": suggested,
         }
@@ -240,7 +234,7 @@ def _normalize_structured_suggestions(
     return out
 
 
-def _parse_rename_json(text: str) -> Optional[Dict[str, Any]]:
+def _parse_rename_json(text: str) -> dict[str, Any] | None:
     """Best-effort JSON extraction from a sampling text response.
 
     Handles three common shapes: a bare JSON object, a JSON object inside
@@ -280,9 +274,9 @@ def _parse_rename_json(text: str) -> Optional[Dict[str, Any]]:
 
 async def suggest_semantic_names(
     ctx: Context,
-    ontology_file: Optional[str],
+    ontology_file: str | None,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Extract and analyze names from a generated ontology."""
     try:
         try:
@@ -323,7 +317,7 @@ async def suggest_semantic_names(
         ]
 
         # Group cryptic properties by table for compact output
-        cryptic_props_by_table: Dict[str, list] = {}
+        cryptic_props_by_table: dict[str, list] = {}
         for p in extraction_result["properties"]:
             if p.get("needs_review", {}).get("is_cryptic"):
                 table = p.get("table_name") or "unknown"
@@ -407,18 +401,18 @@ async def suggest_semantic_names(
             raise
         logger.error(f"Error extracting names for review: {e}")
         return {
-            "error": f"Failed to extract names: {str(e)}",
+            "error": f"Failed to extract names: {e!s}",
             "error_type": "internal_error",
         }
 
 
 async def apply_semantic_names(
     ctx: Context,
-    suggestions: Union[str, Dict[str, Any]],
-    ontology_file: Optional[str],
+    suggestions: str | dict[str, Any],
+    ontology_file: str | None,
     save_to_file: bool,
     services: "HandlerContext",
-) -> Union[str, Dict[str, Any]]:
+) -> str | dict[str, Any]:
     """Apply LLM-suggested semantic names to an existing ontology."""
     try:
         session = services.get_session_data(ctx)
@@ -431,19 +425,18 @@ async def apply_semantic_names(
                 )
                 ontology_path = conn_dir / ontology_file
                 if not ontology_path.exists():
-                    err: Dict[str, Any] = services.create_error_response(
+                    err: dict[str, Any] = services.create_error_response(
                         f"Ontology file not found: {ontology_file}", "file_not_found"
                     )
                     return err
                 generator = OntologyGenerator()
                 generator.load_from_file(str(ontology_path))
-                source_filename = ontology_file
                 logger.info(f"Loaded ontology from provided file: {ontology_file}")
             else:
-                generator, source_filename = services.load_ontology_from_session(ctx)
+                generator, _ = services.load_ontology_from_session(ctx)
         except ValueError as e:
             err = services.create_error_response(
-                f"{str(e)} - pass ontology_file parameter from generate_ontology response",
+                f"{e!s} - pass ontology_file parameter from generate_ontology response",
                 "session_error",
             )
             return err
@@ -455,7 +448,7 @@ async def apply_semantic_names(
                 name_suggestions = suggestions
         except json.JSONDecodeError as e:
             err = services.create_error_response(
-                f"Invalid JSON in suggestions parameter: {str(e)}",
+                f"Invalid JSON in suggestions parameter: {e!s}",
                 "parameter_error",
                 "Ensure suggestions is valid JSON with classes, properties, and relationships arrays",
             )
@@ -562,6 +555,6 @@ async def apply_semantic_names(
     except Exception as e:
         logger.error(f"Error applying semantic names: {e}")
         err = services.create_error_response(
-            f"Failed to apply semantic names: {str(e)}", "internal_error"
+            f"Failed to apply semantic names: {e!s}", "internal_error"
         )
         return err

--- a/src/handlers/query.py
+++ b/src/handlers/query.py
@@ -2,7 +2,7 @@
 
 import logging
 import re
-from typing import Any, Dict, Optional, Union
+from typing import Any
 
 from fastmcp import Context
 
@@ -41,7 +41,7 @@ def _extract_query_intent(sql: str) -> str:
 
     # Extract aggregation functions
     aggs = re.findall(r"\b(SUM|AVG|COUNT|MAX|MIN)\s*\(", sql, re.IGNORECASE)
-    aggs = list(set([a.upper() for a in aggs]))
+    aggs = list({a.upper() for a in aggs})
 
     # Extract WHERE conditions
     where_match = re.search(
@@ -73,7 +73,7 @@ async def validate_sql_syntax(
     ctx: Context,
     sql_query: str,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Validate SQL syntax, security, and fan-trap risks before execution.
 
     Args:
@@ -111,7 +111,7 @@ async def validate_sql_syntax(
                 "database_dialect": "unknown",
             }
 
-        validation_result: Dict[str, Any] = db_manager.validate_sql_syntax(
+        validation_result: dict[str, Any] = db_manager.validate_sql_syntax(
             sql_query.strip()
         )
 
@@ -190,7 +190,7 @@ async def validate_sql_syntax(
         logger.error(f"SQL validation error: {e}")
         return {
             "is_valid": False,
-            "error": f"Validation system error: {str(e)}",
+            "error": f"Validation system error: {e!s}",
             "error_type": "internal_error",
             "suggestions": [
                 "Check if the database connection is stable",
@@ -205,10 +205,10 @@ async def execute_sql_query(
     ctx: Context,
     sql_query: str,
     limit: int,
-    checklist_completed: Union[bool, str],
-    query_intent: Optional[str],
+    checklist_completed: bool | str,
+    query_intent: str | None,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Execute SQL query with built-in validation and fan-trap protection.
 
     Args:
@@ -322,7 +322,7 @@ async def execute_sql_query(
             except Exception as e:
                 logger.debug(f"Context auto-retrieval failed (non-critical): {e}")
 
-        result: Dict[str, Any] = db_manager.execute_sql_query(sql_query.strip(), limit)
+        result: dict[str, Any] = db_manager.execute_sql_query(sql_query.strip(), limit)
 
         # Merge OBQC warnings into result
         if obqc_warnings:
@@ -351,8 +351,8 @@ async def execute_sql_query(
 
     except Exception as e:
         logger.error(f"Critical error in SQL execution: {e}")
-        err: Dict[str, Any] = services.create_error_response(
-            f"Internal server error during SQL execution: {str(e)}",
+        err: dict[str, Any] = services.create_error_response(
+            f"Internal server error during SQL execution: {e!s}",
             "internal_error",
             "This may indicate a system-level issue. Please check server logs and try again.",
         )

--- a/src/handlers/rdf.py
+++ b/src/handlers/rdf.py
@@ -1,7 +1,7 @@
 """Oxigraph RDF store and SPARQL handler implementations."""
 
 import logging
-from typing import Any, Dict, Optional, Union
+from typing import Any
 
 from fastmcp import Context
 
@@ -21,10 +21,10 @@ logger = logging.getLogger(__name__)
 
 async def store_ontology_in_rdf(
     ctx: Context,
-    schema_name: Optional[str],
-    graph_uri: Optional[str],
+    schema_name: str | None,
+    graph_uri: str | None,
     services: "HandlerContext",
-) -> Union[str, Dict[str, Any]]:
+) -> str | dict[str, Any]:
     """Store current session ontology in persistent RDF store with SPARQL access."""
     if not OXIGRAPH_AVAILABLE:
         return DependencyError(
@@ -112,7 +112,7 @@ async def store_ontology_in_rdf(
 
     except Exception as e:
         logger.error(f"Failed to store ontology in RDF: {e}", exc_info=True)
-        return RDFError(f"Failed to store ontology: {str(e)}").to_response()
+        return RDFError(f"Failed to store ontology: {e!s}").to_response()
 
 
 def _detect_sparql_type(sparql_query: str) -> str:
@@ -135,7 +135,7 @@ async def query_sparql(
     sparql_query: str,
     timeout_seconds: int,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Execute SPARQL query (SELECT, ASK, or CONSTRUCT) against stored ontologies."""
     if not OXIGRAPH_AVAILABLE:
         return DependencyError("pyoxigraph not installed").to_response()
@@ -178,14 +178,14 @@ async def query_sparql(
 
     except Exception as e:
         logger.error(f"SPARQL query failed: {e}", exc_info=True)
-        return RDFError(f"SPARQL query failed: {str(e)}").to_response()
+        return RDFError(f"SPARQL query failed: {e!s}").to_response()
 
 
 async def query_sparql_ask(
     ctx: Context,
     sparql_query: str,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Execute SPARQL ASK query (returns true/false)."""
     if not OXIGRAPH_AVAILABLE:
         return DependencyError("pyoxigraph not installed").to_response()
@@ -201,7 +201,7 @@ async def query_sparql_ask(
 
     except Exception as e:
         logger.error(f"SPARQL ASK query failed: {e}", exc_info=True)
-        return RDFError(f"SPARQL ASK query failed: {str(e)}").to_response()
+        return RDFError(f"SPARQL ASK query failed: {e!s}").to_response()
 
 
 async def add_rdf_knowledge(
@@ -209,9 +209,9 @@ async def add_rdf_knowledge(
     subject: str,
     predicate: str,
     object_value: str,
-    metadata: Optional[Dict[str, Any]],
+    metadata: dict[str, Any] | None,
     services: "HandlerContext",
-) -> Union[str, Dict[str, Any]]:
+) -> str | dict[str, Any]:
     """Add custom knowledge/metadata to the RDF store."""
     if not OXIGRAPH_AVAILABLE:
         return DependencyError("pyoxigraph not installed").to_response()
@@ -238,14 +238,14 @@ async def add_rdf_knowledge(
 
     except Exception as e:
         logger.error(f"Failed to add knowledge: {e}", exc_info=True)
-        return RDFError(f"Failed to add knowledge: {str(e)}").to_response()
+        return RDFError(f"Failed to add knowledge: {e!s}").to_response()
 
 
 async def list_tables_sparql(
     ctx: Context,
-    schema_graph: Optional[str],
+    schema_graph: str | None,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """List all tables from stored ontology using SPARQL."""
     if not OXIGRAPH_AVAILABLE:
         return DependencyError("pyoxigraph not installed").to_response()
@@ -273,15 +273,15 @@ async def list_tables_sparql(
 
     except Exception as e:
         logger.error(f"SPARQL table listing failed: {e}", exc_info=True)
-        return RDFError(f"Failed to list tables: {str(e)}").to_response()
+        return RDFError(f"Failed to list tables: {e!s}").to_response()
 
 
 async def find_columns_by_type_sparql(
     ctx: Context,
     data_type: str,
-    schema_graph: Optional[str],
+    schema_graph: str | None,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Find columns by data type using SPARQL."""
     if not OXIGRAPH_AVAILABLE:
         return DependencyError("pyoxigraph not installed").to_response()
@@ -304,13 +304,13 @@ async def find_columns_by_type_sparql(
 
     except Exception as e:
         logger.error(f"SPARQL column search failed: {e}", exc_info=True)
-        return RDFError(f"Failed to find columns: {str(e)}").to_response()
+        return RDFError(f"Failed to find columns: {e!s}").to_response()
 
 
 async def get_rdf_store_stats(
     ctx: Context,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get statistics about the persistent RDF store."""
     if not OXIGRAPH_AVAILABLE:
         return DependencyError("pyoxigraph not installed").to_response()
@@ -326,4 +326,4 @@ async def get_rdf_store_stats(
 
     except Exception as e:
         logger.error(f"Failed to get store stats: {e}", exc_info=True)
-        return RDFError(f"Failed to get stats: {str(e)}").to_response()
+        return RDFError(f"Failed to get stats: {e!s}").to_response()

--- a/src/handlers/schema.py
+++ b/src/handlers/schema.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import logging
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from fastmcp import Context
 
@@ -18,9 +18,9 @@ logger = logging.getLogger(__name__)
 
 async def reset_cache(
     ctx: Context,
-    cache_type: Optional[str],
+    cache_type: str | None,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Reset cached schema and/or ontology data to force re-analysis.
 
     Args:
@@ -62,10 +62,10 @@ async def reset_cache(
 
 async def discover_schema(
     ctx: Context,
-    schema_name: Optional[str],
+    schema_name: str | None,
     lightweight: bool,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Analyze database schema and return table metadata with relationships.
 
     Args:
@@ -498,9 +498,9 @@ async def discover_schema(
 async def get_table_details(
     ctx: Context,
     table_name: str,
-    schema_name: Optional[str],
+    schema_name: str | None,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get detailed metadata for a single table.
 
     Args:
@@ -593,7 +593,7 @@ async def get_table_details(
 
     except Exception as e:
         logger.error(f"Failed to get table details for {table_name}: {e}")
-        await ctx.error(f"Failed to analyze table '{table_name}': {str(e)}")
+        await ctx.error(f"Failed to analyze table '{table_name}': {e!s}")
         return {
             "success": False,
             "error": str(e),
@@ -605,10 +605,10 @@ async def get_table_details(
 async def sample_table_data(
     ctx: Context,
     table_name: str,
-    schema_name: Optional[str],
+    schema_name: str | None,
     limit: int,
     services: "HandlerContext",
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Sample data from a specific table for analysis.
 
     Args:
@@ -630,7 +630,7 @@ async def sample_table_data(
         schema_name = session.get_last_analyzed_schema()
 
     db_manager = services.get_session_db_manager(ctx)
-    sample_data: List[Dict[str, Any]] = db_manager.sample_table_data(
+    sample_data: list[dict[str, Any]] = db_manager.sample_table_data(
         table_name, schema_name, limit
     )
 

--- a/src/handlers/workspace.py
+++ b/src/handlers/workspace.py
@@ -5,7 +5,7 @@ import logging
 import shutil
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from fastmcp import Context
 
@@ -23,9 +23,9 @@ async def _restore_workspace_core(
     ctx: Context,
     session: Any,
     connection_id: str,
-    schema_name: Optional[str],
+    schema_name: str | None,
     services: "HandlerContext",
-) -> Optional[Dict[str, Any]]:
+) -> dict[str, Any] | None:
     """Core workspace restore logic shared by connect_database and cleanup recovery.
 
     Loads schema cache, ontology, GraphRAG, and RDF store from disk into
@@ -68,8 +68,8 @@ async def _restore_workspace_core(
     if not schemas_to_restore:
         return None
 
-    restored: List[str] = []
-    failed: List[str] = []
+    restored: list[str] = []
+    failed: list[str] = []
     any_ontology_enriched = False
 
     # --- Per-schema restore: schema cache + ontology ---
@@ -84,7 +84,7 @@ async def _restore_workspace_core(
             schema_path = conn_dir / schema_file
             if schema_path.exists():
                 try:
-                    with open(schema_path, "r", encoding="utf-8") as f:
+                    with open(schema_path, encoding="utf-8") as f:
                         schema_json = json.load(f)
 
                     tables_raw = schema_json.get("tables", [])
@@ -186,7 +186,7 @@ async def _restore_workspace_core(
     }
 
 
-def _format_restore_summary(result: Dict[str, Any]) -> str:
+def _format_restore_summary(result: dict[str, Any]) -> str:
     """Format a restore result dict into a user-facing markdown summary.
 
     Args:
@@ -212,14 +212,12 @@ def _format_restore_summary(result: Dict[str, Any]) -> str:
 
     if restored:
         lines.append("## Restored")
-        for item in restored:
-            lines.append(f"- {item}")
+        lines.extend(f"- {item}" for item in restored)
 
     if failed:
         lines.append("")
         lines.append("## Not Restored")
-        for item in failed:
-            lines.append(f"- {item}")
+        lines.extend(f"- {item}" for item in failed)
         lines.append("")
         lines.append("Use the relevant tools to regenerate missing components.")
 
@@ -238,8 +236,7 @@ def _format_restore_summary(result: Dict[str, Any]) -> str:
     if skip_tools:
         lines.append("")
         lines.append("## DO NOT CALL (already restored)")
-        for tool in skip_tools:
-            lines.append(f"- {tool}")
+        lines.extend(f"- {tool}" for tool in skip_tools)
 
     lines.append("")
     lines.append("## Ready to Use")
@@ -274,7 +271,7 @@ def _format_restore_summary(result: Dict[str, Any]) -> str:
 async def cleanup_workspace(
     ctx: Context,
     services: "HandlerContext",
-) -> Union[str, Dict[str, Any]]:
+) -> str | dict[str, Any]:
     """Delete all workspace files for the current connection and clear session state.
 
     Removes schema JSON, ontology TTL, R2RML mappings, GraphRAG data,
@@ -292,7 +289,7 @@ async def cleanup_workspace(
     session = services.get_session_data(ctx)
 
     if not session.connection_id:
-        err: Dict[str, Any] = services.create_error_response(
+        err: dict[str, Any] = services.create_error_response(
             "No database connection. Call connect_database first.",
             "connection_error",
         )
@@ -358,9 +355,9 @@ async def save_semantic_model(
     ctx: Context,
     model_yaml: str,
     model_name: str,
-    schema_name: Optional[str],
+    schema_name: str | None,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Save a semantic model YAML to the workspace for reuse across sessions.
 
     Args:
@@ -377,7 +374,7 @@ async def save_semantic_model(
     session = services.get_session_data(ctx)
 
     if not session.connection_id:
-        err: Dict[str, Any] = services.create_error_response(
+        err: dict[str, Any] = services.create_error_response(
             "No database connection. Call connect_database first.",
             "connection_error",
         )
@@ -449,7 +446,7 @@ async def get_semantic_model(
     ctx: Context,
     model_name: str,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Retrieve a stored semantic model YAML by name.
 
     Args:
@@ -464,7 +461,7 @@ async def get_semantic_model(
     session = services.get_session_data(ctx)
 
     if not session.connection_id:
-        err: Dict[str, Any] = services.create_error_response(
+        err: dict[str, Any] = services.create_error_response(
             "No database connection. Call connect_database first.",
             "connection_error",
         )
@@ -529,7 +526,7 @@ async def get_semantic_model(
 async def list_semantic_models(
     ctx: Context,
     services: "HandlerContext",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """List all stored semantic models for the current connection.
 
     Args:
@@ -543,7 +540,7 @@ async def list_semantic_models(
     session = services.get_session_data(ctx)
 
     if not session.connection_id:
-        err: Dict[str, Any] = services.create_error_response(
+        err: dict[str, Any] = services.create_error_response(
             "No database connection. Call connect_database first.",
             "connection_error",
         )

--- a/src/lifecycle/__init__.py
+++ b/src/lifecycle/__init__.py
@@ -14,10 +14,10 @@ from .metadata import (
 )
 
 __all__ = [
-    "VersionMetadataManager",
-    "VersionInfo",
-    "RetentionPolicy",
     "DataCleanupManager",
-    "update_workspace_section",
+    "RetentionPolicy",
+    "VersionInfo",
+    "VersionMetadataManager",
     "update_workspace_rdf",
+    "update_workspace_section",
 ]

--- a/src/lifecycle/cleanup.py
+++ b/src/lifecycle/cleanup.py
@@ -8,7 +8,7 @@ based on retention policies.
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any
 
 from .metadata import VersionMetadataManager
 
@@ -35,7 +35,7 @@ class DataCleanupManager:
 
     def cleanup_graphrag(
         self, schema_name: str, dry_run: bool = True
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Clean up old GraphRAG data based on retention policy.
 
@@ -96,8 +96,8 @@ class DataCleanupManager:
         self,
         schema_name: str,
         dry_run: bool = True,
-        oxigraph_store: Optional[Any] = None,
-    ) -> Dict[str, Any]:
+        oxigraph_store: Any | None = None,
+    ) -> dict[str, Any]:
         """
         Clean up old RDF ontology data based on retention policy.
 

--- a/src/lifecycle/metadata.py
+++ b/src/lifecycle/metadata.py
@@ -12,12 +12,12 @@ import logging
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
 # Module-level lock dict for serializing concurrent metadata writes per connection
-_metadata_locks: Dict[str, asyncio.Lock] = {}
+_metadata_locks: dict[str, asyncio.Lock] = {}
 
 
 @dataclass
@@ -41,7 +41,7 @@ class VersionInfo:
     ontology_status: str  # "active" or "archived"
 
     # Changes from previous version (if any)
-    changes: Optional[Dict[str, Any]] = None
+    changes: dict[str, Any] | None = None
 
     # Overall status
     status: str = "active"  # "active" or "archived"
@@ -83,12 +83,12 @@ class VersionMetadataManager:
         # Load or initialize metadata
         self.metadata = self._load_metadata()
 
-    def _load_metadata(self) -> Dict[str, Any]:
+    def _load_metadata(self) -> dict[str, Any]:
         """Load metadata from disk or create new."""
         if self.metadata_file.exists():
             try:
-                with open(self.metadata_file, "r") as f:
-                    metadata: Dict[str, Any] = json.load(f)
+                with open(self.metadata_file) as f:
+                    metadata: dict[str, Any] = json.load(f)
                 logger.debug(f"Loaded metadata for connection {self.connection_id}")
                 return metadata
             except Exception as e:
@@ -98,7 +98,7 @@ class VersionMetadataManager:
         else:
             return self._create_fresh_metadata()
 
-    def _create_fresh_metadata(self) -> Dict[str, Any]:
+    def _create_fresh_metadata(self) -> dict[str, Any]:
         """Create fresh metadata structure."""
         return {
             "connection_id": self.connection_id,
@@ -116,14 +116,14 @@ class VersionMetadataManager:
         except Exception as e:
             logger.error(f"Failed to save metadata: {e}")
 
-    def get_schema_metadata(self, schema_name: str) -> Optional[Dict[str, Any]]:
+    def get_schema_metadata(self, schema_name: str) -> dict[str, Any] | None:
         """Get metadata for a specific schema."""
-        schema_meta: Optional[Dict[str, Any]] = self.metadata.get("schemas", {}).get(
+        schema_meta: dict[str, Any] | None = self.metadata.get("schemas", {}).get(
             schema_name
         )
         return schema_meta
 
-    def get_current_version(self, schema_name: str) -> Optional[VersionInfo]:
+    def get_current_version(self, schema_name: str) -> VersionInfo | None:
         """Get current (active) version for a schema."""
         schema_meta = self.get_schema_metadata(schema_name)
         if not schema_meta:
@@ -145,7 +145,7 @@ class VersionMetadataManager:
         self,
         schema_name: str,
         data_type: str = "all",  # "graphrag", "ontology", or "all"
-    ) -> List[VersionInfo]:
+    ) -> list[VersionInfo]:
         """
         Get versions that should be cleaned up based on retention policy.
 
@@ -209,12 +209,12 @@ class VersionMetadataManager:
 
     def _get_cleanup_list(
         self,
-        versions: List[VersionInfo],
+        versions: list[VersionInfo],
         keep_count: int,
         max_age_days: int,
         min_versions: int,
         status_field: str,
-    ) -> List[VersionInfo]:
+    ) -> list[VersionInfo]:
         """
         Get versions to cleanup based on policy.
 
@@ -297,25 +297,23 @@ class VersionMetadataManager:
 
     # --- Workspace State Management ---
 
-    def get_workspace(self) -> Optional[Dict[str, Any]]:
+    def get_workspace(self) -> dict[str, Any] | None:
         """Get the full workspace section from metadata."""
         return self.metadata.get("workspace")
 
-    def get_workspace_schema(self, schema_name: str) -> Optional[Dict[str, Any]]:
+    def get_workspace_schema(self, schema_name: str) -> dict[str, Any] | None:
         """Get workspace data for a specific schema."""
         workspace = self.get_workspace()
         if not workspace:
             return None
-        schema_ws: Optional[Dict[str, Any]] = workspace.get("schemas", {}).get(
-            schema_name
-        )
+        schema_ws: dict[str, Any] | None = workspace.get("schemas", {}).get(schema_name)
         return schema_ws
 
     def update_workspace(
         self,
         schema_name: str,
         section: str,
-        data: Dict[str, Any],
+        data: dict[str, Any],
     ) -> None:
         """Update a workspace section for a schema.
 
@@ -368,7 +366,7 @@ class VersionMetadataManager:
 
         self._save_metadata()
 
-    def update_workspace_rdf_store(self, data: Dict[str, Any]) -> None:
+    def update_workspace_rdf_store(self, data: dict[str, Any]) -> None:
         """Update connection-level RDF store info.
 
         Args:
@@ -392,7 +390,7 @@ async def update_workspace_section(
     output_dir: Path,
     schema_name: str,
     section: str,
-    data: Dict[str, Any],
+    data: dict[str, Any],
 ) -> None:
     """Thread-safe workspace section update with per-connection locking.
 
@@ -415,7 +413,7 @@ async def update_workspace_section(
 async def update_workspace_rdf(
     connection_id: str,
     output_dir: Path,
-    data: Dict[str, Any],
+    data: dict[str, Any],
 ) -> None:
     """Thread-safe RDF store workspace update.
 

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ modules so this file stays mostly decorators + delegation:
 
 import logging
 import os
-from typing import Annotated, Any, Dict, List, Literal, Optional, Union, cast
+from typing import Annotated, Any, Literal, cast
 
 from dotenv import load_dotenv
 from fastmcp import Context, FastMCP
@@ -193,7 +193,7 @@ async def connect_database(ctx: Context, db_type: _DbType) -> str:  # type: igno
 
 
 @mcp.tool()
-async def list_schemas(ctx: Context) -> List[str]:
+async def list_schemas(ctx: Context) -> list[str]:
     """Get a list of available schemas from the connected database.
 
     REQUIRES: connect_database must be called first.
@@ -204,8 +204,8 @@ async def list_schemas(ctx: Context) -> List[str]:
 @mcp.tool()
 async def reset_cache(
     ctx: Context,
-    cache_type: Optional[Literal["schema", "ontology", "all"]] = None,
-) -> Dict[str, Any]:
+    cache_type: Literal["schema", "ontology", "all"] | None = None,
+) -> dict[str, Any]:
     """Reset cached schema and/or ontology data to force re-analysis.
 
     Args:
@@ -220,9 +220,9 @@ async def reset_cache(
 @mcp.tool()
 async def discover_schema(
     ctx: Context,
-    schema_name: Optional[_Identifier] = None,
+    schema_name: _Identifier | None = None,
     lightweight: bool = True,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Analyze database schema and return table metadata with relationships.
 
     REQUIRES: connect_database must be called first and must complete before calling this tool.
@@ -244,8 +244,8 @@ async def discover_schema(
 async def get_table_details(
     ctx: Context,
     table_name: _Identifier,
-    schema_name: Optional[_Identifier] = None,
-) -> Dict[str, Any]:
+    schema_name: _Identifier | None = None,
+) -> dict[str, Any]:
     """Get detailed metadata for a single table. Only use when you need to
     inspect a specific table that the user asked about — do NOT call this for
     every table. discover_schema() and the ontology already contain full
@@ -268,11 +268,11 @@ async def get_table_details(
 @mcp.tool()
 async def generate_ontology(
     ctx: Context,
-    schema_info: Optional[_DocBody] = None,
-    schema_name: Optional[_Identifier] = None,
+    schema_info: _DocBody | None = None,
+    schema_name: _Identifier | None = None,
     base_uri: _Uri = "http://example.com/ontology/",
     auto_persist: bool = True,
-    graph_uri: Optional[_Uri] = None,
+    graph_uri: _Uri | None = None,
 ) -> str:
     """Generate an RDF ontology from database schema. AUTO-ANALYZES schema if needed!
 
@@ -303,8 +303,8 @@ async def generate_ontology(
 @mcp.tool()
 async def suggest_semantic_names(
     ctx: Context,
-    ontology_file: Optional[_SafeName] = None,
-) -> Dict[str, Any]:
+    ontology_file: _SafeName | None = None,
+) -> dict[str, Any]:
     """Extract and analyze names from a generated ontology to identify abbreviations and cryptic names.
 
     When the connected MCP client supports sampling (and ENABLE_SAMPLING=true),
@@ -328,8 +328,8 @@ async def suggest_semantic_names(
 @mcp.tool()
 async def apply_semantic_names(
     ctx: Context,
-    suggestions: Union[Annotated[str, Field(max_length=2_000_000)], Dict[str, Any]],
-    ontology_file: Optional[_SafeName] = None,
+    suggestions: Annotated[str, Field(max_length=2000000)] | dict[str, Any],
+    ontology_file: _SafeName | None = None,
     save_to_file: bool = True,
 ) -> str:
     """Apply semantic name suggestions to an existing ontology.
@@ -373,10 +373,10 @@ async def load_my_ontology(
     ctx: Context,
     import_folder: _FolderPath = "./import",
     auto_persist: bool = True,
-    graph_uri: Optional[_Uri] = None,
-    ontology_content: Optional[_DocBody] = None,
-    file_name: Optional[_SafeName] = None,
-) -> Dict[str, Any]:
+    graph_uri: _Uri | None = None,
+    ontology_content: _DocBody | None = None,
+    file_name: _SafeName | None = None,
+) -> dict[str, Any]:
     """Load an ontology in Turtle (.ttl) format.
 
     Accepts either inline content (e.g. when the user drops a .ttl file into the
@@ -407,9 +407,9 @@ async def load_my_ontology(
 async def download_artifact(
     ctx: Context,
     artifact_type: Literal["ontology", "r2rml"],
-    schema_name: Optional[_Identifier] = None,
+    schema_name: _Identifier | None = None,
     source: Literal["rdf", "file"] = "rdf",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Download a generated artifact as TTL file.
 
     Args:
@@ -440,9 +440,9 @@ async def download_artifact(
 async def sample_table_data(
     ctx: Context,
     table_name: _Identifier,
-    schema_name: Optional[_Identifier] = None,
+    schema_name: _Identifier | None = None,
     limit: int = 10,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Sample data from a specific table for analysis.
 
     REQUIRES: connect_database must be called first.
@@ -467,8 +467,8 @@ async def execute_sql_query(
     sql_query: _QueryBody,
     limit: int = 1000,
     checklist_completed: bool = False,
-    query_intent: Optional[_ShortText] = None,
-) -> Dict[str, Any]:
+    query_intent: _ShortText | None = None,
+) -> dict[str, Any]:
     """Execute SQL query with built-in syntax validation, security checks, OBQC
     validation, and fan-trap protection.
 
@@ -502,17 +502,15 @@ async def execute_sql_query(
 @mcp.tool()
 async def generate_chart(
     ctx: Context,
-    data_source: Union[
-        List[Dict[str, Any]], Annotated[str, Field(max_length=5_000_000)]
-    ],
+    data_source: list[dict[str, Any]] | Annotated[str, Field(max_length=5000000)],
     chart_type: Literal["bar", "line", "scatter", "heatmap"],
     x_column: _Identifier,
-    y_column: Optional[Union[_Identifier, List[_Identifier]]] = None,
-    color_column: Optional[_Identifier] = None,
-    title: Optional[_ShortText] = None,
+    y_column: _Identifier | list[_Identifier] | None = None,
+    color_column: _Identifier | None = None,
+    title: _ShortText | None = None,
     chart_style: Literal["grouped", "stacked"] = "grouped",
-    sort_by: Optional[_Identifier] = None,
-    sort_order: Optional[Literal["ascending", "descending"]] = None,
+    sort_by: _Identifier | None = None,
+    sort_order: Literal["ascending", "descending"] | None = None,
     output_format: Literal["interactive", "image"] = "interactive",
 ) -> str:
     """Generate a chart from query results. Returns a ui:// MCP Apps widget for interactive use.
@@ -578,8 +576,8 @@ async def save_semantic_model(
     ctx: Context,
     model_yaml: _DocBody,
     model_name: _SafeName,
-    schema_name: Optional[_Identifier] = None,
-) -> Dict[str, Any]:
+    schema_name: _Identifier | None = None,
+) -> dict[str, Any]:
     """Save a semantic model (e.g., OBML YAML) to the workspace for reuse across sessions.
 
     Stores the model definition so it can be retrieved in future sessions via
@@ -603,7 +601,7 @@ async def save_semantic_model(
 async def get_semantic_model(
     ctx: Context,
     model_name: _SafeName,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Retrieve a stored semantic model YAML by name.
 
     Use this to get a previously saved model definition, e.g., to pass it
@@ -620,7 +618,7 @@ async def get_semantic_model(
 
 
 @mcp.tool()
-async def list_semantic_models(ctx: Context) -> Dict[str, Any]:
+async def list_semantic_models(ctx: Context) -> dict[str, Any]:
     """List all stored semantic models for the current database connection.
 
     Returns:
@@ -638,11 +636,11 @@ async def list_semantic_models(ctx: Context) -> Dict[str, Any]:
 @mcp.tool()
 async def graphrag_search(
     ctx: Context,
-    query: Optional[_QueryText] = None,
+    query: _QueryText | None = None,
     top_k: int = 5,
-    element_type: Optional[Literal["table", "column", "relationship"]] = None,
+    element_type: Literal["table", "column", "relationship"] | None = None,
     overview: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Search schema using natural language via GraphRAG, or get a schema overview.
 
     GraphRAG is auto-initialized by discover_schema. Pass overview=True to get
@@ -679,7 +677,7 @@ async def graphrag_query_context(
     query: _QueryText,
     max_tables: int = 5,
     max_columns: int = 20,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get optimized context for SQL query generation using GraphRAG.
 
     Args:
@@ -705,7 +703,7 @@ async def graphrag_find_join_path(
     from_table: _Identifier,
     to_table: _Identifier,
     max_hops: int = 3,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Find join path between two tables using GraphRAG graph traversal.
 
     Args:
@@ -729,8 +727,8 @@ async def graphrag_find_join_path(
 async def reachable_from(
     ctx: Context,
     table: _Identifier,
-    max_hops: Optional[int] = None,
-) -> Dict[str, Any]:
+    max_hops: int | None = None,
+) -> dict[str, Any]:
     """List the dimension-capable tables for a query anchored on a table.
 
     Follows foreign keys in the many-to-one (finer grain -> coarser grain)
@@ -759,8 +757,8 @@ async def reachable_from(
 async def measurable_from(
     ctx: Context,
     table: _Identifier,
-    max_hops: Optional[int] = None,
-) -> Dict[str, Any]:
+    max_hops: int | None = None,
+) -> dict[str, Any]:
     """List the measure-capable tables for a query anchored on a table.
 
     Follows foreign keys in the one-to-many (toward finer grain) direction: the
@@ -786,9 +784,9 @@ async def measurable_from(
 @mcp.tool()
 async def plan_composite_query(
     ctx: Context,
-    facts: List[_Identifier],
-    dimensions: Optional[List[_Identifier]] = None,
-) -> Dict[str, Any]:
+    facts: list[_Identifier],
+    dimensions: list[_Identifier] | None = None,
+) -> dict[str, Any]:
     """Advise a Composite Fact Layer (CFL) decomposition for a multi-fact query.
 
     Given the fact (measure-source) tables a query needs, determines whether
@@ -823,8 +821,8 @@ async def plan_composite_query(
 @mcp.tool()
 async def store_ontology_in_rdf(
     ctx: Context,
-    schema_name: Optional[_Identifier] = None,
-    graph_uri: Optional[_Uri] = None,
+    schema_name: _Identifier | None = None,
+    graph_uri: _Uri | None = None,
 ) -> str:
     """Store current session ontology in persistent RDF store with SPARQL access.
 
@@ -851,7 +849,7 @@ async def query_sparql(
     ctx: Context,
     sparql_query: _QueryBody,
     timeout_seconds: int = 30,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Execute a SPARQL query against the RDF ontology store. Use this to explore
     schema relationships, classes, properties, and semantic metadata loaded via
     generate_ontology or load_my_ontology. Requires an ontology to be loaded first.
@@ -883,7 +881,7 @@ async def add_rdf_knowledge(
     subject: _Uri,
     predicate: _Uri,
     object: Annotated[str, Field(max_length=8192)],
-    metadata: Optional[Dict[str, Any]] = None,
+    metadata: dict[str, Any] | None = None,
 ) -> str:
     """Add custom knowledge/metadata to the RDF store.
 
@@ -917,7 +915,7 @@ def cleanup_server() -> None:
     _server_state.cleanup()
 
 
-def get_registered_tool_names() -> List[str]:
+def get_registered_tool_names() -> list[str]:
     """Return the sorted names of every tool registered on the MCP server.
 
     This is the single source of truth for tool counts in the startup banner

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -8,7 +8,7 @@ and fan-trap patterns without using LLM.
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set
+from typing import Any
 
 import sqlglot
 from rdflib import Graph, Namespace, URIRef
@@ -50,9 +50,9 @@ class OBQCIssue:
     issue_type: OBQCIssueType
     severity: OBQCSeverity
     message: str
-    location: Optional[str] = None
-    suggestion: Optional[str] = None
-    related_entities: List[str] = field(default_factory=list)
+    location: str | None = None
+    suggestion: str | None = None
+    related_entities: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -60,16 +60,16 @@ class OBQCResult:
     """Complete OBQC validation result."""
 
     is_valid: bool
-    issues: List[OBQCIssue] = field(default_factory=list)
-    parsed_tables: List[str] = field(default_factory=list)
-    parsed_columns: List[str] = field(default_factory=list)
-    parsed_joins: List[Dict[str, Any]] = field(default_factory=list)
+    issues: list[OBQCIssue] = field(default_factory=list)
+    parsed_tables: list[str] = field(default_factory=list)
+    parsed_columns: list[str] = field(default_factory=list)
+    parsed_joins: list[dict[str, Any]] = field(default_factory=list)
     has_aggregation: bool = False
     has_group_by: bool = False
     fan_trap_risk: bool = False
     ontology_compatible: bool = True  # Whether ontology has oba: annotations
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert result to dictionary for JSON serialization."""
         return {
             "obqc_valid": self.is_valid,
@@ -107,12 +107,12 @@ class ColumnSchema:
     name: str
     table_name: str
     sql_data_type: str
-    xsd_type: Optional[URIRef] = None
+    xsd_type: URIRef | None = None
     is_nullable: bool = True
     is_primary_key: bool = False
     is_foreign_key: bool = False
-    fk_referenced_table: Optional[str] = None
-    fk_referenced_column: Optional[str] = None
+    fk_referenced_table: str | None = None
+    fk_referenced_column: str | None = None
 
 
 @dataclass
@@ -121,8 +121,8 @@ class TableSchema:
 
     name: str
     schema_name: str
-    columns: Dict[str, ColumnSchema] = field(default_factory=dict)
-    primary_keys: List[str] = field(default_factory=list)
+    columns: dict[str, ColumnSchema] = field(default_factory=dict)
+    primary_keys: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -141,8 +141,8 @@ class RelationshipInfo:
 class OntologySchema:
     """Cached schema information extracted from ontology."""
 
-    tables: Dict[str, TableSchema] = field(default_factory=dict)
-    relationships: Dict[str, RelationshipInfo] = field(default_factory=dict)
+    tables: dict[str, TableSchema] = field(default_factory=dict)
+    relationships: dict[str, RelationshipInfo] = field(default_factory=dict)
 
 
 class OBQCValidator:
@@ -162,15 +162,15 @@ class OBQCValidator:
     DIALECT_MAP = DB_SQLGLOT_DIALECTS
 
     def __init__(self) -> None:
-        self._schema_cache: Optional[OntologySchema] = None
-        self._graph: Optional[Graph] = None
-        self._base_uri: Optional[Namespace] = None
-        self._oba_ns: Optional[Namespace] = None
+        self._schema_cache: OntologySchema | None = None
+        self._graph: Graph | None = None
+        self._base_uri: Namespace | None = None
+        self._oba_ns: Namespace | None = None
         self._is_compatible: bool = False  # Whether ontology has oba: annotations
         # Fan-trap topology read straight from the ontology axioms (Phase 2):
         # pairs of lower-cased table names declared owl:disjointWith each other
         # (sibling facts sharing a dimension — the canonical fan-trap shape).
-        self._disjoint_pairs: Set[frozenset] = set()
+        self._disjoint_pairs: set[frozenset] = set()
 
     def load_ontology(self, ontology_graph: Graph, base_uri: str) -> None:
         """Load and cache schema from ontology graph.
@@ -321,7 +321,7 @@ class OBQCValidator:
 
         return schema
 
-    def _extract_disjoint_pairs(self) -> Set[frozenset]:
+    def _extract_disjoint_pairs(self) -> set[frozenset]:
         """Read owl:disjointWith axioms as pairs of lower-cased table names.
 
         The generator emits owl:disjointWith between sibling fact tables that
@@ -329,7 +329,7 @@ class OBQCValidator:
         topology. Reading it here lets OBQC ground fan-trap detection in the
         ontology instead of re-deriving it from the relationship heuristic.
         """
-        pairs: Set[frozenset] = set()
+        pairs: set[frozenset] = set()
         if self._graph is None or self._oba_ns is None:
             return pairs
 
@@ -341,7 +341,7 @@ class OBQCValidator:
 
         return pairs
 
-    def _get_literal(self, subject: Node, predicate: URIRef) -> Optional[str]:
+    def _get_literal(self, subject: Node, predicate: URIRef) -> str | None:
         """Get string value of a literal predicate."""
         if self._graph is None:
             return None
@@ -405,7 +405,7 @@ class OBQCValidator:
                 OBQCIssue(
                     issue_type=OBQCIssueType.TABLE_NOT_FOUND,
                     severity=OBQCSeverity.ERROR,
-                    message=f"SQL parse error: {str(e)}",
+                    message=f"SQL parse error: {e!s}",
                     location="Query",
                 )
             )
@@ -451,7 +451,7 @@ class OBQCValidator:
     def _extract_joins(self, parsed: exp.Expr, result: OBQCResult) -> None:
         """Extract join information from parsed query."""
         for join in parsed.find_all(exp.Join):
-            join_info: Dict[str, Any] = {
+            join_info: dict[str, Any] = {
                 "type": join.kind or "INNER",
                 "table": None,
                 "on_condition": None,
@@ -527,14 +527,16 @@ class OBQCValidator:
             else:
                 # Unqualified column - check for ambiguity
                 col_key = col_ref.lower()
-                found_in_tables: List[str] = []
+                found_in_tables: list[str] = []
 
                 # Only check tables that are actually in the query
                 for table_name in result.parsed_tables:
                     table_key = table_name.lower()
-                    if table_key in self._schema_cache.tables:
-                        if col_key in self._schema_cache.tables[table_key].columns:
-                            found_in_tables.append(table_name)
+                    if (
+                        table_key in self._schema_cache.tables
+                        and col_key in self._schema_cache.tables[table_key].columns
+                    ):
+                        found_in_tables.append(table_name)
 
                 if len(found_in_tables) == 0 and len(result.parsed_tables) > 0:
                     result.issues.append(
@@ -608,7 +610,7 @@ class OBQCValidator:
                 )
 
     def _is_valid_join_condition(
-        self, join_table: Optional[str], on_condition: str, all_tables: List[str]
+        self, join_table: str | None, on_condition: str, all_tables: list[str]
     ) -> bool:
         """Check if join condition matches a declared relationship."""
         if self._schema_cache is None or join_table is None:
@@ -618,22 +620,21 @@ class OBQCValidator:
         join_table_lower = join_table.lower()
 
         for rel_info in self._schema_cache.relationships.values():
-            # Check if relationship involves the join table
+            # Relationship must involve the join table AND the condition must
+            # reference both of its FK columns.
             if (
                 rel_info.from_table.lower() == join_table_lower
                 or rel_info.to_table.lower() == join_table_lower
+            ) and (
+                rel_info.from_column.lower() in on_lower
+                and rel_info.to_column.lower() in on_lower
             ):
-                # Check if condition references the FK columns
-                if (
-                    rel_info.from_column.lower() in on_lower
-                    and rel_info.to_column.lower() in on_lower
-                ):
-                    return True
+                return True
         return False
 
     def _get_suggested_join(
-        self, join_table: Optional[str], all_tables: List[str]
-    ) -> Optional[str]:
+        self, join_table: str | None, all_tables: list[str]
+    ) -> str | None:
         """Get suggested join condition from ontology relationships."""
         if self._schema_cache is None or join_table is None:
             return None
@@ -642,12 +643,16 @@ class OBQCValidator:
         all_tables_lower = [t.lower() for t in all_tables]
 
         for rel_info in self._schema_cache.relationships.values():
-            if rel_info.from_table.lower() == join_table_lower:
-                if rel_info.to_table.lower() in all_tables_lower:
-                    return f"Suggested: {rel_info.join_condition}"
-            elif rel_info.to_table.lower() == join_table_lower:
-                if rel_info.from_table.lower() in all_tables_lower:
-                    return f"Suggested: {rel_info.join_condition}"
+            if (
+                rel_info.from_table.lower() == join_table_lower
+                and rel_info.to_table.lower() in all_tables_lower
+            ):
+                return f"Suggested: {rel_info.join_condition}"
+            if (
+                rel_info.to_table.lower() == join_table_lower
+                and rel_info.from_table.lower() in all_tables_lower
+            ):
+                return f"Suggested: {rel_info.join_condition}"
         return None
 
     def _validate_type_compatibility(
@@ -663,19 +668,22 @@ class OBQCValidator:
             left_type = self._infer_type(left)
             right_type = self._infer_type(right)
 
-            if left_type and right_type:
-                if not self._types_compatible(left_type, right_type):
-                    result.issues.append(
-                        OBQCIssue(
-                            issue_type=OBQCIssueType.TYPE_MISMATCH,
-                            severity=OBQCSeverity.WARNING,
-                            message=f"Type mismatch: {self._type_name(left_type)} vs {self._type_name(right_type)}",
-                            location="WHERE/ON clause",
-                            suggestion="Ensure compared values have compatible types",
-                        )
+            if (
+                left_type
+                and right_type
+                and not self._types_compatible(left_type, right_type)
+            ):
+                result.issues.append(
+                    OBQCIssue(
+                        issue_type=OBQCIssueType.TYPE_MISMATCH,
+                        severity=OBQCSeverity.WARNING,
+                        message=f"Type mismatch: {self._type_name(left_type)} vs {self._type_name(right_type)}",
+                        location="WHERE/ON clause",
+                        suggestion="Ensure compared values have compatible types",
                     )
+                )
 
-    def _infer_type(self, expr: exp.Expr) -> Optional[str]:
+    def _infer_type(self, expr: exp.Expr) -> str | None:
         """Infer the XSD type of an expression from ontology."""
         if self._schema_cache is None:
             return None
@@ -750,7 +758,7 @@ class OBQCValidator:
             expressions = select.args.get("expressions", [])
 
             # Get GROUP BY columns
-            group_by_cols: Set[str] = set()
+            group_by_cols: set[str] = set()
             if select.args.get("group"):
                 for group_expr in select.args["group"].expressions:
                     if isinstance(group_expr, exp.Column):
@@ -761,8 +769,8 @@ class OBQCValidator:
 
             # Check each SELECT expression
             for expr in expressions:
-                col_name: Optional[str] = None
-                col_table: Optional[str] = None
+                col_name: str | None = None
+                col_table: str | None = None
 
                 if isinstance(expr, exp.Column):
                     col_name = expr.name
@@ -813,13 +821,18 @@ class OBQCValidator:
 
         for agg in select.find_all(*agg_types):
             for col in agg.find_all(exp.Column):
-                if isinstance(expr, exp.Column):
-                    if col.name == expr.name:
-                        if col.table == expr.table:
-                            return True
-                elif isinstance(expr, exp.Alias) and isinstance(expr.this, exp.Column):
-                    if col.name == expr.this.name:
-                        return True
+                if (
+                    isinstance(expr, exp.Column)
+                    and col.name == expr.name
+                    and col.table == expr.table
+                ):
+                    return True
+                if (
+                    isinstance(expr, exp.Alias)
+                    and isinstance(expr.this, exp.Column)
+                    and col.name == expr.this.name
+                ):
+                    return True
         return False
 
     def _detect_fan_trap(self, result: OBQCResult) -> None:
@@ -841,7 +854,7 @@ class OBQCValidator:
 
         # --- Axiom-grounded path: disjoint sibling facts in the same query ----
         queried = {t.lower() for t in result.parsed_tables}
-        disjoint_hits: Set[frozenset] = {
+        disjoint_hits: set[frozenset] = {
             pair for pair in self._disjoint_pairs if pair <= queried
         }
         if disjoint_hits:
@@ -869,7 +882,7 @@ class OBQCValidator:
 
         # --- Heuristic fallback: count one-to-many joins (no disjointness axioms)
         one_to_many_count = 0
-        involved_tables: List[str] = []
+        involved_tables: list[str] = []
 
         for join_info in result.parsed_joins:
             join_table = join_info.get("table")
@@ -877,14 +890,15 @@ class OBQCValidator:
                 join_table_lower = join_table.lower()
                 for rel_info in self._schema_cache.relationships.values():
                     # A table is on the "many" side in these cases
-                    if rel_info.relationship_type == "one_to_many":
-                        if rel_info.to_table.lower() == join_table_lower:
-                            one_to_many_count += 1
-                            involved_tables.append(join_table)
-                    elif rel_info.relationship_type == "many_to_one":
-                        if rel_info.from_table.lower() == join_table_lower:
-                            one_to_many_count += 1
-                            involved_tables.append(join_table)
+                    if (
+                        rel_info.relationship_type == "one_to_many"
+                        and rel_info.to_table.lower() == join_table_lower
+                    ) or (
+                        rel_info.relationship_type == "many_to_one"
+                        and rel_info.from_table.lower() == join_table_lower
+                    ):
+                        one_to_many_count += 1
+                        involved_tables.append(join_table)
 
         if one_to_many_count >= 2:
             result.fan_trap_risk = True

--- a/src/ontology_generator.py
+++ b/src/ontology_generator.py
@@ -3,7 +3,7 @@
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, ClassVar
 
 from rdflib import BNode, Graph, Literal, Namespace, URIRef
 from rdflib.collection import Collection
@@ -56,13 +56,13 @@ class DenormalizedField:
 class OntologyQualityReport:
     """Report on ontology generation quality."""
 
-    inferred_relationships: List[InferredRelationship] = field(default_factory=list)
-    denormalized_fields: List[DenormalizedField] = field(default_factory=list)
-    type_overrides: List[Dict[str, str]] = field(default_factory=list)
-    missing_descriptions: List[str] = field(default_factory=list)
-    warnings: List[str] = field(default_factory=list)
+    inferred_relationships: list[InferredRelationship] = field(default_factory=list)
+    denormalized_fields: list[DenormalizedField] = field(default_factory=list)
+    type_overrides: list[dict[str, str]] = field(default_factory=list)
+    missing_descriptions: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert report to dictionary for JSON serialization."""
         return {
             "inferred_relationships": [
@@ -102,7 +102,7 @@ class OntologyGenerator:
     """Generates an ontology from a database schema with comprehensive database annotations."""
 
     # Patterns for inferring FK relationships from column names
-    FK_PATTERNS = [
+    FK_PATTERNS: ClassVar[list[tuple[str, str]]] = [
         # Pattern: suppliercountryid → country/countries
         (r"^(.+?)(?:_)?id$", "suffix_id"),
         # Pattern: id_country → country
@@ -118,7 +118,7 @@ class OntologyGenerator:
     ]
 
     # Column name patterns that indicate quantities (should be integers)
-    QUANTITY_PATTERNS = [
+    QUANTITY_PATTERNS: ClassVar[list[str]] = [
         "quantity",
         "qty",
         "count",
@@ -130,7 +130,13 @@ class OntologyGenerator:
     ]
 
     # Patterns for denormalized text fields
-    DENORM_SUFFIXES = ["name", "title", "description", "desc", "label"]
+    DENORM_SUFFIXES: ClassVar[list[str]] = [
+        "name",
+        "title",
+        "description",
+        "desc",
+        "label",
+    ]
 
     def __init__(self, base_uri: str = DEFAULT_BASE_URI):
         self.graph = Graph()
@@ -147,9 +153,9 @@ class OntologyGenerator:
         self.graph.bind("xsd", XSD)
 
         # Quality tracking
-        self.quality_report: Optional[OntologyQualityReport] = None
-        self._table_lookup: Dict[str, TableInfo] = {}
-        self._pk_columns: Dict[str, List[str]] = {}  # table -> primary key columns
+        self.quality_report: OntologyQualityReport | None = None
+        self._table_lookup: dict[str, TableInfo] = {}
+        self._pk_columns: dict[str, list[str]] = {}  # table -> primary key columns
 
     def load_from_file(self, file_path: str) -> None:
         """Load an existing ontology from a Turtle file.
@@ -191,7 +197,7 @@ class OntologyGenerator:
 
     def generate_from_schema(
         self,
-        tables_info: List[TableInfo],
+        tables_info: list[TableInfo],
         include_inferred_relationships: bool = True,
         annotate_denormalized: bool = True,
     ) -> str:
@@ -267,7 +273,7 @@ class OntologyGenerator:
 
         return self.graph.serialize(format="turtle")
 
-    def get_quality_report(self) -> Optional[OntologyQualityReport]:
+    def get_quality_report(self) -> OntologyQualityReport | None:
         """Get the quality report from the last generation.
 
         Returns:
@@ -368,7 +374,7 @@ class OntologyGenerator:
             self.graph.add((prop_uri, RDFS.comment, Literal(column.comment)))
 
     def _add_relationship_to_ontology(
-        self, table_uri: URIRef, fk: Dict[str, str], table_name: str
+        self, table_uri: URIRef, fk: dict[str, str], table_name: str
     ) -> None:
         """Add a foreign key relationship as an object property with comprehensive database annotations."""
         referenced_table = fk.get("referenced_table")
@@ -466,7 +472,7 @@ class OntologyGenerator:
 
         return cleaned or "unnamed"
 
-    def _build_table_lookup(self, tables_info: List[TableInfo]) -> None:
+    def _build_table_lookup(self, tables_info: list[TableInfo]) -> None:
         """Build lookup structures for tables and their primary keys."""
         self._table_lookup = {}
         self._pk_columns = {}
@@ -487,7 +493,7 @@ class OntologyGenerator:
             # Store primary key columns
             self._pk_columns[table.name] = table.primary_keys
 
-    def _find_matching_table(self, name: str) -> Optional[TableInfo]:
+    def _find_matching_table(self, name: str) -> TableInfo | None:
         """Find a table that matches the given name (handles pluralization)."""
         name_lower = name.lower()
 
@@ -524,8 +530,8 @@ class OntologyGenerator:
         return None
 
     def _infer_implicit_relationships(
-        self, tables_info: List[TableInfo]
-    ) -> List[InferredRelationship]:
+        self, tables_info: list[TableInfo]
+    ) -> list[InferredRelationship]:
         """Detect likely FK relationships from column naming patterns.
 
         This method analyzes column names to find implicit relationships that
@@ -537,8 +543,8 @@ class OntologyGenerator:
         Returns:
             List of inferred relationships with confidence levels
         """
-        inferred: List[InferredRelationship] = []
-        existing_fks: Set[Tuple[str, str]] = set()
+        inferred: list[InferredRelationship] = []
+        existing_fks: set[tuple[str, str]] = set()
 
         # Build set of existing declared FKs to avoid duplicates
         for table in tables_info:
@@ -546,7 +552,7 @@ class OntologyGenerator:
                 existing_fks.add((table.name.lower(), fk["column"].lower()))
 
         # Build table name variations for matching (include singular/plural forms)
-        table_name_variations: Dict[str, TableInfo] = {}
+        table_name_variations: dict[str, TableInfo] = {}
         for t in tables_info:
             name_lower = t.name.lower()
             table_name_variations[name_lower] = t
@@ -675,9 +681,9 @@ class OntologyGenerator:
         if target_pk_cols:
             target_pk_type = target_pk_cols[0].data_type.lower()
             col_type = column.data_type.lower()
-            if "int" in col_type and "int" in target_pk_type:
-                score += 2
-            elif col_type == target_pk_type:
+            if (
+                "int" in col_type and "int" in target_pk_type
+            ) or col_type == target_pk_type:
                 score += 2
 
         # Higher confidence if exact table name match (vs plural/singular variation)
@@ -688,7 +694,7 @@ class OntologyGenerator:
 
         # Higher confidence for common FK naming patterns
         col_lower = column.name.lower()
-        if col_lower.endswith("id") or col_lower.endswith("_id"):
+        if col_lower.endswith(("id", "_id")):
             score += 1
 
         if score >= 4:
@@ -698,8 +704,8 @@ class OntologyGenerator:
         return "low"
 
     def _detect_denormalized_fields(
-        self, tables_info: List[TableInfo]
-    ) -> List[DenormalizedField]:
+        self, tables_info: list[TableInfo]
+    ) -> list[DenormalizedField]:
         """Detect likely denormalized text fields that duplicate data from other tables.
 
         Denormalized fields store redundant copies of data (like customer names in orders)
@@ -711,10 +717,10 @@ class OntologyGenerator:
         Returns:
             List of detected denormalized fields
         """
-        denormalized: List[DenormalizedField] = []
+        denormalized: list[DenormalizedField] = []
 
         # Build table name variations for matching (singular and plural)
-        table_name_variations: Dict[str, str] = {}
+        table_name_variations: dict[str, str] = {}
         for t in tables_info:
             name_lower = t.name.lower()
             table_name_variations[name_lower] = t.name
@@ -920,7 +926,7 @@ class OntologyGenerator:
                 (prop_uri, self.oba_ns.denormalizationWarning, Literal(denorm.warning))
             )
 
-    def _add_disjoint_axioms(self, tables_info: List[TableInfo]) -> None:
+    def _add_disjoint_axioms(self, tables_info: list[TableInfo]) -> None:
         """Add owl:disjointWith axioms between sibling tables that share a dimension.
 
         Two tables are considered siblings when they both hold foreign keys to
@@ -932,7 +938,7 @@ class OntologyGenerator:
             tables_info: List of table information
         """
         # Build mapping: referenced_table -> set of source tables that FK into it
-        dimension_to_sources: Dict[str, Set[str]] = {}
+        dimension_to_sources: dict[str, set[str]] = {}
         for table in tables_info:
             for fk in table.foreign_keys:
                 ref = fk.get("referenced_table", "")
@@ -959,7 +965,7 @@ class OntologyGenerator:
         # disjoint would contradict the relationship and feed OBQC bad input.
         # So derive the exclusion set from both declared FKs and the inferred
         # many-to-one relationships already materialized in the graph.
-        fk_pairs: Set[Tuple[str, str]] = set()
+        fk_pairs: set[tuple[str, str]] = set()
         for table in tables_info:
             for fk in table.foreign_keys:
                 ref = fk.get("referenced_table", "")
@@ -980,8 +986,8 @@ class OntologyGenerator:
                     fk_pairs.add((str(ref_table), str(source_name)))
 
         # Declare disjoint pairs: siblings sharing a dimension, no FK between them
-        declared: Set[Tuple[str, str]] = set()
-        for _dim, sources in dimension_to_sources.items():
+        declared: set[tuple[str, str]] = set()
+        for sources in dimension_to_sources.values():
             source_list = sorted(sources)
             for i, a in enumerate(source_list):
                 for b in source_list[i + 1 :]:
@@ -1003,7 +1009,7 @@ class OntologyGenerator:
                             f"(sibling tables sharing a dimension)"
                         )
 
-    def _add_property_chain_axioms(self, tables_info: List[TableInfo]) -> None:
+    def _add_property_chain_axioms(self, tables_info: list[TableInfo]) -> None:
         """Add owl:propertyChainAxiom for transitive multi-hop join paths.
 
         When A→B and B→C are FK relationships but A→C has no direct FK,
@@ -1016,7 +1022,7 @@ class OntologyGenerator:
         """
         # Collect all many-to-one relationships currently in the graph
         # as (source_table_name, target_table_name, property_uri)
-        relationships: List[Tuple[str, str, URIRef]] = []
+        relationships: list[tuple[str, str, URIRef]] = []
         for subj in self.graph.subjects(RDF.type, OWL.ObjectProperty):
             if not isinstance(subj, URIRef):
                 continue
@@ -1032,12 +1038,12 @@ class OntologyGenerator:
                     relationships.append((str(src), str(tgt), subj))
 
         # Build lookup: (source, target) -> property URI
-        rel_lookup: Dict[Tuple[str, str], URIRef] = {}
+        rel_lookup: dict[tuple[str, str], URIRef] = {}
         for rel_src, rel_tgt, rel_uri in relationships:
             rel_lookup[(rel_src, rel_tgt)] = rel_uri
 
         # Find 2-hop chains A→B→C where A→C has no direct relationship
-        declared: Set[Tuple[str, str]] = set()
+        declared: set[tuple[str, str]] = set()
         for src_ab, tgt_ab, uri_ab in relationships:
             for src_bc, tgt_bc, uri_bc in relationships:
                 if tgt_ab != src_bc:
@@ -1081,7 +1087,7 @@ class OntologyGenerator:
                 declared.add((a, c))
                 logger.info(f"Added owl:propertyChainAxiom: {a} -> {tgt_ab} -> {c}")
 
-    def validate_enrichment_completeness(self) -> Dict[str, Any]:
+    def validate_enrichment_completeness(self) -> dict[str, Any]:
         """Check that all classes and properties have semantic descriptions.
 
         Returns:
@@ -1174,7 +1180,7 @@ class OntologyGenerator:
 
     def _map_sql_to_xsd(
         self, sql_type: str, column_name: str = "", table_name: str = ""
-    ) -> Tuple[Optional[URIRef], Optional[Dict[str, str]]]:
+    ) -> tuple[URIRef | None, dict[str, str] | None]:
         """Map SQL data types to XSD Schema datatypes with semantic awareness.
 
         This method considers column naming patterns to make smarter type decisions.
@@ -1193,20 +1199,23 @@ class OntologyGenerator:
         type_override = None
 
         # Semantic override: quantities should be integers even if stored as float/double
-        if col_lower and any(p in col_lower for p in self.QUANTITY_PATTERNS):
-            if any(
+        if (
+            col_lower
+            and any(p in col_lower for p in self.QUANTITY_PATTERNS)
+            and any(
                 t in sql_type_lower
                 for t in ["float", "double", "decimal", "numeric", "real"]
-            ):
-                type_override = {
-                    "table": table_name,
-                    "column": column_name,
-                    "original_sql_type": sql_type,
-                    "original_xsd_type": "xsd:double",
-                    "overridden_xsd_type": "xsd:integer",
-                    "reason": f"Column name '{column_name}' indicates quantity/count (should be integer)",
-                }
-                return XSD.integer, type_override
+            )
+        ):
+            type_override = {
+                "table": table_name,
+                "column": column_name,
+                "original_sql_type": sql_type,
+                "original_xsd_type": "xsd:double",
+                "overridden_xsd_type": "xsd:integer",
+                "reason": f"Column name '{column_name}' indicates quantity/count (should be integer)",
+            }
+            return XSD.integer, type_override
 
         # Integer types - check tinyint first before checking for "int"
         if "tinyint" in sql_type_lower:
@@ -1256,7 +1265,7 @@ class OntologyGenerator:
         logger.warning(f"Unknown SQL type '{sql_type}', mapping to xsd:string")
         return XSD.string, None
 
-    def apply_semantic_descriptions(self, descriptions: Dict[str, Any]) -> None:
+    def apply_semantic_descriptions(self, descriptions: dict[str, Any]) -> None:
         """Apply LLM-generated semantic descriptions to the ontology.
 
         This method allows applying rich, context-aware descriptions generated
@@ -1399,8 +1408,8 @@ class OntologyGenerator:
         return self.graph.serialize(format="turtle")
 
     def get_enrichment_data(
-        self, tables_info: List[TableInfo], sample_data: Dict[str, List[Dict[str, Any]]]
-    ) -> Dict[str, Any]:
+        self, tables_info: list[TableInfo], sample_data: dict[str, list[dict[str, Any]]]
+    ) -> dict[str, Any]:
         """Generate enrichment data structure for LLM processing.
 
         Args:
@@ -1413,7 +1422,7 @@ class OntologyGenerator:
         schema_data = []
 
         for table_info in tables_info:
-            table_data: Dict[str, Any] = {
+            table_data: dict[str, Any] = {
                 "table_name": table_info.name,
                 "schema": table_info.schema,
                 "row_count": table_info.row_count,
@@ -1437,7 +1446,7 @@ class OntologyGenerator:
                 table_data["columns"].append(column_data)
 
             # Add sample data if available (limit to 3 rows)
-            if table_info.name in sample_data and sample_data[table_info.name]:
+            if sample_data.get(table_info.name):
                 table_data["sample_data"] = sample_data[table_info.name][:3]
 
             schema_data.append(table_data)
@@ -1481,7 +1490,7 @@ class OntologyGenerator:
         return {"schema_data": schema_data, "instructions": instructions}
 
     def apply_enrichment(
-        self, enrichment_suggestions: Dict[str, List[Dict[str, Any]]]
+        self, enrichment_suggestions: dict[str, list[dict[str, Any]]]
     ) -> None:
         """Apply enrichment suggestions to the ontology.
 
@@ -1575,7 +1584,7 @@ class OntologyGenerator:
         logger.info("Finished applying enrichment suggestions")
 
     def enrich_with_llm(
-        self, tables_info: List[TableInfo], sample_data: Dict[str, List[Dict[str, Any]]]
+        self, tables_info: list[TableInfo], sample_data: dict[str, list[dict[str, Any]]]
     ) -> str:
         """Generate basic ontology with optional LLM enrichment.
 
@@ -1592,7 +1601,7 @@ class OntologyGenerator:
         logger.info("Generating basic ontology (LLM enrichment handled by MCP tools)")
         return self.generate_from_schema(tables_info)
 
-    def extract_names_for_review(self, compact: bool = False) -> Dict[str, Any]:
+    def extract_names_for_review(self, compact: bool = False) -> dict[str, Any]:
         """Extract all class, property, and relationship names from the ontology for LLM review.
 
         This method analyzes the current ontology graph and extracts all names that might
@@ -1621,7 +1630,7 @@ class OntologyGenerator:
             if subject == OWL.Class:
                 continue
 
-            class_info: Dict[str, Any] = {
+            class_info: dict[str, Any] = {
                 "uri": str(subject),
                 "local_name": str(subject).split("/")[-1]
                 if "/" in str(subject)
@@ -1655,7 +1664,7 @@ class OntologyGenerator:
 
         # Extract data properties (columns)
         for subject in self.graph.subjects(RDF.type, OWL.DatatypeProperty):
-            prop_info: Dict[str, Any] = {
+            prop_info: dict[str, Any] = {
                 "uri": str(subject),
                 "local_name": str(subject).split("/")[-1]
                 if "/" in str(subject)
@@ -1695,7 +1704,7 @@ class OntologyGenerator:
 
         # Extract object properties (relationships)
         for subject in self.graph.subjects(RDF.type, OWL.ObjectProperty):
-            rel_info: Dict[str, Any] = {
+            rel_info: dict[str, Any] = {
                 "uri": str(subject),
                 "local_name": str(subject).split("/")[-1]
                 if "/" in str(subject)
@@ -1756,7 +1765,7 @@ class OntologyGenerator:
         # with limited context windows can still see all names at a glance.
         if compact:
 
-            def _compact_class(c: Dict[str, Any]) -> Dict[str, Any]:
+            def _compact_class(c: dict[str, Any]) -> dict[str, Any]:
                 if c.get("needs_review", {}).get("is_cryptic"):
                     return c
                 return {
@@ -1764,7 +1773,7 @@ class OntologyGenerator:
                     "table_name": c.get("table_name"),
                 }
 
-            def _compact_prop(p: Dict[str, Any]) -> Dict[str, Any]:
+            def _compact_prop(p: dict[str, Any]) -> dict[str, Any]:
                 if p.get("needs_review", {}).get("is_cryptic"):
                     return p
                 return {
@@ -1772,7 +1781,7 @@ class OntologyGenerator:
                     "table_name": p.get("table_name"),
                 }
 
-            def _compact_rel(r: Dict[str, Any]) -> Dict[str, Any]:
+            def _compact_rel(r: dict[str, Any]) -> dict[str, Any]:
                 if r.get("needs_review", {}).get("is_cryptic"):
                     return r
                 return {"local_name": r["local_name"]}
@@ -1812,7 +1821,7 @@ class OntologyGenerator:
             return True
         return word_frequency(token, "en") >= _WORD_FREQ_THRESHOLD
 
-    def _analyze_name_quality(self, name: str) -> Dict[str, Any]:
+    def _analyze_name_quality(self, name: str) -> dict[str, Any]:
         """Analyze if a name looks like an abbreviation or cryptic identifier.
 
         Uses a combination of structural heuristics (length, casing, suffix
@@ -1900,7 +1909,7 @@ class OntologyGenerator:
             else "low",
         }
 
-    def apply_semantic_names(self, name_suggestions: Dict[str, Any]) -> str:
+    def apply_semantic_names(self, name_suggestions: dict[str, Any]) -> str:
         """Apply suggested semantic names to the ontology.
 
         This method takes LLM-generated name suggestions and updates the ontology
@@ -1992,7 +2001,7 @@ class OntologyGenerator:
                 changing_uris = {
                     c["prop_uri"] for c in proposed_changes if c["suggested"]
                 }
-                existing_labels: Dict[str, URIRef] = {}
+                existing_labels: dict[str, URIRef] = {}
                 for rdf_type in (OWL.DatatypeProperty, OWL.ObjectProperty):
                     for s, _, _ in self.graph.triples((None, RDF.type, rdf_type)):
                         if isinstance(s, URIRef) and s not in changing_uris:
@@ -2000,7 +2009,7 @@ class OntologyGenerator:
                                 existing_labels[str(label).lower()] = s
 
                 # Group proposed changes by suggested label (case-insensitive)
-                label_groups: Dict[str, list] = {}
+                label_groups: dict[str, list] = {}
                 for change in proposed_changes:
                     if change["suggested"]:
                         key = change["suggested"].lower()

--- a/src/oxigraph_store.py
+++ b/src/oxigraph_store.py
@@ -8,7 +8,7 @@ Stores ontologies, schema metadata, and accumulated knowledge across sessions.
 import logging
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from pyoxigraph import (
@@ -84,7 +84,7 @@ def _escape_sparql_iri(value: str) -> str:
 class OxigraphStoreManager:
     """Manages persistent RDF storage using Oxigraph."""
 
-    def __init__(self, store_path: Optional[Path] = None):
+    def __init__(self, store_path: Path | None = None):
         """
         Initialize Oxigraph store manager.
 
@@ -124,7 +124,7 @@ class OxigraphStoreManager:
             logger.info("Initialized Oxigraph in-memory store")
 
         # Track loaded ontologies
-        self._loaded_ontologies: Dict[str, str] = {}  # schema_name -> graph_uri
+        self._loaded_ontologies: dict[str, str] = {}  # schema_name -> graph_uri
 
     def load_ontology(self, ontology_ttl: str, graph_uri: str, schema_name: str) -> int:
         """
@@ -186,8 +186,8 @@ class OxigraphStoreManager:
             raise
 
     def query_sparql(
-        self, sparql_query: str, timeout_seconds: Optional[int] = 30
-    ) -> List[Dict[str, Any]]:
+        self, sparql_query: str, timeout_seconds: int | None = 30
+    ) -> list[dict[str, Any]]:
         """
         Execute SPARQL query.
 
@@ -220,13 +220,13 @@ class OxigraphStoreManager:
         if timeout_seconds is None:
             return self._execute_select(sparql_query)
 
-        result: List[List[Dict[str, Any]]] = []
-        error: List[BaseException] = []
+        result: list[list[dict[str, Any]]] = []
+        error: list[BaseException] = []
 
         def _runner() -> None:
             try:
                 result.append(self._execute_select(sparql_query))
-            except BaseException as exc:  # noqa: BLE001 - re-raised on caller thread
+            except BaseException as exc:
                 error.append(exc)
 
         worker = threading.Thread(target=_runner, name="sparql-query", daemon=True)
@@ -243,7 +243,7 @@ class OxigraphStoreManager:
             raise error[0]
         return result[0]
 
-    def _execute_select(self, sparql_query: str) -> List[Dict[str, Any]]:
+    def _execute_select(self, sparql_query: str) -> list[dict[str, Any]]:
         """Execute a SELECT query and materialize its bindings (no timeout).
 
         Args:
@@ -261,7 +261,7 @@ class OxigraphStoreManager:
             solutions = cast("QuerySolutions", self.store.query(sparql_query))
             variables = solutions.variables
             for solution in solutions:
-                binding: Dict[str, Any] = {}
+                binding: dict[str, Any] = {}
                 for var in variables:
                     term = solution[var]
                     if term is None:
@@ -351,7 +351,7 @@ class OxigraphStoreManager:
         subject: str,
         predicate: str,
         object: str,
-        graph_uri: Optional[str] = None,
+        graph_uri: str | None = None,
         object_is_literal: bool = False,
     ) -> None:
         """
@@ -396,7 +396,7 @@ class OxigraphStoreManager:
         subject: str,
         predicate: str,
         object: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: dict[str, Any] | None = None,
         graph_uri: str = "http://example.com/knowledge",
     ) -> None:
         """
@@ -448,7 +448,7 @@ class OxigraphStoreManager:
             logger.error(f"Failed to add knowledge: {e}", exc_info=True)
             raise
 
-    def get_ontology_stats(self, graph_uri: Optional[str] = None) -> Dict[str, Any]:
+    def get_ontology_stats(self, graph_uri: str | None = None) -> dict[str, Any]:
         """
         Get statistics about stored ontologies.
 
@@ -498,7 +498,7 @@ class OxigraphStoreManager:
             logger.error(f"Failed to get stats: {e}", exc_info=True)
             return {"error": str(e)}
 
-    def list_tables_sparql(self, schema_graph: str) -> List[str]:
+    def list_tables_sparql(self, schema_graph: str) -> list[str]:
         """
         List all tables from an ontology using SPARQL.
 
@@ -526,8 +526,8 @@ class OxigraphStoreManager:
         return [r["tableName"] for r in results]
 
     def find_columns_by_type(
-        self, data_type: str, schema_graph: Optional[str] = None
-    ) -> List[Dict[str, str]]:
+        self, data_type: str, schema_graph: str | None = None
+    ) -> list[dict[str, str]]:
         """
         Find columns by data type using SPARQL.
 

--- a/src/paths.py
+++ b/src/paths.py
@@ -6,7 +6,6 @@ Replaces scattered Path construction and hardcoded paths.
 
 import os
 from pathlib import Path
-from typing import Optional
 
 from .constants import DEFAULT_OUTPUT_DIR
 
@@ -23,7 +22,7 @@ def ensure_output_dir() -> Path:
     return OUTPUT_DIR
 
 
-def get_env_file_path() -> Optional[Path]:
+def get_env_file_path() -> Path | None:
     """Find the .env file using standard resolution order.
 
     Resolution order:
@@ -40,7 +39,7 @@ def get_env_file_path() -> Optional[Path]:
     return None
 
 
-def get_oxigraph_store_dir(connection_id: Optional[str] = None) -> Path:
+def get_oxigraph_store_dir(connection_id: str | None = None) -> Path:
     """Get Oxigraph store directory, scoped per connection.
 
     Args:

--- a/src/r2rml_generator.py
+++ b/src/r2rml_generator.py
@@ -13,7 +13,6 @@ R2RML mappings enable:
 
 import logging
 import re
-from typing import Dict, List, Optional
 
 from .database_manager import ColumnInfo, TableInfo
 
@@ -45,7 +44,7 @@ class R2RMLGenerator:
         self.database_name = database_name
 
     def generate_from_schema(
-        self, tables_info: List[TableInfo], schema_name: Optional[str] = None
+        self, tables_info: list[TableInfo], schema_name: str | None = None
     ) -> str:
         """Generate R2RML mapping from database schema information.
 
@@ -78,7 +77,7 @@ class R2RMLGenerator:
 
         return "\n".join(lines)
 
-    def _generate_prefixes(self) -> List[str]:
+    def _generate_prefixes(self) -> list[str]:
         """Generate R2RML prefix declarations."""
         prefixes = [
             "@prefix rr: <http://www.w3.org/ns/r2rml#> .",
@@ -90,9 +89,9 @@ class R2RMLGenerator:
     def _generate_triples_map(
         self,
         table_info: TableInfo,
-        schema_name: Optional[str],
-        table_lookup: Dict[str, TableInfo],
-    ) -> List[str]:
+        schema_name: str | None,
+        table_lookup: dict[str, TableInfo],
+    ) -> list[str]:
         """Generate a TriplesMap for a single table.
 
         Args:
@@ -165,7 +164,7 @@ class R2RMLGenerator:
         return lines
 
     def _generate_subject_template(
-        self, table_info: TableInfo, schema_name: Optional[str]
+        self, table_info: TableInfo, schema_name: str | None
     ) -> str:
         """Generate subject IRI template based on primary keys.
 
@@ -209,7 +208,7 @@ class R2RMLGenerator:
 
     def _generate_predicate_object_map(
         self, column: ColumnInfo, table_name: str
-    ) -> List[str]:
+    ) -> list[str]:
         """Generate predicate-object map for a regular column.
 
         Args:
@@ -236,10 +235,10 @@ class R2RMLGenerator:
     def _generate_fk_predicate_object_map(
         self,
         column: ColumnInfo,
-        fk: Dict[str, str],
-        schema_name: Optional[str],
-        table_lookup: Dict[str, TableInfo],
-    ) -> List[str]:
+        fk: dict[str, str],
+        schema_name: str | None,
+        table_lookup: dict[str, TableInfo],
+    ) -> list[str]:
         """Generate predicate-object map for a foreign key column.
 
         Foreign key columns are mapped as object properties that reference

--- a/src/resources.py
+++ b/src/resources.py
@@ -4,7 +4,7 @@ Kept out of ``main.py`` so server setup stays thin. Call
 :func:`register_resources` with the FastMCP instance to wire these up.
 """
 
-from typing import Callable
+from collections.abc import Callable
 
 from fastmcp import FastMCP
 

--- a/src/security.py
+++ b/src/security.py
@@ -7,7 +7,7 @@ import os
 import re
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, ClassVar
 
 from cryptography.fernet import Fernet
 from cryptography.hazmat.primitives import hashes
@@ -29,9 +29,9 @@ class SecurityLevel(Enum):
 class SecureCredentialManager:
     """Secure credential management with encryption."""
 
-    def __init__(self, master_password: Optional[str] = None):
+    def __init__(self, master_password: str | None = None):
         """Initialize with optional master password for encryption."""
-        self._cipher: Optional[Fernet] = None
+        self._cipher: Fernet | None = None
         self._salt_file = Path.home() / ".mcp_credential_salt"
 
         # Try to get master password from environment if not provided
@@ -82,7 +82,7 @@ class SecureCredentialManager:
             logger.info("Created new salt file: %s", self._salt_file)
             return salt
 
-        except (OSError, IOError) as e:
+        except OSError as e:
             logger.error("Failed to manage salt file: %s", e)
             # Fallback to session-only salt (less secure)
             logger.warning(
@@ -91,7 +91,7 @@ class SecureCredentialManager:
             )
             return os.urandom(16)
 
-    def encrypt_credentials(self, credentials: Dict[str, Any]) -> str:
+    def encrypt_credentials(self, credentials: dict[str, Any]) -> str:
         """Encrypt credentials dictionary."""
         if not self._cipher:
             raise ValueError("Encryption not initialized")
@@ -107,7 +107,7 @@ class SecureCredentialManager:
         encrypted_data = self._cipher.encrypt(json_data)
         return base64.urlsafe_b64encode(encrypted_data).decode()
 
-    def decrypt_credentials(self, encrypted_data: str) -> Dict[str, Any]:
+    def decrypt_credentials(self, encrypted_data: str) -> dict[str, Any]:
         """Decrypt credentials dictionary."""
         if not self._cipher:
             raise ValueError("Encryption not initialized")
@@ -115,13 +115,13 @@ class SecureCredentialManager:
         try:
             decoded_data = base64.urlsafe_b64decode(encrypted_data.encode())
             decrypted_data = self._cipher.decrypt(decoded_data)
-            credentials_dict: Dict[str, Any] = json.loads(decrypted_data.decode())
+            credentials_dict: dict[str, Any] = json.loads(decrypted_data.decode())
             return credentials_dict
         except Exception as e:
             logger.error("Failed to decrypt credentials: %s", e)
             raise ValueError("Invalid or corrupted credential data") from e
 
-    def _sanitize_credentials(self, credentials: Dict[str, Any]) -> Dict[str, Any]:
+    def _sanitize_credentials(self, credentials: dict[str, Any]) -> dict[str, Any]:
         """Remove sensitive information for logging."""
         sensitive_keys = {
             "password",
@@ -146,7 +146,7 @@ class SQLInjectionValidator:
     """Validates SQL queries to prevent injection attacks."""
 
     # Dangerous SQL patterns that should be blocked
-    DANGEROUS_PATTERNS = [
+    DANGEROUS_PATTERNS: ClassVar[list[str]] = [
         # Multiple statements with DDL/DML
         r";.*(?:DROP|DELETE|INSERT|UPDATE|CREATE|ALTER|TRUNCATE)",
         # Classic injection patterns (but NOT blocking UNION/UNION ALL)
@@ -178,7 +178,7 @@ class SQLInjectionValidator:
     # Pattern matches: optional (-- followed by non-SQL text, or /* ... */) followed by whitespace
     _OPT_COMMENT = r"^(?:--[^;]*?\s+)?"
 
-    SAFE_PATTERNS = [
+    SAFE_PATTERNS: ClassVar[list[str]] = [
         # Basic SELECT queries with JOINs (with optional leading comments)
         _OPT_COMMENT + r"SELECT\s+.+\s+FROM\s+.+$",
         # CTEs (WITH clauses) - now more permissive for complex queries
@@ -203,7 +203,7 @@ class SQLInjectionValidator:
             for pattern in self.SAFE_PATTERNS
         ]
 
-    def validate_query(self, sql_query: str) -> Dict[str, Any]:
+    def validate_query(self, sql_query: str) -> dict[str, Any]:
         """Validate SQL query for security issues."""
         if not sql_query or not sql_query.strip():
             return {
@@ -329,7 +329,7 @@ class IdentifierValidator:
 
 def audit_log_security_event(
     event_type: str,
-    details: Dict[str, Any],
+    details: dict[str, Any],
     risk_level: SecurityLevel = SecurityLevel.MEDIUM,
 ) -> None:
     """Log security-related events for auditing."""
@@ -372,7 +372,7 @@ _WRITE_EXPRESSIONS = (
 )
 
 
-def analyze_sql_statement(sql_query: str, dialect: str = "postgres") -> Dict[str, Any]:
+def analyze_sql_statement(sql_query: str, dialect: str = "postgres") -> dict[str, Any]:
     """Dialect-aware structural analysis of a SQL statement using sqlglot.
 
     This is the *primary*, parser-based safety gate. Unlike regex/``startswith``
@@ -395,7 +395,7 @@ def analyze_sql_statement(sql_query: str, dialect: str = "postgres") -> Dict[str
     import sqlglot
     from sqlglot import expressions as exp
 
-    result: Dict[str, Any] = {
+    result: dict[str, Any] = {
         "parsed": False,
         "single_statement": True,
         "query_type": "UNKNOWN",

--- a/src/serialization.py
+++ b/src/serialization.py
@@ -5,10 +5,11 @@ in both sample_table_data() and execute_sql_query() within database_manager.py.
 """
 
 import decimal
-from typing import Any, Dict, List, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 
-def serialize_row(row: Sequence[Any], columns: List[str]) -> Dict[str, Any]:
+def serialize_row(row: Sequence[Any], columns: list[str]) -> dict[str, Any]:
     """Serialize a database row into a JSON-compatible dict.
 
     Handles conversion of non-serializable types:
@@ -26,7 +27,7 @@ def serialize_row(row: Sequence[Any], columns: List[str]) -> Dict[str, Any]:
     Returns:
         Dictionary mapping column names to serialized values
     """
-    row_dict: Dict[str, Any] = {}
+    row_dict: dict[str, Any] = {}
     for i, value in enumerate(row):
         column_name = columns[i]
         if value is None:
@@ -47,8 +48,8 @@ def serialize_row(row: Sequence[Any], columns: List[str]) -> Dict[str, Any]:
 
 
 def serialize_rows(
-    rows: Sequence[Sequence[Any]], columns: List[str]
-) -> List[Dict[str, Any]]:
+    rows: Sequence[Sequence[Any]], columns: list[str]
+) -> list[dict[str, Any]]:
     """Serialize multiple database rows into JSON-compatible dicts.
 
     Args:

--- a/src/server_state.py
+++ b/src/server_state.py
@@ -15,7 +15,7 @@ import json
 import logging
 import os
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, cast
 
 from fastmcp import Context
 from pydantic import BaseModel
@@ -55,9 +55,9 @@ def _get_connection_fingerprint(db_manager: DatabaseManager) -> str:
     return hashlib.sha256(fingerprint_data.encode()).hexdigest()[:16]
 
 
-def _calculate_schema_hash(tables_info: List[Any]) -> str:
+def _calculate_schema_hash(tables_info: list[Any]) -> str:
     """Calculate deterministic hash of schema structure."""
-    schema_structure: Dict[str, List[Dict[str, Any]]] = {"tables": []}
+    schema_structure: dict[str, list[dict[str, Any]]] = {"tables": []}
 
     sorted_tables = sorted(tables_info, key=lambda t: t.name)
     for table in sorted_tables:
@@ -120,8 +120,8 @@ class ServerState:
     """Manages server state with per-session isolation and idle eviction."""
 
     def __init__(self) -> None:
-        self._sessions: Dict[str, SessionData] = {}
-        self._eviction_task: Optional[asyncio.Task[None]] = None
+        self._sessions: dict[str, SessionData] = {}
+        self._eviction_task: asyncio.Task[None] | None = None
 
     @property
     def session_count(self) -> int:
@@ -266,7 +266,7 @@ def get_session_db_manager(ctx: Context) -> DatabaseManager:
     return cast(DatabaseManager, session.db_manager)
 
 
-def get_session_obqc_validator(ctx: Context) -> Optional[OBQCValidator]:
+def get_session_obqc_validator(ctx: Context) -> OBQCValidator | None:
     """Get or create OBQC validator for the current session."""
     session = get_session_data(ctx)
 
@@ -303,7 +303,7 @@ def get_session_obqc_validator(ctx: Context) -> Optional[OBQCValidator]:
         session.obqc_validator.load_ontology(ontology_generator.graph, base_uri)
         logger.debug(f"Initialized OBQC validator for session: {get_session_id(ctx)}")
 
-    return cast(Optional[OBQCValidator], session.obqc_validator)
+    return cast(OBQCValidator | None, session.obqc_validator)
 
 
 def get_session_safe_filename(ctx: Context, prefix: str, suffix: str = "") -> str:
@@ -350,12 +350,12 @@ class ErrorResponse(BaseModel):
 
     error: str
     error_type: str = "unknown"
-    details: Optional[str] = None
+    details: str | None = None
 
 
 def create_error_response(
-    error_msg: str, error_type: str = "unknown", details: Optional[str] = None
-) -> Dict[str, Any]:
+    error_msg: str, error_type: str = "unknown", details: str | None = None
+) -> dict[str, Any]:
     """Create a standardized error response.
 
     DEPRECATED: Use exceptions from src.exceptions instead.
@@ -368,7 +368,7 @@ def create_error_response(
     return response.model_dump()
 
 
-def get_oxigraph_store(ctx: Context) -> Optional[OxigraphStoreManager]:
+def get_oxigraph_store(ctx: Context) -> OxigraphStoreManager | None:
     """Get or initialize connection-scoped Oxigraph store for the session."""
     session = get_session_data(ctx)
 
@@ -395,4 +395,4 @@ def get_oxigraph_store(ctx: Context) -> Optional[OxigraphStoreManager]:
             logger.error(f"Failed to initialize Oxigraph store: {e}")
             return None
 
-    return cast(Optional[OxigraphStoreManager], session.oxigraph_store)
+    return cast(OxigraphStoreManager | None, session.oxigraph_store)

--- a/src/session.py
+++ b/src/session.py
@@ -11,7 +11,7 @@ Each MCP session gets its own SessionData instance containing:
 import asyncio
 import logging
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -20,22 +20,20 @@ class ConnectionState:
     """Database connection tracking."""
 
     def __init__(self) -> None:
-        self.connection_id: Optional[str] = None
-        self.connected_at: Optional[datetime] = None
-        self.db_manager: Optional[Any] = None  # DatabaseManager (avoid circular import)
+        self.connection_id: str | None = None
+        self.connected_at: datetime | None = None
+        self.db_manager: Any | None = None  # DatabaseManager (avoid circular import)
 
 
 class OntologyState:
     """Ontology generation and loading state."""
 
     def __init__(self) -> None:
-        self.ontology_file: Optional[str] = None
-        self.r2rml_file: Optional[str] = None
-        self.loaded_ontology: Optional[str] = None  # TTL content
-        self.loaded_ontology_path: Optional[str] = None  # File path
-        self.obqc_validator: Optional[
-            Any
-        ] = None  # OBQCValidator (avoid circular import)
+        self.ontology_file: str | None = None
+        self.r2rml_file: str | None = None
+        self.loaded_ontology: str | None = None  # TTL content
+        self.loaded_ontology_path: str | None = None  # File path
+        self.obqc_validator: Any | None = None  # OBQCValidator (avoid circular import)
         self.ontology_enriched: bool = False  # True after semantic names applied
 
 
@@ -43,12 +41,12 @@ class SchemaCache:
     """Cached schema analysis results (multi-schema capable)."""
 
     def __init__(self) -> None:
-        self._cached_schema: Optional[
-            Dict[str, List[Any]]
-        ] = None  # schema_name -> List[TableInfo]
-        self._last_analyzed_schema: Optional[str] = None
+        self._cached_schema: dict[
+            str, list[Any]
+        ] | None = None  # schema_name -> List[TableInfo]
+        self._last_analyzed_schema: str | None = None
 
-    def cache_schema_analysis(self, schema_name: str, tables_info: List[Any]) -> None:
+    def cache_schema_analysis(self, schema_name: str, tables_info: list[Any]) -> None:
         """Cache schema analysis results for reuse."""
         if self._cached_schema is None:
             self._cached_schema = {}
@@ -59,7 +57,7 @@ class SchemaCache:
             f"Cached schema analysis for '{cache_key}': {len(tables_info)} tables"
         )
 
-    def get_cached_schema(self, schema_name: str) -> Optional[List[Any]]:
+    def get_cached_schema(self, schema_name: str) -> list[Any] | None:
         """Get cached schema analysis results if available."""
         if self._cached_schema is None:
             return None
@@ -69,7 +67,7 @@ class SchemaCache:
             logger.debug(f"Using cached schema for '{cache_key}': {len(cached)} tables")
         return cached
 
-    def clear(self, schema_name: Optional[str] = None) -> None:
+    def clear(self, schema_name: str | None = None) -> None:
         """Clear cached schema analysis.
 
         Args:
@@ -87,7 +85,7 @@ class SchemaCache:
             self._last_analyzed_schema = None
             logger.debug("Cleared all schema caches")
 
-    def get_last_analyzed_schema(self) -> Optional[str]:
+    def get_last_analyzed_schema(self) -> str | None:
         """Get the name of the last analyzed schema."""
         return self._last_analyzed_schema
 
@@ -96,9 +94,9 @@ class GraphRAGState:
     """GraphRAG integration state with Future-based init tracking."""
 
     def __init__(self) -> None:
-        self.graphrag_manager: Optional[Any] = None  # GraphRAGManager
+        self.graphrag_manager: Any | None = None  # GraphRAGManager
         self.graphrag_initialized: bool = False
-        self._init_task: Optional[asyncio.Task[Any]] = None
+        self._init_task: asyncio.Task[Any] | None = None
 
 
 class RDFStoreState:
@@ -109,9 +107,9 @@ class RDFStoreState:
     """
 
     def __init__(self) -> None:
-        self.oxigraph_store: Optional[Any] = None  # OxigraphStoreManager
+        self.oxigraph_store: Any | None = None  # OxigraphStoreManager
         self.oxigraph_initialized: bool = False
-        self._init_task: Optional[asyncio.Task[Any]] = None
+        self._init_task: asyncio.Task[Any] | None = None
 
 
 class SchemaState:
@@ -124,7 +122,7 @@ class SchemaState:
 
     def __init__(self, schema_name: str):
         self.schema_name = schema_name
-        self.schema_file: Optional[str] = None
+        self.schema_file: str | None = None
         self.ontology = OntologyState()
 
 
@@ -145,8 +143,8 @@ class SessionData:
         self.graphrag = GraphRAGState()
 
         # Multi-schema state (ontology is per-schema)
-        self._schema_states: Dict[str, SchemaState] = {}
-        self._current_schema: Optional[str] = None
+        self._schema_states: dict[str, SchemaState] = {}
+        self._current_schema: str | None = None
 
         # Activity tracking for idle eviction
         self.created_at: datetime = datetime.now()
@@ -159,7 +157,7 @@ class SessionData:
     # --- Multi-schema management ---
 
     @property
-    def current_schema(self) -> Optional[str]:
+    def current_schema(self) -> str | None:
         """Name of the currently active schema."""
         return self._current_schema
 
@@ -181,7 +179,7 @@ class SessionData:
         return self._schema_states[key]
 
     def get_schema_state(
-        self, schema_name: Optional[str] = None
+        self, schema_name: str | None = None
     ) -> Optional["SchemaState"]:
         """Get SchemaState for a specific or the current schema.
 
@@ -198,7 +196,7 @@ class SessionData:
         return self._schema_states.get(key)
 
     def get_or_create_schema_state(
-        self, schema_name: Optional[str] = None
+        self, schema_name: str | None = None
     ) -> "SchemaState":
         """Get or create SchemaState for a specific or the current schema.
 
@@ -210,7 +208,7 @@ class SessionData:
         return self._schema_states[key]
 
     @property
-    def schema_names(self) -> List[str]:
+    def schema_names(self) -> list[str]:
         """List of all schema names with active state."""
         return list(self._schema_states.keys())
 
@@ -239,74 +237,74 @@ class SessionData:
     # Connection properties (session-scoped, unchanged)
 
     @property
-    def db_manager(self) -> Optional[Any]:
+    def db_manager(self) -> Any | None:
         return self.connection.db_manager
 
     @db_manager.setter
-    def db_manager(self, value: Optional[Any]) -> None:
+    def db_manager(self, value: Any | None) -> None:
         self.connection.db_manager = value
 
     @property
-    def connection_id(self) -> Optional[str]:
+    def connection_id(self) -> str | None:
         return self.connection.connection_id
 
     @connection_id.setter
-    def connection_id(self, value: Optional[str]) -> None:
+    def connection_id(self, value: str | None) -> None:
         self.connection.connection_id = value
 
     @property
-    def connected_at(self) -> Optional[datetime]:
+    def connected_at(self) -> datetime | None:
         return self.connection.connected_at
 
     @connected_at.setter
-    def connected_at(self, value: Optional[datetime]) -> None:
+    def connected_at(self, value: datetime | None) -> None:
         self.connection.connected_at = value
 
     # Ontology properties (per-schema via current schema)
 
     @property
-    def ontology_file(self) -> Optional[str]:
+    def ontology_file(self) -> str | None:
         ss = self._current_schema_state
         return ss.ontology.ontology_file if ss else None
 
     @ontology_file.setter
-    def ontology_file(self, value: Optional[str]) -> None:
+    def ontology_file(self, value: str | None) -> None:
         self._ensure_schema_state().ontology.ontology_file = value
 
     @property
-    def r2rml_file(self) -> Optional[str]:
+    def r2rml_file(self) -> str | None:
         ss = self._current_schema_state
         return ss.ontology.r2rml_file if ss else None
 
     @r2rml_file.setter
-    def r2rml_file(self, value: Optional[str]) -> None:
+    def r2rml_file(self, value: str | None) -> None:
         self._ensure_schema_state().ontology.r2rml_file = value
 
     @property
-    def loaded_ontology(self) -> Optional[str]:
+    def loaded_ontology(self) -> str | None:
         ss = self._current_schema_state
         return ss.ontology.loaded_ontology if ss else None
 
     @loaded_ontology.setter
-    def loaded_ontology(self, value: Optional[str]) -> None:
+    def loaded_ontology(self, value: str | None) -> None:
         self._ensure_schema_state().ontology.loaded_ontology = value
 
     @property
-    def loaded_ontology_path(self) -> Optional[str]:
+    def loaded_ontology_path(self) -> str | None:
         ss = self._current_schema_state
         return ss.ontology.loaded_ontology_path if ss else None
 
     @loaded_ontology_path.setter
-    def loaded_ontology_path(self, value: Optional[str]) -> None:
+    def loaded_ontology_path(self, value: str | None) -> None:
         self._ensure_schema_state().ontology.loaded_ontology_path = value
 
     @property
-    def obqc_validator(self) -> Optional[Any]:
+    def obqc_validator(self) -> Any | None:
         ss = self._current_schema_state
         return ss.ontology.obqc_validator if ss else None
 
     @obqc_validator.setter
-    def obqc_validator(self, value: Optional[Any]) -> None:
+    def obqc_validator(self, value: Any | None) -> None:
         self._ensure_schema_state().ontology.obqc_validator = value
 
     @property
@@ -321,22 +319,22 @@ class SessionData:
     # Schema file (per-schema via current schema)
 
     @property
-    def schema_file(self) -> Optional[str]:
+    def schema_file(self) -> str | None:
         ss = self._current_schema_state
         return ss.schema_file if ss else None
 
     @schema_file.setter
-    def schema_file(self, value: Optional[str]) -> None:
+    def schema_file(self, value: str | None) -> None:
         self._ensure_schema_state().schema_file = value
 
     # GraphRAG properties (connection-scoped, accumulative across schemas)
 
     @property
-    def graphrag_manager(self) -> Optional[Any]:
+    def graphrag_manager(self) -> Any | None:
         return self.graphrag.graphrag_manager
 
     @graphrag_manager.setter
-    def graphrag_manager(self, value: Optional[Any]) -> None:
+    def graphrag_manager(self, value: Any | None) -> None:
         self.graphrag.graphrag_manager = value
 
     @property
@@ -350,11 +348,11 @@ class SessionData:
     # RDF Store properties (connection-scoped, unchanged)
 
     @property
-    def oxigraph_store(self) -> Optional[Any]:
+    def oxigraph_store(self) -> Any | None:
         return self.rdf_store.oxigraph_store
 
     @oxigraph_store.setter
-    def oxigraph_store(self, value: Optional[Any]) -> None:
+    def oxigraph_store(self, value: Any | None) -> None:
         self.rdf_store.oxigraph_store = value
 
     @property
@@ -367,15 +365,15 @@ class SessionData:
 
     # --- Delegated methods ---
 
-    def cache_schema_analysis(self, schema_name: str, tables_info: List[Any]) -> None:
+    def cache_schema_analysis(self, schema_name: str, tables_info: list[Any]) -> None:
         """Cache schema analysis results for reuse."""
         self.schema_cache.cache_schema_analysis(schema_name, tables_info)
 
-    def get_cached_schema(self, schema_name: str) -> Optional[List[Any]]:
+    def get_cached_schema(self, schema_name: str) -> list[Any] | None:
         """Get cached schema analysis results if available."""
         return self.schema_cache.get_cached_schema(schema_name)
 
-    def clear_schema_cache(self, schema_name: Optional[str] = None) -> None:
+    def clear_schema_cache(self, schema_name: str | None = None) -> None:
         """Clear cached schema analysis.
 
         Args:
@@ -383,6 +381,6 @@ class SessionData:
         """
         self.schema_cache.clear(schema_name)
 
-    def get_last_analyzed_schema(self) -> Optional[str]:
+    def get_last_analyzed_schema(self) -> str | None:
         """Get the name of the last analyzed schema."""
         return self.schema_cache.get_last_analyzed_schema()

--- a/src/shacl_validator.py
+++ b/src/shacl_validator.py
@@ -11,7 +11,7 @@ real conformance checking wherever the pieces are present.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict
+from typing import Any
 
 from .paths import PROJECT_ROOT
 
@@ -33,7 +33,7 @@ def shacl_available() -> bool:
     return True
 
 
-def validate_ontology(ontology_ttl: str) -> Dict[str, Any]:
+def validate_ontology(ontology_ttl: str) -> dict[str, Any]:
     """Validate ontology Turtle against the OBA SHACL shapes.
 
     Returns a structured report. When validation cannot run (missing dependency

--- a/src/tools/chart.py
+++ b/src/tools/chart.py
@@ -2,7 +2,7 @@
 
 import logging
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 from ..chart_utils import create_plotly_chart
 
@@ -10,19 +10,19 @@ logger = logging.getLogger(__name__)
 
 
 def generate_chart(
-    data_source: List[Dict[str, Any]],
+    data_source: list[dict[str, Any]],
     chart_type: str,
     x_column: str,
-    y_column: Optional[Union[str, List[str]]] = None,
-    color_column: Optional[str] = None,
-    title: Optional[str] = None,
+    y_column: str | list[str] | None = None,
+    color_column: str | None = None,
+    title: str | None = None,
     chart_style: str = "grouped",
     width: int = 800,
     height: int = 600,
-    sort_by: Optional[str] = None,
-    sort_order: Optional[str] = None,
+    sort_by: str | None = None,
+    sort_order: str | None = None,
     output_format: str = "image",
-) -> Union[Tuple[bytes, str], Dict[str, Any]]:
+) -> tuple[bytes, str] | dict[str, Any]:
     """Generate chart and return either Plotly data or image bytes.
 
     Args:
@@ -258,4 +258,4 @@ def generate_chart(
 
     except Exception as e:
         logger.error(f"Chart creation error: {e}")
-        return {"error": f"❌ Chart generation failed: {str(e)}"}
+        return {"error": f"❌ Chart generation failed: {e!s}"}

--- a/src/workspace.py
+++ b/src/workspace.py
@@ -5,7 +5,7 @@ and format summaries for user-facing messages.
 """
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any
 
 from .lifecycle.metadata import VersionMetadataManager
 from .paths import OUTPUT_DIR, get_connection_dir
@@ -13,7 +13,7 @@ from .paths import OUTPUT_DIR, get_connection_dir
 logger = logging.getLogger(__name__)
 
 
-def detect_workspace(connection_id: str) -> Optional[Dict[str, Any]]:
+def detect_workspace(connection_id: str) -> dict[str, Any] | None:
     """Detect an existing workspace for a connection.
 
     Reads metadata.json, checks the workspace section exists, and validates
@@ -41,10 +41,10 @@ def detect_workspace(connection_id: str) -> Optional[Dict[str, Any]]:
             return None
 
         conn_dir = get_connection_dir(connection_id)
-        validated: Dict[str, Any] = {}
+        validated: dict[str, Any] = {}
 
         for schema_name, schema_data in schemas.items():
-            schema_status: Dict[str, Any] = {}
+            schema_status: dict[str, Any] = {}
 
             # Validate schema artifact
             schema_section = schema_data.get("schema", {})
@@ -96,7 +96,7 @@ def detect_workspace(connection_id: str) -> Optional[Dict[str, Any]]:
         if not validated:
             return None
 
-        result: Dict[str, Any] = {
+        result: dict[str, Any] = {
             "schemas": validated,
             "updated_at": workspace.get("updated_at"),
             "db_type": workspace.get("db_type"),
@@ -115,7 +115,7 @@ def detect_workspace(connection_id: str) -> Optional[Dict[str, Any]]:
         return None
 
 
-def format_workspace_summary(workspace: Dict[str, Any]) -> str:
+def format_workspace_summary(workspace: dict[str, Any]) -> str:
     """Format workspace detection result for user display.
 
     Args:

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -299,9 +299,8 @@ class TestDatabaseManager(unittest.TestCase):
 
     def test_get_connection_no_engine(self):
         """Test connection context manager without engine."""
-        with self.assertRaises(RuntimeError):
-            with self.db_manager.get_connection():
-                pass
+        with self.assertRaises(RuntimeError), self.db_manager.get_connection():
+            pass
 
     def test_strip_leading_sql_comments_preserves_duplicates(self):
         """Ensure comment stripping doesn't mis-handle duplicate lines."""

--- a/tests/test_graphrag_integration.py
+++ b/tests/test_graphrag_integration.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Comprehensive tests for GraphRAG integration.
 
@@ -357,7 +356,8 @@ class TestGraphRetriever:
         retriever = GraphRetriever()
 
         # Add isolated table
-        tables = sample_tables + [
+        tables = [
+            *sample_tables,
             {
                 "name": "isolated_table",
                 "schema": "public",
@@ -366,7 +366,7 @@ class TestGraphRetriever:
                 "primary_keys": [],
                 "comment": None,
                 "row_count": 0,
-            }
+            },
         ]
 
         retriever.build_graph(tables)
@@ -389,7 +389,8 @@ class TestGraphRetriever:
         retriever = GraphRetriever()
 
         # Create schema with fan-trap
-        fan_trap_tables = sample_tables + [
+        fan_trap_tables = [
+            *sample_tables,
             {
                 "name": "payments",
                 "schema": "public",
@@ -404,7 +405,7 @@ class TestGraphRetriever:
                 ],
                 "comment": None,
                 "row_count": 0,
-            }
+            },
         ]
 
         retriever.build_graph(fan_trap_tables)
@@ -442,7 +443,7 @@ class TestCommunityDetector:
 
         # All tables are connected, so should be 1 community
         assert len(communities) == 1
-        assert len(list(communities.values())[0]) == 3
+        assert len(next(iter(communities.values()))) == 3
 
     def test_get_community_summary(self, sample_tables):
         """Test getting community summary."""

--- a/tests/test_ontology_generator.py
+++ b/tests/test_ontology_generator.py
@@ -211,7 +211,7 @@ class TestOntologyGenerator(unittest.TestCase):
 
         for sql_type, expected_xsd in test_cases:
             with self.subTest(sql_type=sql_type):
-                result, override = self.generator._map_sql_to_xsd(sql_type)
+                result, _override = self.generator._map_sql_to_xsd(sql_type)
                 self.assertEqual(
                     result,
                     expected_xsd,

--- a/tests/test_ontology_workflow_fix.py
+++ b/tests/test_ontology_workflow_fix.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Test that ontology generation works correctly after discover_schema(lightweight=True).
 

--- a/tests/test_phase2_hierarchical.py
+++ b/tests/test_phase2_hierarchical.py
@@ -230,12 +230,12 @@ class TestPhase2EdgeCases:
         """Test behavior when schema has no tables."""
         # This should be handled gracefully
         # Lightweight mode should return empty lists
-        pass  # Requires actual DB connection
+        # Requires actual DB connection
 
     def test_get_table_details_nonexistent_table(self):
         """Test get_table_details with nonexistent table."""
         # Should return error response with success=False
-        pass  # Requires actual DB connection
+        # Requires actual DB connection
 
     def test_get_table_details_without_schema(self):
         """Test get_table_details uses default schema."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -229,6 +229,7 @@ class TestMCPToolsAsync:
         mock_db_manager.connect_postgresql.return_value = True
         mock_session_data.db_manager = mock_db_manager
 
+        # The function raises exception (no internal error handling)
         with patch("src.main.get_session_data", return_value=mock_session_data), patch(
             "src.main.get_session_db_manager", return_value=mock_db_manager
         ), patch(
@@ -364,10 +365,10 @@ class TestMCPToolsAsync:
                 "POSTGRES_USERNAME": "testuser",
                 "POSTGRES_PASSWORD": "testpass",
             },
+        ), pytest.raises(
+            Exception, match="Connection error"
         ):
-            # The function raises exception (no internal error handling)
-            with pytest.raises(Exception, match="Connection error"):
-                await main_module.connect_database(mock_ctx, db_type="postgresql")
+            await main_module.connect_database(mock_ctx, db_type="postgresql")
 
     async def test_list_schemas_success(self, mock_ctx, mock_session_data):
         """Test successful schema listing with session isolation."""
@@ -375,6 +376,7 @@ class TestMCPToolsAsync:
         mock_db_manager.get_schemas.return_value = ["public", "private", "analytics"]
         mock_session_data.db_manager = mock_db_manager
 
+        # The function raises exception (no internal error handling)
         with patch("src.main.get_session_data", return_value=mock_session_data), patch(
             "src.main.get_session_db_manager", return_value=mock_db_manager
         ):
@@ -394,10 +396,8 @@ class TestMCPToolsAsync:
 
         with patch("src.main.get_session_data", return_value=mock_session_data), patch(
             "src.main.get_session_db_manager", return_value=mock_db_manager
-        ):
-            # The function raises exception (no internal error handling)
-            with pytest.raises(RuntimeError, match="No database connection"):
-                await main_module.list_schemas(mock_ctx)
+        ), pytest.raises(RuntimeError, match="No database connection"):
+            await main_module.list_schemas(mock_ctx)
 
     async def test_discover_schema_success(
         self, mock_ctx, mock_session_data, sample_users_table, sample_orders_table
@@ -411,6 +411,7 @@ class TestMCPToolsAsync:
         ]
         mock_session_data.db_manager = mock_db_manager
 
+        # The function raises exception (no internal error handling)
         with patch("src.main.get_session_data", return_value=mock_session_data), patch(
             "src.main.get_session_db_manager", return_value=mock_db_manager
         ), patch("src.server_state.get_session_id", return_value="test-session"), patch(
@@ -447,10 +448,8 @@ class TestMCPToolsAsync:
 
         with patch("src.main.get_session_data", return_value=mock_session_data), patch(
             "src.main.get_session_db_manager", return_value=mock_db_manager
-        ):
-            # The function raises exception (no internal error handling)
-            with pytest.raises(RuntimeError, match="No database connection"):
-                await main_module.discover_schema(mock_ctx, "public")
+        ), pytest.raises(RuntimeError, match="No database connection"):
+            await main_module.discover_schema(mock_ctx, "public")
 
     async def test_generate_ontology_success(
         self, mock_ctx, mock_session_data, sample_users_table
@@ -471,6 +470,7 @@ class TestMCPToolsAsync:
             "@prefix ns: <http://example.com/ontology/> ."
         )
 
+        # The function raises exception (no internal error handling)
         with patch("src.main.get_session_data", return_value=mock_session_data), patch(
             "src.main.get_session_db_manager", return_value=mock_db_manager
         ), patch(
@@ -556,12 +556,8 @@ class TestMCPToolsAsync:
 
         with patch("src.main.get_session_data", return_value=mock_session_data), patch(
             "src.main.get_session_db_manager", return_value=mock_db_manager
-        ):
-            # The function raises exception (no internal error handling)
-            with pytest.raises(ValueError, match="Invalid table name format"):
-                await main_module.sample_table_data(
-                    mock_ctx, "invalid-table", "public", 10
-                )
+        ), pytest.raises(ValueError, match="Invalid table name format"):
+            await main_module.sample_table_data(mock_ctx, "invalid-table", "public", 10)
 
 
 class TestOntologyGenerator(unittest.TestCase):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -151,17 +151,16 @@ class TestAsyncWriteSerialization:
     @pytest.mark.asyncio
     async def test_concurrent_writes_dont_corrupt(self):
         """Multiple concurrent writes produce valid JSON."""
-        tasks = []
-        for i in range(5):
-            tasks.append(
-                update_workspace_section(
-                    connection_id=self.connection_id,
-                    output_dir=self.output_dir,
-                    schema_name=f"schema_{i}",
-                    section="schema",
-                    data={"table_count": i * 10},
-                )
+        tasks = [
+            update_workspace_section(
+                connection_id=self.connection_id,
+                output_dir=self.output_dir,
+                schema_name=f"schema_{i}",
+                section="schema",
+                data={"table_count": i * 10},
             )
+            for i in range(5)
+        ]
 
         await asyncio.gather(*tasks)
 


### PR DESCRIPTION
Stacked on #65 — **base is `chore/pin-ruff-lint-select`, not `main`.** Merge #65 first; this retargets to `main` automatically.

Follow-up to the note in #65 about findings I'd deliberately left on the table. This adopts the mechanical half and **fixes every finding rather than suppressing it**.

## What's enabled

`UP`, `C4`, `SIM`, `PIE`, `PERF`, `EXE`, `PYI`, `RUF` on top of the pinned `E4/E7/E9/F` baseline. ~1120 fixes across 64 files. No intended behavior change.

Mostly mechanical: PEP 585/604 typing (`Dict`→`dict`, `Optional[X]`→`X | None`), f-string conversion flags, collection-call and comprehension cleanups, `ClassVar` on mutable class constants, dead shebang removal.

## Three that needed real review, not a blind `--fix`

Running `ruff --fix` unattended would have shipped two bugs:

**1. `UP007` introduced an `F823`.** It rewrote a quoted annotation in `graphrag/manager.py` to an unquoted union:
```python
self.vector_store: Union["ChromaDBVectorStore", "VectorStore"]   # before
self.vector_store: ChromaDBVectorStore | VectorStore             # after --fix
```
Neither name is guaranteed bound at runtime — `ChromaDBVectorStore` is unbound if its import raised `ImportError`, and `VectorStore` is `TYPE_CHECKING`-only *and* shadowed by a local import in the `else` branch. That's precisely why the original was quoted. Restored the quotes with a `noqa: UP037` and a comment recording why. (It doesn't crash today only because attribute annotations in a function body aren't evaluated — I verified that rather than assuming it.)

**2. `RUF059` orphaned a sibling assignment.** It renamed one unpacked binding to `_source_filename`, leaving the other branch's plain `source_filename = ontology_file` dangling as a fresh `F841`. `source_filename` is dead in *both* branches of `apply_semantic_names` (confirmed across its full 413–565 extent), so it's removed outright rather than left as a renamed corpse.

**3. `UP042` `(str, Enum)` → `StrEnum`** changes `str()`/f-string output. Safe here only because `to_response()` reads `.error_type.value` explicitly and nothing else stringifies it — checked every consumer before applying.

I also worked through the `SIM102` collapses in `obqc_validator.py` by hand rather than trusting them, since that's the fan-trap core. The `if/elif` at `_get_suggested_join` looked like a control-flow trap; it isn't — both arms can only be true for a self-referential FK, and in that case the two inner conditions are the same expression. Equivalent, so applied.

## `SIM105` is deferred, and that's deliberate

It's in `ignore` with a comment explaining why. All **14 `S110`** blind-swallow sites are a strict subset of the **19 `SIM105`** sites (the driver `close()` paths). Rewriting them to `contextlib.suppress` would make the entire `S110` signal disappear without anyone deciding whether swallowing `Exception` is correct there — suppression wearing a fix's clothing. It belongs to the error-handling audit below, not to a mechanical cleanup.

## Verification

- `ruff check` clean under **both** 0.15.10 and 0.16.0
- `black --check` 91 files unchanged; `isort` clean
- `mypy --strict` — no issues in 60 source files
- `pytest` — **378 passed**

## Still to come (Tier B)

The judgment-heavy half, worth its own PR and its own scrutiny: `BLE001` (159 blind excepts), `DTZ005/006` (41 naive datetimes), `G201` (24), `S110` (14), `ASYNC230` (11 blocking file opens inside async functions — the one I'd look at first, in an async MCP server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)