### PR TITLE
fix: Tier B error-handling, async and timestamp audit

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -18,6 +18,14 @@ AUTO_GRAPHRAG=true
 # When enabled: ontology is automatically generated and stored in Oxigraph RDF store
 AUTO_ONTOLOGY=false
 
+# Superseded artifact pruning
+# Artifact filenames carry a timestamp, so every generate_ontology /
+# discover_schema writes a NEW file while metadata records only the latest.
+# This is how many generations of each artifact (per connection, per schema)
+# to keep; older ones are deleted as soon as a new one is written. Minimum 1
+# -- the file currently referenced is never a deletion candidate.
+ARTIFACT_KEEP_VERSIONS=3
+
 # Startup Workspace Cleanup
 # -------------------------
 # NOTE: per-version retention (keeping the last N GraphRAG/ontology versions)
@@ -135,7 +143,7 @@ ENABLE_SAMPLING=true
 # - Use a persistent directory (e.g., /var/lib/orionbelt, /data/orionbelt)
 # - Mount as a volume in containerized environments
 # - Ensure proper backup of OUTPUT_DIR
-# - Consider retention policies (see Phase 3B settings above)
+# - Consider ARTIFACT_KEEP_VERSIONS / AUTO_CLEANUP_ON_STARTUP (see above)
 #
 OUTPUT_DIR=tmp
 

--- a/.env.template
+++ b/.env.template
@@ -18,24 +18,32 @@ AUTO_GRAPHRAG=true
 # When enabled: ontology is automatically generated and stored in Oxigraph RDF store
 AUTO_ONTOLOGY=false
 
-# Phase 3B: Data Lifecycle - Retention Policies
-# ----------------------------------------------
-# Control how many versions to keep and for how long
-
-# GraphRAG Retention
-GRAPHRAG_KEEP_VERSIONS=3          # Keep last 3 versions
-GRAPHRAG_MAX_AGE_DAYS=30          # Delete versions older than 30 days
-
-# Ontology Retention (keep longer than GraphRAG - more expensive to regenerate)
-ONTOLOGY_KEEP_VERSIONS=5          # Keep last 5 versions
-ONTOLOGY_MAX_AGE_DAYS=60          # Delete versions older than 60 days
-
-# Workspace Retention
-WORKSPACE_MAX_AGE_DAYS=30         # Remove workspaces not updated in this many days
-
-# Cleanup Triggers
-# Options: false (default), true (retention-based), all (remove everything)
+# Startup Workspace Cleanup
+# -------------------------
+# NOTE: per-version retention (keeping the last N GraphRAG/ontology versions)
+# is designed but NOT wired up, so GRAPHRAG_KEEP_VERSIONS, GRAPHRAG_MAX_AGE_DAYS,
+# ONTOLOGY_KEEP_VERSIONS and ONTOLOGY_MAX_AGE_DAYS are deliberately absent here:
+# nothing reads them. Cleanup operates on whole workspace directories only.
+#
+# Runs on every startup regardless of the setting below:
+#   - stale loose files directly under the output dir are deleted
+#   - each workspace's charts/ directory is deleted (chart images are ephemeral)
+#
+# AUTO_CLEANUP_ON_STARTUP then controls whether whole workspaces are deleted:
+#   false (default) - nothing further; all workspaces are kept
+#   true            - delete a workspace if it has no metadata.json (orphaned),
+#                     or if its workspace.updated_at is older than
+#                     WORKSPACE_MAX_AGE_DAYS. A workspace whose metadata has no
+#                     updated_at is kept.
+#   all             - delete every workspace directory (fresh start)
+#
+# Deletion is whole-workspace: schema cache, ontology, GraphRAG vectors, RDF
+# store and saved semantic models for that connection all go together.
 AUTO_CLEANUP_ON_STARTUP=false
+
+# Age threshold for AUTO_CLEANUP_ON_STARTUP=true, measured from the workspace's
+# last update (not file mtime). Ignored for the false and all modes.
+WORKSPACE_MAX_AGE_DAYS=30
 
 # MCP Transport Configuration
 # Options: http, sse (Server-Sent Events)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,21 +37,19 @@ AUTO_GRAPHRAG=true
 # When enabled: ontology is automatically generated and stored in Oxigraph RDF store
 AUTO_ONTOLOGY=false
 
-# Phase 3B: Data Lifecycle - Retention Policies
-# ----------------------------------------------
-# Control how many versions to keep and for how long
-
-# GraphRAG Retention
-GRAPHRAG_KEEP_VERSIONS=3          # Keep last 3 versions
-GRAPHRAG_MAX_AGE_DAYS=30          # Delete versions older than 30 days
-
-# Ontology Retention (keep longer than GraphRAG - more expensive to regenerate)
-ONTOLOGY_KEEP_VERSIONS=5          # Keep last 5 versions
-ONTOLOGY_MAX_AGE_DAYS=60          # Delete versions older than 60 days
-
-# Cleanup Triggers
-# Options: false (default), true (retention-based), all (remove everything)
+# Startup Workspace Cleanup
+# -------------------------
+# Runs on every startup regardless of the setting below:
+#   - stale loose files directly under the output dir are deleted
+#   - each workspace's charts/ directory is deleted (chart images are ephemeral)
+#
+# AUTO_CLEANUP_ON_STARTUP then controls whether whole workspaces are deleted.
+# See "Startup workspace cleanup" below for the exact semantics.
 AUTO_CLEANUP_ON_STARTUP=false
+
+# Age threshold for AUTO_CLEANUP_ON_STARTUP=true, measured from the workspace's
+# last update (not file mtime). Ignored for the false and all modes.
+WORKSPACE_MAX_AGE_DAYS=30
 
 # MCP Sampling
 # ------------
@@ -111,7 +109,7 @@ R2RML_BASE_IRI=http://mycompany.com/
 # - Use a persistent directory (e.g., /var/lib/orionbelt, /data/orionbelt)
 # - Mount as a volume in containerized environments
 # - Ensure proper backup of OUTPUT_DIR
-# - Consider retention policies (see Phase 3B settings above)
+# - Consider AUTO_CLEANUP_ON_STARTUP / WORKSPACE_MAX_AGE_DAYS (see above)
 #
 OUTPUT_DIR=tmp
 
@@ -202,12 +200,8 @@ DATABRICKS_SCHEMA=default
 | `LOG_LEVEL` | `INFO` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
 | `AUTO_GRAPHRAG` | `true` | Auto-initialize GraphRAG when schema is analyzed |
 | `AUTO_ONTOLOGY` | `false` | Auto-generate ontology after GraphRAG completes |
-| `GRAPHRAG_KEEP_VERSIONS` | `3` | Number of GraphRAG versions to retain |
-| `GRAPHRAG_MAX_AGE_DAYS` | `30` | Maximum age in days for GraphRAG versions |
-| `ONTOLOGY_KEEP_VERSIONS` | `5` | Number of ontology versions to retain |
-| `ONTOLOGY_MAX_AGE_DAYS` | `60` | Maximum age in days for ontology versions |
-| `AUTO_CLEANUP_ON_STARTUP` | `false` | Startup cleanup: `false` (none), `true` (retention-based), `all` (remove all workspaces) |
-| `WORKSPACE_MAX_AGE_DAYS` | `30` | Maximum age in days for workspace directories |
+| `AUTO_CLEANUP_ON_STARTUP` | `false` | Delete whole workspaces at startup: `false` (keep all), `true` (orphaned, or older than `WORKSPACE_MAX_AGE_DAYS`), `all` (delete every workspace). See [Startup workspace cleanup](#startup-workspace-cleanup) |
+| `WORKSPACE_MAX_AGE_DAYS` | `30` | Age threshold for `AUTO_CLEANUP_ON_STARTUP=true`, measured from the workspace's last update. Ignored in the other modes |
 | `ONTOLOGY_BASE_URI` | `http://example.com/ontology/` | Base URI for generated RDF ontologies |
 | `R2RML_BASE_IRI` | `http://mycompany.com/` | Base IRI for R2RML subject templates |
 | `OUTPUT_DIR` | `tmp` | Directory for generated files (relative to project root) |
@@ -218,6 +212,37 @@ DATABRICKS_SCHEMA=default
 | `SESSION_IDLE_TIMEOUT_SECONDS` | `1800` | Idle timeout before session eviction (0 to disable) |
 | `SESSION_SCAN_INTERVAL_SECONDS` | `60` | How often to scan for idle sessions |
 | `MCP_MASTER_PASSWORD` | *(unset)* | Master password for encrypting credentials in memory |
+
+### Startup workspace cleanup
+
+`AUTO_CLEANUP_ON_STARTUP` controls how much of the output directory survives a restart. It operates on **whole workspaces** -- one per database connection, under `OUTPUT_DIR/{connection_id}/` -- and honours a custom `OUTPUT_DIR`.
+
+**Always runs, whatever the setting is:**
+
+- stale loose files sitting directly in `OUTPUT_DIR` (not inside a connection directory) are deleted
+- every workspace's `charts/` directory is deleted -- chart images are ephemeral and are regenerated on demand
+
+Workspace data itself is only touched by the modes below.
+
+| Mode | What is deleted |
+|------|-----------------|
+| `false` *(default)* | Nothing beyond the two steps above. Every workspace is kept, so auto-restore works after a restart. |
+| `true` | A workspace is deleted if it has **no `metadata.json`** (orphaned directory), or if its recorded `workspace.updated_at` is older than `WORKSPACE_MAX_AGE_DAYS`. A workspace whose metadata exists but has no `updated_at` is **kept**. |
+| `all` | Every workspace directory, unconditionally -- a full fresh start. |
+
+**Deletion is all-or-nothing per connection.** Removing a workspace removes its schema cache, ontology TTL, R2RML mapping, saved semantic models, *and* the satellite stores held outside the workspace directory:
+
+```
+OUTPUT_DIR/{connection_id}/            # workspace: metadata.json, schema, ontology, models/
+OUTPUT_DIR/chromadb/{connection_id}/   # GraphRAG vectors
+OUTPUT_DIR/oxigraph/{connection_id}/   # RDF / SPARQL store
+```
+
+There is no partial or per-artifact cleanup. The `chromadb/` and `oxigraph/` parent directories are shared across connections and are never themselves treated as workspaces.
+
+**Age comes from metadata, not the filesystem.** The `true` mode reads `workspace.updated_at` out of `metadata.json` rather than looking at file modification times, so touching files on disk does not keep a workspace alive.
+
+> **Note on per-version retention.** An earlier design kept the last *N* versions of GraphRAG and ontology data per schema, configured by `GRAPHRAG_KEEP_VERSIONS`, `GRAPHRAG_MAX_AGE_DAYS`, `ONTOLOGY_KEEP_VERSIONS` and `ONTOLOGY_MAX_AGE_DAYS`. That mechanism is **not wired up** -- those four variables are read nowhere in the code and setting them has no effect, so they are intentionally absent from `.env.template`. The retention policy defaults are still recorded in each workspace's `metadata.json`, and `DataCleanupManager` still implements the logic, but nothing invokes it. Only the whole-workspace cleanup described above actually runs.
 
 ### Security Notes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,14 @@ AUTO_GRAPHRAG=true
 # When enabled: ontology is automatically generated and stored in Oxigraph RDF store
 AUTO_ONTOLOGY=false
 
+# Superseded artifact pruning
+# Artifact filenames carry a timestamp, so every generate_ontology /
+# discover_schema writes a NEW file while metadata records only the latest.
+# This is how many generations of each artifact (per connection, per schema)
+# to keep; older ones are deleted as soon as a new one is written. Minimum 1
+# -- the file currently referenced is never a deletion candidate.
+ARTIFACT_KEEP_VERSIONS=3
+
 # Startup Workspace Cleanup
 # -------------------------
 # Runs on every startup regardless of the setting below:
@@ -200,6 +208,7 @@ DATABRICKS_SCHEMA=default
 | `LOG_LEVEL` | `INFO` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
 | `AUTO_GRAPHRAG` | `true` | Auto-initialize GraphRAG when schema is analyzed |
 | `AUTO_ONTOLOGY` | `false` | Auto-generate ontology after GraphRAG completes |
+| `ARTIFACT_KEEP_VERSIONS` | `3` | Generations of each ontology / schema / R2RML file to keep per schema. Older ones are pruned when a new one is written. Minimum 1 |
 | `AUTO_CLEANUP_ON_STARTUP` | `false` | Delete whole workspaces at startup: `false` (keep all), `true` (orphaned, or older than `WORKSPACE_MAX_AGE_DAYS`), `all` (delete every workspace). See [Startup workspace cleanup](#startup-workspace-cleanup) |
 | `WORKSPACE_MAX_AGE_DAYS` | `30` | Age threshold for `AUTO_CLEANUP_ON_STARTUP=true`, measured from the workspace's last update. Ignored in the other modes |
 | `ONTOLOGY_BASE_URI` | `http://example.com/ontology/` | Base URI for generated RDF ontologies |

--- a/docs/development.md
+++ b/docs/development.md
@@ -98,17 +98,17 @@ Test files follow the `test_*.py` convention in the `tests/` directory, covering
 
 ```bash
 # Auto-format with black (line length 88, Python 3.13 target)
-black src/ tests/
+black src/ tests/ server.py
 
 # Sort imports (configured for black compatibility)
-isort src/ tests/
+isort src/ tests/ server.py
 ```
 
 ### Linting
 
 ```bash
 # Ruff -- fast linter and formatter
-ruff check src/ tests/
+ruff check src/ tests/ server.py
 
 # Flake8
 flake8 src/
@@ -361,9 +361,9 @@ docs: update configuration reference for BigQuery
 2. **Format and lint** your code:
 
    ```bash
-   black src/ tests/
-   isort src/ tests/
-   ruff check src/ tests/
+   black src/ tests/ server.py
+   isort src/ tests/ server.py
+   ruff check src/ tests/ server.py
    mypy src/
    ```
 

--- a/integrations/google-adk/agent_example.py
+++ b/integrations/google-adk/agent_example.py
@@ -73,7 +73,7 @@ async def main() -> None:
     print("OrionBelt Analytics Agent (type 'quit' to exit)\n")
     try:
         while True:
-            user_input = input("You: ").strip()
+            user_input = (await asyncio.to_thread(input, "You: ")).strip()
             if user_input.lower() in ("quit", "exit", "q"):
                 break
             if not user_input:

--- a/integrations/langchain/agent_example.py
+++ b/integrations/langchain/agent_example.py
@@ -67,7 +67,7 @@ async def main() -> None:
         # Interactive loop
         print("OrionBelt Analytics Agent (type 'quit' to exit)\n")
         while True:
-            user_input = input("You: ").strip()
+            user_input = (await asyncio.to_thread(input, "You: ")).strip()
             if user_input.lower() in ("quit", "exit", "q"):
                 break
             if not user_input:

--- a/integrations/openai-agents-sdk/agent_example.py
+++ b/integrations/openai-agents-sdk/agent_example.py
@@ -58,7 +58,7 @@ async def main() -> None:
     # Interactive loop
     print("OrionBelt Analytics Agent (type 'quit' to exit)\n")
     while True:
-        user_input = input("You: ").strip()
+        user_input = (await asyncio.to_thread(input, "You: ")).strip()
         if user_input.lower() in ("quit", "exit", "q"):
             break
         if not user_input:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,16 +136,8 @@ select = [
     "EXE",    # shebang correctness
     "PYI",    # stub/typing correctness
     "RUF",    # ruff-specific
-]
-
-ignore = [
-    # Deferred, NOT dismissed. Every SIM105 site is also an S110 site (blind
-    # `except Exception: pass` in the drivers). Rewriting them to
-    # contextlib.suppress would delete the S110 signal without anyone deciding
-    # whether swallowing is correct there -- suppression wearing a fix's
-    # clothing. These are handled in the error-handling audit that enables
-    # BLE/S110/G/DTZ/ASYNC, where each swallow is judged on merit.
-    "SIM105",
+    "ASYNC",  # blocking calls inside async functions
+    "S110",   # silently swallowed exceptions
 ]
 
 # Tests legitimately hold mutable class-level fixtures; that is noise there

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ select = [
     "ASYNC",  # blocking calls inside async functions
     "S110",   # silently swallowed exceptions
     "DTZ",    # naive datetimes -- timestamps are persisted and compared
+    "G201",   # logger.error(exc_info=True) -> logger.exception
 ]
 
 # Tests legitimately hold mutable class-level fixtures; that is noise there

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,19 @@ select = [
     "G201",   # logger.error(exc_info=True) -> logger.exception
 ]
 
+# BLE001 (blind `except Exception`) is intentionally NOT selected. All 167
+# sites were audited, not waved through: 153 log, 23 re-raise, and 23 fold the
+# message into the returned error payload. That breadth is required at the MCP
+# tool boundary -- a handler must convert failures into an error response
+# rather than leak an arbitrary exception into the protocol layer -- so
+# enabling the rule would mean 167 `noqa` comments and no added safety.
+#
+# The 4 handlers that genuinely discarded their exception were fixed. The
+# invariant that actually matters ("a broad handler must not throw the error
+# away") is enforced by tests/test_no_silent_exceptions.py, which walks the AST
+# and fails on any regression -- a stricter and more precise guarantee than the
+# lint rule provides.
+
 # Tests legitimately hold mutable class-level fixtures; that is noise there
 # rather than signal.
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ select = [
     "RUF",    # ruff-specific
     "ASYNC",  # blocking calls inside async functions
     "S110",   # silently swallowed exceptions
+    "DTZ",    # naive datetimes -- timestamps are persisted and compared
 ]
 
 # Tests legitimately hold mutable class-level fixtures; that is noise there

--- a/server.py
+++ b/server.py
@@ -6,7 +6,7 @@ import json
 import shutil
 import signal
 import sys
-from datetime import datetime, timedelta
+from datetime import timedelta
 from pathlib import Path
 
 # Add src directory to path for imports
@@ -19,7 +19,7 @@ from src import __name__ as SERVER_NAME  # noqa: E402
 from src import __version__  # noqa: E402
 from src.config import config_manager  # noqa: E402
 from src.main import cleanup_server, mcp  # noqa: E402
-from src.utils import setup_logging  # noqa: E402
+from src.utils import parse_timestamp, setup_logging, utc_now  # noqa: E402
 
 # Setup logging
 config = config_manager.get_server_config()
@@ -227,7 +227,7 @@ def cleanup_tmp_folder():
         f"Retention cleanup enabled (WORKSPACE_MAX_AGE_DAYS={max_age_days}), "
         f"scanning {len(workspace_dirs)} workspace(s)..."
     )
-    cutoff = datetime.now() - timedelta(days=max_age_days)
+    cutoff = utc_now() - timedelta(days=max_age_days)
     cleaned = 0
 
     for conn_dir in workspace_dirs:
@@ -251,11 +251,11 @@ def cleanup_tmp_folder():
             workspace = metadata.get("workspace", {})
             updated_at = workspace.get("updated_at")
             if updated_at:
-                last_update = datetime.fromisoformat(updated_at)
+                last_update = parse_timestamp(updated_at)
                 if last_update < cutoff:
                     shutil.rmtree(conn_dir)
                     cleaned += 1
-                    age_days = (datetime.now() - last_update).days
+                    age_days = (utc_now() - last_update).days
                     logger.info(
                         f"Removed stale workspace: {conn_dir.name} "
                         f"(last updated {age_days} days ago, max {max_age_days})"

--- a/server.py
+++ b/server.py
@@ -143,27 +143,51 @@ def print_startup_info():
 
 
 def cleanup_tmp_folder():
-    """Clean up stale top-level files from tmp/, preserving workspace data.
+    """Clean the output directory at startup, preserving live workspace data.
 
-    Connection-scoped directories (tmp/{connection_id}/) contain workspace
-    artifacts (metadata.json, schema JSON, ontology TTL, Oxigraph store,
-    ChromaDB) that must survive server restarts for workspace auto-restore to work.
+    Always runs, whatever AUTO_CLEANUP_ON_STARTUP is set to:
+    - deletes stale loose files sitting directly in OUTPUT_DIR
+    - deletes every workspace's charts/ directory (chart images are ephemeral)
 
-    Only removes top-level files that are not inside a connection directory.
+    AUTO_CLEANUP_ON_STARTUP then decides whether whole workspaces go:
+    - "false" (default): none; every workspace is kept so auto-restore works
+    - "true": deletes a workspace with no metadata.json (orphaned), or whose
+      workspace.updated_at is older than WORKSPACE_MAX_AGE_DAYS. A workspace
+      whose metadata has no updated_at is kept.
+    - "all": deletes every workspace (fresh start)
 
-    AUTO_CLEANUP_ON_STARTUP controls workspace cleanup:
-    - "false" (default): no workspace cleanup, only top-level files and charts
-    - "true": retention-based — removes workspaces older than WORKSPACE_MAX_AGE_DAYS
-    - "all": removes ALL workspace directories (fresh start)
+    Deleting a workspace also deletes the satellite stores keyed to that
+    connection -- chromadb/{id} and oxigraph/{id} live beside the workspace, not
+    inside it, so they would otherwise be stranded on disk forever. The
+    chromadb/ and oxigraph/ parents are shared across connections and are never
+    themselves treated as workspaces (they carry no metadata.json, so doing so
+    would delete every connection's vectors and triples).
     """
     import os
 
-    tmp_dir = Path(__file__).parent / "tmp"
+    from src.paths import NON_WORKSPACE_DIRS, OUTPUT_DIR, get_connection_store_dirs
+
+    tmp_dir = OUTPUT_DIR
 
     if not tmp_dir.exists():
-        tmp_dir.mkdir(exist_ok=True)
-        logger.info("Created tmp directory for output files")
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        logger.info(f"Created output directory for generated files: {tmp_dir}")
         return
+
+    def _remove_workspace(conn_dir: Path) -> None:
+        """Remove a workspace and the satellite stores keyed to it.
+
+        chromadb/{id} and oxigraph/{id} live outside the workspace directory,
+        so deleting only conn_dir would strand them on disk forever.
+        """
+        shutil.rmtree(conn_dir)
+        for store_dir in get_connection_store_dirs(conn_dir.name):
+            if store_dir.exists():
+                try:
+                    shutil.rmtree(store_dir)
+                    logger.debug(f"Removed satellite store: {store_dir}")
+                except Exception as e:
+                    logger.warning(f"Failed to remove {store_dir}: {e}")
 
     # Phase 1: Remove stale top-level files (always)
     removed = 0
@@ -174,7 +198,11 @@ def cleanup_tmp_folder():
                 item.unlink()
                 removed += 1
                 logger.debug(f"Removed stale file: {item.name}")
-            elif item.is_dir():
+            elif item.is_dir() and item.name not in NON_WORKSPACE_DIRS:
+                # chromadb/ and oxigraph/ hold per-connection stores one level
+                # deeper. They carry no metadata.json, so counting them as
+                # workspaces makes them look orphaned -- which deleted every
+                # connection's vectors and triples on the first retention run.
                 workspace_dirs.append(item)
     except Exception as e:
         logger.warning(f"Failed to clean tmp directory: {e}")
@@ -213,7 +241,7 @@ def cleanup_tmp_folder():
         cleaned = 0
         for conn_dir in workspace_dirs:
             try:
-                shutil.rmtree(conn_dir)
+                _remove_workspace(conn_dir)
                 cleaned += 1
                 logger.info(f"Removed workspace: {conn_dir.name}")
             except Exception as e:
@@ -235,7 +263,7 @@ def cleanup_tmp_folder():
         if not metadata_file.exists():
             # No metadata — orphaned directory, remove it
             try:
-                shutil.rmtree(conn_dir)
+                _remove_workspace(conn_dir)
                 cleaned += 1
                 logger.info(f"Removed orphaned workspace directory: {conn_dir.name}")
             except Exception as e:
@@ -253,7 +281,7 @@ def cleanup_tmp_folder():
             if updated_at:
                 last_update = parse_timestamp(updated_at)
                 if last_update < cutoff:
-                    shutil.rmtree(conn_dir)
+                    _remove_workspace(conn_dir)
                     cleaned += 1
                     age_days = (utc_now() - last_update).days
                     logger.info(

--- a/src/chart_utils.py
+++ b/src/chart_utils.py
@@ -1,5 +1,6 @@
 """Chart generation utilities for OrionBelt Analytics."""
 
+import contextlib
 import logging
 from collections.abc import Callable
 from typing import Any, cast
@@ -504,11 +505,9 @@ def create_plotly_chart(
         else:
             # Try to convert x_column to datetime if it looks like a date
             # This ensures proper chronological sorting
-            try:
+            # Not a datetime column -- use the values as-is.
+            with contextlib.suppress(ValueError, TypeError):
                 sorted_df[x_column] = pd.to_datetime(sorted_df[x_column])
-            except (ValueError, TypeError):
-                # Not a datetime column, use as-is
-                pass
 
             # Sort data by x-axis column (default) or specified column for proper line chart ordering
             sorted_df = sorted_df.sort_values(

--- a/src/drivers/bigquery.py
+++ b/src/drivers/bigquery.py
@@ -341,8 +341,13 @@ class BigQueryDriver(DatabaseDriver):
                             logger.error(f"Error fetching results: {fetch_error}")
                             try:
                                 result.close()
-                            except Exception:
-                                pass
+                            except Exception as close_error:
+                                # Swallowed on purpose: a cursor-close failure must never
+                                # mask the real error being raised. Logged so it stays
+                                # diagnosable instead of vanishing.
+                                logger.debug(
+                                    f"Ignoring cursor close failure: {close_error}"
+                                )
                             raise
 
                         result_data["data"] = serialize_rows(
@@ -354,8 +359,11 @@ class BigQueryDriver(DatabaseDriver):
                 finally:
                     try:
                         result.close()
-                    except Exception:
-                        pass
+                    except Exception as close_error:
+                        # Swallowed on purpose: a cursor-close failure must never
+                        # mask the real error being raised. Logged so it stays
+                        # diagnosable instead of vanishing.
+                        logger.debug(f"Ignoring cursor close failure: {close_error}")
 
                 end_time = time_mod.time()
                 result_data["execution_time_ms"] = round(

--- a/src/drivers/clickhouse.py
+++ b/src/drivers/clickhouse.py
@@ -407,8 +407,13 @@ class ClickHouseDriver(DatabaseDriver):
                             logger.error(f"Error fetching results: {fetch_error}")
                             try:
                                 result.close()
-                            except Exception:
-                                pass
+                            except Exception as close_error:
+                                # Swallowed on purpose: a cursor-close failure must never
+                                # mask the real error being raised. Logged so it stays
+                                # diagnosable instead of vanishing.
+                                logger.debug(
+                                    f"Ignoring cursor close failure: {close_error}"
+                                )
                             raise
 
                         result_data["data"] = serialize_rows(
@@ -420,8 +425,11 @@ class ClickHouseDriver(DatabaseDriver):
                 finally:
                     try:
                         result.close()
-                    except Exception:
-                        pass
+                    except Exception as close_error:
+                        # Swallowed on purpose: a cursor-close failure must never
+                        # mask the real error being raised. Logged so it stays
+                        # diagnosable instead of vanishing.
+                        logger.debug(f"Ignoring cursor close failure: {close_error}")
 
                 end_time = time_mod.time()
                 result_data["execution_time_ms"] = round(

--- a/src/drivers/databricks.py
+++ b/src/drivers/databricks.py
@@ -429,8 +429,13 @@ class DatabricksDriver(DatabaseDriver):
                             logger.error(f"Error fetching results: {fetch_error}")
                             try:
                                 result.close()
-                            except Exception:
-                                pass
+                            except Exception as close_error:
+                                # Swallowed on purpose: a cursor-close failure must never
+                                # mask the real error being raised. Logged so it stays
+                                # diagnosable instead of vanishing.
+                                logger.debug(
+                                    f"Ignoring cursor close failure: {close_error}"
+                                )
                             raise
 
                         result_data["data"] = serialize_rows(
@@ -442,8 +447,11 @@ class DatabricksDriver(DatabaseDriver):
                 finally:
                     try:
                         result.close()
-                    except Exception:
-                        pass
+                    except Exception as close_error:
+                        # Swallowed on purpose: a cursor-close failure must never
+                        # mask the real error being raised. Logged so it stays
+                        # diagnosable instead of vanishing.
+                        logger.debug(f"Ignoring cursor close failure: {close_error}")
 
                 end_time = time_mod.time()
                 result_data["execution_time_ms"] = round(

--- a/src/drivers/duckdb.py
+++ b/src/drivers/duckdb.py
@@ -369,8 +369,13 @@ class DuckDBDriver(DatabaseDriver):
                             logger.error(f"Error fetching results: {fetch_error}")
                             try:
                                 result.close()
-                            except Exception:
-                                pass
+                            except Exception as close_error:
+                                # Swallowed on purpose: a cursor-close failure must never
+                                # mask the real error being raised. Logged so it stays
+                                # diagnosable instead of vanishing.
+                                logger.debug(
+                                    f"Ignoring cursor close failure: {close_error}"
+                                )
                             raise
 
                         result_data["data"] = serialize_rows(
@@ -382,8 +387,11 @@ class DuckDBDriver(DatabaseDriver):
                 finally:
                     try:
                         result.close()
-                    except Exception:
-                        pass
+                    except Exception as close_error:
+                        # Swallowed on purpose: a cursor-close failure must never
+                        # mask the real error being raised. Logged so it stays
+                        # diagnosable instead of vanishing.
+                        logger.debug(f"Ignoring cursor close failure: {close_error}")
 
                 end_time = time_mod.time()
                 result_data["execution_time_ms"] = round(

--- a/src/drivers/mysql.py
+++ b/src/drivers/mysql.py
@@ -370,8 +370,13 @@ class MySQLDriver(DatabaseDriver):
                             logger.error(f"Error fetching results: {fetch_error}")
                             try:
                                 result.close()
-                            except Exception:
-                                pass
+                            except Exception as close_error:
+                                # Swallowed on purpose: a cursor-close failure must never
+                                # mask the real error being raised. Logged so it stays
+                                # diagnosable instead of vanishing.
+                                logger.debug(
+                                    f"Ignoring cursor close failure: {close_error}"
+                                )
                             raise
 
                         result_data["data"] = serialize_rows(
@@ -383,8 +388,11 @@ class MySQLDriver(DatabaseDriver):
                 finally:
                     try:
                         result.close()
-                    except Exception:
-                        pass
+                    except Exception as close_error:
+                        # Swallowed on purpose: a cursor-close failure must never
+                        # mask the real error being raised. Logged so it stays
+                        # diagnosable instead of vanishing.
+                        logger.debug(f"Ignoring cursor close failure: {close_error}")
 
                 end_time = time_mod.time()
                 result_data["execution_time_ms"] = round(

--- a/src/drivers/postgresql.py
+++ b/src/drivers/postgresql.py
@@ -372,8 +372,13 @@ class PostgreSQLDriver(DatabaseDriver):
                             logger.error(f"Error fetching results: {fetch_error}")
                             try:
                                 result.close()
-                            except Exception:
-                                pass
+                            except Exception as close_error:
+                                # Swallowed on purpose: a cursor-close failure must never
+                                # mask the real error being raised. Logged so it stays
+                                # diagnosable instead of vanishing.
+                                logger.debug(
+                                    f"Ignoring cursor close failure: {close_error}"
+                                )
                             raise
 
                         result_data["data"] = serialize_rows(
@@ -385,8 +390,11 @@ class PostgreSQLDriver(DatabaseDriver):
                 finally:
                     try:
                         result.close()
-                    except Exception:
-                        pass
+                    except Exception as close_error:
+                        # Swallowed on purpose: a cursor-close failure must never
+                        # mask the real error being raised. Logged so it stays
+                        # diagnosable instead of vanishing.
+                        logger.debug(f"Ignoring cursor close failure: {close_error}")
 
                 end_time = time_mod.time()
                 result_data["execution_time_ms"] = round(

--- a/src/drivers/snowflake.py
+++ b/src/drivers/snowflake.py
@@ -647,8 +647,13 @@ class SnowflakeDriver(DatabaseDriver):
                             logger.error(f"Error fetching results: {fetch_error}")
                             try:
                                 result.close()
-                            except Exception:
-                                pass
+                            except Exception as close_error:
+                                # Swallowed on purpose: a cursor-close failure must never
+                                # mask the real error being raised. Logged so it stays
+                                # diagnosable instead of vanishing.
+                                logger.debug(
+                                    f"Ignoring cursor close failure: {close_error}"
+                                )
                             raise
 
                         result_data["data"] = serialize_rows(
@@ -660,8 +665,11 @@ class SnowflakeDriver(DatabaseDriver):
                 finally:
                     try:
                         result.close()
-                    except Exception:
-                        pass
+                    except Exception as close_error:
+                        # Swallowed on purpose: a cursor-close failure must never
+                        # mask the real error being raised. Logged so it stays
+                        # diagnosable instead of vanishing.
+                        logger.debug(f"Ignoring cursor close failure: {close_error}")
 
                 end_time = time_mod.time()
                 result_data["execution_time_ms"] = round(

--- a/src/graphrag/retriever.py
+++ b/src/graphrag/retriever.py
@@ -5,6 +5,7 @@ Provides intelligent schema navigation using the graph structure
 of foreign key relationships and semantic similarity.
 """
 
+import contextlib
 import logging
 from collections import defaultdict, deque
 from collections.abc import Callable
@@ -138,19 +139,15 @@ class GraphRetriever:
             path_backward = None
             path_undirected = None
 
-            try:
+            with contextlib.suppress(nx.NetworkXNoPath):
                 path_forward = nx.shortest_path(
                     self.graph, source=from_table, target=to_table
                 )
-            except nx.NetworkXNoPath:
-                pass
 
-            try:
+            with contextlib.suppress(nx.NetworkXNoPath):
                 path_backward = nx.shortest_path(
                     self.graph, source=to_table, target=from_table
                 )
-            except nx.NetworkXNoPath:
-                pass
 
             # Try undirected view for mixed-direction paths
             try:

--- a/src/graphrag/vector_store_chromadb.py
+++ b/src/graphrag/vector_store_chromadb.py
@@ -569,7 +569,14 @@ class ChromaDBVectorStore:
                     where={"element_type": element_type}, include=[]
                 )
                 type_counts[element_type] = len(results["ids"])
-        except Exception:
+        except Exception as exc:
+            # Report zeros rather than failing the whole stats call, but say so
+            # -- a silent all-zero breakdown reads as "empty store".
+            logger.warning(
+                "ChromaDB type-distribution query failed (%s): %s; reporting zeros",
+                type(exc).__name__,
+                exc,
+            )
             type_counts = {"table": 0, "column": 0, "relationship": 0}
 
         return {

--- a/src/handlers/chart.py
+++ b/src/handlers/chart.py
@@ -1,5 +1,6 @@
 """Chart generation handler implementation."""
 
+import asyncio
 import logging
 from typing import Any, cast
 from uuid import uuid4
@@ -160,8 +161,12 @@ async def generate_chart(
                     format="png", width=PNG_WIDTH, height=PNG_HEIGHT
                 )
                 connection_id = services.get_session_data(ctx).connection_id
-                image_file_path = save_image_to_tmp(
-                    image_bytes, image_id, "png", connection_id=connection_id
+                image_file_path = await asyncio.to_thread(
+                    save_image_to_tmp,
+                    image_bytes,
+                    image_id,
+                    "png",
+                    connection_id=connection_id,
                 )
                 if image_file_path:
                     file_uri = f"\nStatic image: file://{image_file_path}"
@@ -191,7 +196,8 @@ async def generate_chart(
 
         connection_id = services.get_session_data(ctx).connection_id
 
-        image_file_path = save_image_to_tmp(
+        image_file_path = await asyncio.to_thread(
+            save_image_to_tmp,
             image_bytes,
             image_id,
             "png",

--- a/src/handlers/connection.py
+++ b/src/handlers/connection.py
@@ -9,7 +9,7 @@ from fastmcp import Context
 from ..constants import SUPPORTED_DB_TYPES
 from ..exceptions import ConnectionError, ValidationError
 from ..handler_context import HandlerContext
-from ..lifecycle.metadata import VersionMetadataManager
+from ..lifecycle.metadata import mutate_workspace_metadata
 from ..paths import OUTPUT_DIR
 from ..utils import utc_now
 from ..workspace import detect_workspace, format_workspace_summary
@@ -320,8 +320,13 @@ async def connect_database(
 
         # Write workspace connection info
         try:
-            mgr = VersionMetadataManager(new_conn_id, OUTPUT_DIR)
-            mgr.update_workspace_connection(db_type=db_type, db_name=db_name)
+            await mutate_workspace_metadata(
+                new_conn_id,
+                OUTPUT_DIR,
+                lambda mgr: mgr.update_workspace_connection(
+                    db_type=db_type, db_name=db_name
+                ),
+            )
         except Exception as e:
             logger.warning(f"Failed to write workspace connection info: {e}")
 

--- a/src/handlers/connection.py
+++ b/src/handlers/connection.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-from datetime import datetime
 from typing import cast
 
 from fastmcp import Context
@@ -12,6 +11,7 @@ from ..exceptions import ConnectionError, ValidationError
 from ..handler_context import HandlerContext
 from ..lifecycle.metadata import VersionMetadataManager
 from ..paths import OUTPUT_DIR
+from ..utils import utc_now
 from ..workspace import detect_workspace, format_workspace_summary
 from .workspace import _format_restore_summary, _restore_workspace_core
 
@@ -313,7 +313,7 @@ async def connect_database(
             logger.info(f"Initial connection established: {new_conn_id[:8]}...")
 
         session.connection_id = new_conn_id
-        session.connected_at = datetime.now()
+        session.connected_at = utc_now()
         session.clear_schema_cache()
 
         await ctx.info(f"Connected to {db_type}: {db_name}")

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import time
-from datetime import datetime
 from typing import Any, cast
 
 from fastmcp import Context
@@ -15,6 +14,7 @@ from ..lifecycle.metadata import update_workspace_section
 from ..ontology_generator import OntologyGenerator
 from ..oxigraph_store import OXIGRAPH_AVAILABLE
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
+from ..utils import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +80,7 @@ async def _auto_generate_ontology_background(
             else ensure_output_dir()
         )
 
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        timestamp = utc_now().strftime("%Y%m%d_%H%M%S")
         ontology_file = conn_dir / f"ontology_{schema_name}_{timestamp}.ttl"
         ontology_file.write_text(ontology_ttl, encoding="utf-8")
 
@@ -173,7 +173,7 @@ async def _auto_initialize_graphrag_background(
                         "table_count": len(tables_dict),
                         "embedding_count": stats.get("total_elements", 0),
                         "schemas": schemas,
-                        "initialized_at": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+                        "initialized_at": utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
                     },
                 )
             except Exception as e:
@@ -309,7 +309,7 @@ async def initialize_graphrag(
                         "table_count": len(tables_dict),
                         "embedding_count": stats.get("total_elements", 0),
                         "schemas": schemas,
-                        "initialized_at": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+                        "initialized_at": utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
                     },
                 )
             except Exception as e:

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -11,6 +11,7 @@ from fastmcp import Context
 from ..exceptions import ConnectionError
 from ..graphrag import GraphRAGManager
 from ..handler_context import HandlerContext
+from ..lifecycle.artifacts import prune_superseded_artifacts
 from ..lifecycle.metadata import update_workspace_section
 from ..ontology_generator import OntologyGenerator
 from ..oxigraph_store import OXIGRAPH_AVAILABLE
@@ -84,6 +85,7 @@ async def _auto_generate_ontology_background(
         timestamp = utc_now().strftime("%Y%m%d_%H%M%S")
         ontology_file = conn_dir / f"ontology_{schema_name}_{timestamp}.ttl"
         await write_text_file(ontology_file, ontology_ttl)
+        await prune_superseded_artifacts(ontology_file)
 
         # Write to the specific schema's state (not current schema)
         schema_state = session.get_or_create_schema_state(schema_name)

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -1,5 +1,6 @@
 """GraphRAG initialization and search handler implementations."""
 
+import asyncio
 import logging
 import os
 import time
@@ -14,7 +15,7 @@ from ..lifecycle.metadata import update_workspace_section
 from ..ontology_generator import OntologyGenerator
 from ..oxigraph_store import OXIGRAPH_AVAILABLE
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
-from ..utils import utc_now
+from ..utils import utc_now, write_text_file
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +83,7 @@ async def _auto_generate_ontology_background(
 
         timestamp = utc_now().strftime("%Y%m%d_%H%M%S")
         ontology_file = conn_dir / f"ontology_{schema_name}_{timestamp}.ttl"
-        ontology_file.write_text(ontology_ttl, encoding="utf-8")
+        await write_text_file(ontology_file, ontology_ttl)
 
         # Write to the specific schema's state (not current schema)
         schema_state = session.get_or_create_schema_state(schema_name)
@@ -147,7 +148,7 @@ async def _auto_initialize_graphrag_background(
             )
 
         output_dir = ensure_output_dir()
-        session.graphrag_manager.save_state(output_dir)
+        await asyncio.to_thread(session.graphrag_manager.save_state, output_dir)
 
         elapsed = time.time() - start_time
         session.graphrag_initialized = True
@@ -173,7 +174,7 @@ async def _auto_initialize_graphrag_background(
                         "table_count": len(tables_dict),
                         "embedding_count": stats.get("total_elements", 0),
                         "schemas": schemas,
-                        "initialized_at": utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
+                        "initialized_at": utc_now().isoformat(),
                     },
                 )
             except Exception as e:
@@ -289,7 +290,7 @@ async def initialize_graphrag(
         session.graphrag_initialized = True
 
         output_dir = ensure_output_dir()
-        session.graphrag_manager.save_state(output_dir)
+        await asyncio.to_thread(session.graphrag_manager.save_state, output_dir)
 
         total_tables = session.graphrag_manager.graph_retriever.graph.number_of_nodes()
         schemas = session.graphrag_manager._schema_names
@@ -308,7 +309,7 @@ async def initialize_graphrag(
                         "table_count": len(tables_dict),
                         "embedding_count": stats.get("total_elements", 0),
                         "schemas": schemas,
-                        "initialized_at": utc_now().strftime("%Y-%m-%dT%H:%M:%S"),
+                        "initialized_at": utc_now().isoformat(),
                     },
                 )
             except Exception as e:

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -11,7 +11,7 @@ from fastmcp import Context
 from ..exceptions import ConnectionError
 from ..graphrag import GraphRAGManager
 from ..handler_context import HandlerContext
-from ..lifecycle.artifacts import prune_superseded_artifacts
+from ..lifecycle.artifacts import artifact_family_lock, prune_superseded_artifacts
 from ..lifecycle.metadata import update_workspace_section
 from ..ontology_generator import OntologyGenerator
 from ..oxigraph_store import OXIGRAPH_AVAILABLE
@@ -83,39 +83,42 @@ async def _auto_generate_ontology_background(
         )
 
         timestamp = utc_now().strftime("%Y%m%d_%H%M%S")
-        ontology_file = conn_dir / f"ontology_{schema_name}_{timestamp}.ttl"
-        await write_text_file(ontology_file, ontology_ttl)
+        # Serialize produce -> record -> prune for this family; a concurrent
+        # generation for the same schema must not have its file pruned as stale.
+        async with artifact_family_lock(conn_dir, f"ontology_{schema_name}"):
+            ontology_file = conn_dir / f"ontology_{schema_name}_{timestamp}.ttl"
+            await write_text_file(ontology_file, ontology_ttl)
 
-        # Write to the specific schema's state (not current schema)
-        schema_state = session.get_or_create_schema_state(schema_name)
-        previous_ontology_file = schema_state.ontology.ontology_file
-        schema_state.ontology.ontology_file = ontology_file.name
+            # Write to the specific schema's state (not current schema)
+            schema_state = session.get_or_create_schema_state(schema_name)
+            previous_ontology_file = schema_state.ontology.ontology_file
+            schema_state.ontology.ontology_file = ontology_file.name
 
-        if OXIGRAPH_AVAILABLE:
-            try:
-                # Direct store access for background task (connection-scoped)
-                if session.oxigraph_store:
-                    graph_uri = f"{base_uri}{schema_name}"
-                    triple_count = session.oxigraph_store.load_ontology(
-                        ontology_ttl, graph_uri, schema_name
-                    )
-                    logger.info(
-                        f"Stored {triple_count} triples in RDF store (graph: {graph_uri})"
-                    )
-            except Exception as e:
-                logger.warning(f"Failed to store in RDF: {e}")
+            if OXIGRAPH_AVAILABLE:
+                try:
+                    # Direct store access for background task (connection-scoped)
+                    if session.oxigraph_store:
+                        graph_uri = f"{base_uri}{schema_name}"
+                        triple_count = session.oxigraph_store.load_ontology(
+                            ontology_ttl, graph_uri, schema_name
+                        )
+                        logger.info(
+                            f"Stored {triple_count} triples in RDF store (graph: {graph_uri})"
+                        )
+                except Exception as e:
+                    logger.warning(f"Failed to store in RDF: {e}")
 
-        elapsed = time.time() - start_time
-        logger.info(f"Ontology auto-generated successfully ({elapsed:.2f}s)")
-        logger.info(f"Saved to: {ontology_file.name}")
+            elapsed = time.time() - start_time
+            logger.info(f"Ontology auto-generated successfully ({elapsed:.2f}s)")
+            logger.info(f"Saved to: {ontology_file.name}")
 
-        # Pruned last, and never touching what the session previously pointed
-        # at: this path writes no persisted metadata, so the in-memory
-        # reference is the only record that the older file is still in use.
-        await prune_superseded_artifacts(
-            ontology_file,
-            protect=[previous_ontology_file] if previous_ontology_file else [],
-        )
+            # Pruned last, and never touching what the session previously
+            # pointed at: this path writes no persisted metadata, so the
+            # in-memory reference is the only record the older file is in use.
+            await prune_superseded_artifacts(
+                ontology_file,
+                protect=[previous_ontology_file] if previous_ontology_file else [],
+            )
 
     except Exception as e:
         logger.error(f"Ontology auto-generation failed: {type(e).__name__}: {e}")

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -191,9 +191,8 @@ async def _auto_initialize_graphrag_background(
             )
 
     except Exception as e:
-        logger.error(
+        logger.exception(
             f"GraphRAG auto-initialization failed: {type(e).__name__}: {e}",
-            exc_info=True,
         )
         session.graphrag_initialized = False
 
@@ -335,7 +334,7 @@ async def initialize_graphrag(
         )
 
     except Exception as e:
-        logger.error(f"GraphRAG initialization failed: {e}", exc_info=True)
+        logger.exception(f"GraphRAG initialization failed: {e}")
         return cast(
             str,
             services.create_error_response(
@@ -376,7 +375,7 @@ async def graphrag_search(
         }
 
     except Exception as e:
-        logger.error(f"GraphRAG search failed: {e}", exc_info=True)
+        logger.exception(f"GraphRAG search failed: {e}")
         err = services.create_error_response(
             f"GraphRAG search failed: {e!s}", "graphrag_error"
         )
@@ -422,7 +421,7 @@ async def graphrag_query_context(
         }
 
     except Exception as e:
-        logger.error(f"GraphRAG query context failed: {e}", exc_info=True)
+        logger.exception(f"GraphRAG query context failed: {e}")
         err = services.create_error_response(
             f"GraphRAG query context failed: {e!s}", "graphrag_error"
         )
@@ -478,7 +477,7 @@ async def graphrag_find_join_path(
         }
 
     except Exception as e:
-        logger.error(f"GraphRAG find join path failed: {e}", exc_info=True)
+        logger.exception(f"GraphRAG find join path failed: {e}")
         err = services.create_error_response(
             f"GraphRAG find join path failed: {e!s}", "graphrag_error"
         )
@@ -529,7 +528,7 @@ async def reachable_from(
         }
 
     except Exception as e:
-        logger.error(f"reachable_from failed: {e}", exc_info=True)
+        logger.exception(f"reachable_from failed: {e}")
         err = services.create_error_response(
             f"reachable_from failed: {e!s}", "graphrag_error"
         )
@@ -580,7 +579,7 @@ async def measurable_from(
         }
 
     except Exception as e:
-        logger.error(f"measurable_from failed: {e}", exc_info=True)
+        logger.exception(f"measurable_from failed: {e}")
         err = services.create_error_response(
             f"measurable_from failed: {e!s}", "graphrag_error"
         )
@@ -728,7 +727,7 @@ async def graphrag_overview(
         return {"success": True, "overview": overview}
 
     except Exception as e:
-        logger.error(f"GraphRAG overview failed: {e}", exc_info=True)
+        logger.exception(f"GraphRAG overview failed: {e}")
         err = services.create_error_response(
             f"GraphRAG overview failed: {e!s}", "graphrag_error"
         )

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -85,10 +85,10 @@ async def _auto_generate_ontology_background(
         timestamp = utc_now().strftime("%Y%m%d_%H%M%S")
         ontology_file = conn_dir / f"ontology_{schema_name}_{timestamp}.ttl"
         await write_text_file(ontology_file, ontology_ttl)
-        await prune_superseded_artifacts(ontology_file)
 
         # Write to the specific schema's state (not current schema)
         schema_state = session.get_or_create_schema_state(schema_name)
+        previous_ontology_file = schema_state.ontology.ontology_file
         schema_state.ontology.ontology_file = ontology_file.name
 
         if OXIGRAPH_AVAILABLE:
@@ -108,6 +108,14 @@ async def _auto_generate_ontology_background(
         elapsed = time.time() - start_time
         logger.info(f"Ontology auto-generated successfully ({elapsed:.2f}s)")
         logger.info(f"Saved to: {ontology_file.name}")
+
+        # Pruned last, and never touching what the session previously pointed
+        # at: this path writes no persisted metadata, so the in-memory
+        # reference is the only record that the older file is still in use.
+        await prune_superseded_artifacts(
+            ontology_file,
+            protect=[previous_ontology_file] if previous_ontology_file else [],
+        )
 
     except Exception as e:
         logger.error(f"Ontology auto-generation failed: {type(e).__name__}: {e}")

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -74,7 +74,9 @@ async def _auto_generate_ontology_background(
         base_uri = config.ontology_base_uri
 
         ontology_generator = OntologyGenerator(base_uri=base_uri)
-        ontology_ttl = ontology_generator.generate_from_schema(tables_info)
+        ontology_ttl = await asyncio.to_thread(
+            ontology_generator.generate_from_schema, tables_info
+        )
 
         conn_dir = (
             get_connection_dir(session.connection_id)

--- a/src/handlers/ontology_artifacts.py
+++ b/src/handlers/ontology_artifacts.py
@@ -9,6 +9,7 @@ from fastmcp import Context
 from ..handler_context import HandlerContext
 from ..oxigraph_store import OXIGRAPH_AVAILABLE, schema_graph_uri
 from ..paths import ensure_output_dir, get_connection_dir
+from ..utils import read_text_file, write_text_file
 
 logger = logging.getLogger(__name__)
 
@@ -66,8 +67,7 @@ async def download_ontology(
                 file_name = f"ontology_{schema_safe}_export.ttl"
                 file_path = conn_dir / file_name
 
-                with open(file_path, "w", encoding="utf-8") as f:
-                    f.write(ontology_ttl)
+                await write_text_file(file_path, ontology_ttl)
 
                 triple_count = len(
                     [
@@ -134,8 +134,7 @@ async def download_ontology(
                     "error_type": "file_not_found",
                 }
 
-            with open(ontology_file_path, encoding="utf-8") as f:
-                ontology_ttl = f.read()
+            ontology_ttl = await read_text_file(ontology_file_path)
 
             file_stat = ontology_file_path.stat()
             logger.info(f"Read ontology from file: {ontology_file_path}")
@@ -220,8 +219,7 @@ async def download_r2rml(
                 "hint": "Run discover_schema() to generate R2RML mapping",
             }
 
-        with open(r2rml_file_path, encoding="utf-8") as f:
-            r2rml_content = f.read()
+        r2rml_content = await read_text_file(r2rml_file_path)
 
         file_stat = r2rml_file_path.stat()
 

--- a/src/handlers/ontology_generation.py
+++ b/src/handlers/ontology_generation.py
@@ -283,13 +283,13 @@ async def generate_ontology(
         ontology_file_path = conn_dir / ontology_filename
 
         await write_text_file(ontology_file_path, ontology_ttl)
-        await prune_superseded_artifacts(ontology_file_path)
 
         logger.info(
             f"Generated ontology for schema '{schema_name or 'default'}': {len(tables_info)} tables"
         )
         logger.info(f"Saved ontology to: {ontology_file_path}")
 
+        previous_ontology_file = session.ontology_file
         session.ontology_file = ontology_filename
         session.obqc_validator = None
 
@@ -311,6 +311,14 @@ async def generate_ontology(
                 )
             except Exception as e:
                 logger.warning(f"Failed to write workspace metadata: {e}")
+
+        # Prune only once metadata durably names the new file; the previously
+        # referenced one is protected so a failed metadata write cannot leave
+        # restore chasing a deleted artifact.
+        await prune_superseded_artifacts(
+            ontology_file_path,
+            protect=[previous_ontology_file] if previous_ontology_file else [],
+        )
 
         await ctx.info(
             "Ontology generation complete; next call should be suggest_semantic_names to improve cryptic names"

--- a/src/handlers/ontology_generation.py
+++ b/src/handlers/ontology_generation.py
@@ -10,7 +10,7 @@ from fastmcp import Context
 
 from ..database_manager import ColumnInfo, TableInfo
 from ..handler_context import HandlerContext
-from ..lifecycle.artifacts import prune_superseded_artifacts
+from ..lifecycle.artifacts import artifact_family_lock, prune_superseded_artifacts
 from ..lifecycle.metadata import update_workspace_rdf, update_workspace_section
 from ..oxigraph_store import OXIGRAPH_AVAILABLE, schema_graph_uri
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
@@ -277,48 +277,57 @@ async def generate_ontology(
         )
 
         schema_safe = (schema_name or "default").replace(" ", "_").replace(".", "_")
-        ontology_filename = (
-            services.get_session_safe_filename(ctx, "ontology", schema_safe) + ".ttl"
-        )
-        ontology_file_path = conn_dir / ontology_filename
 
-        await write_text_file(ontology_file_path, ontology_ttl)
+        # Serialize the whole produce -> record -> prune sequence for this
+        # family. Two overlapping generate_ontology calls for one schema would
+        # otherwise each write a file, and the loser's prune would delete the
+        # winner's just-written artifact.
+        async with artifact_family_lock(
+            conn_dir, f"ontology_{session.connection_id or 'default'}_{schema_safe}"
+        ):
+            ontology_filename = (
+                services.get_session_safe_filename(ctx, "ontology", schema_safe)
+                + ".ttl"
+            )
+            ontology_file_path = conn_dir / ontology_filename
 
-        logger.info(
-            f"Generated ontology for schema '{schema_name or 'default'}': {len(tables_info)} tables"
-        )
-        logger.info(f"Saved ontology to: {ontology_file_path}")
+            await write_text_file(ontology_file_path, ontology_ttl)
 
-        previous_ontology_file = session.ontology_file
-        session.ontology_file = ontology_filename
-        session.obqc_validator = None
+            logger.info(
+                f"Generated ontology for schema '{schema_name or 'default'}': {len(tables_info)} tables"
+            )
+            logger.info(f"Saved ontology to: {ontology_file_path}")
 
-        # Write workspace metadata for ontology section
-        if session.connection_id:
-            try:
-                await update_workspace_section(
-                    connection_id=session.connection_id,
-                    output_dir=OUTPUT_DIR,
-                    schema_name=schema_name or "default",
-                    section="ontology",
-                    data={
-                        "ontology_file": ontology_filename,
-                        "enriched": False,
-                        "graph_uri": graph_uri,
-                        "persisted_to_rdf": False,
-                        "generated_at": utc_now().isoformat(),
-                    },
-                )
-            except Exception as e:
-                logger.warning(f"Failed to write workspace metadata: {e}")
+            previous_ontology_file = session.ontology_file
+            session.ontology_file = ontology_filename
+            session.obqc_validator = None
 
-        # Prune only once metadata durably names the new file; the previously
-        # referenced one is protected so a failed metadata write cannot leave
-        # restore chasing a deleted artifact.
-        await prune_superseded_artifacts(
-            ontology_file_path,
-            protect=[previous_ontology_file] if previous_ontology_file else [],
-        )
+            # Write workspace metadata for ontology section
+            if session.connection_id:
+                try:
+                    await update_workspace_section(
+                        connection_id=session.connection_id,
+                        output_dir=OUTPUT_DIR,
+                        schema_name=schema_name or "default",
+                        section="ontology",
+                        data={
+                            "ontology_file": ontology_filename,
+                            "enriched": False,
+                            "graph_uri": graph_uri,
+                            "persisted_to_rdf": False,
+                            "generated_at": utc_now().isoformat(),
+                        },
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to write workspace metadata: {e}")
+
+            # Prune only once metadata durably names the new file; the previously
+            # referenced one is protected so a failed metadata write cannot leave
+            # restore chasing a deleted artifact.
+            await prune_superseded_artifacts(
+                ontology_file_path,
+                protect=[previous_ontology_file] if previous_ontology_file else [],
+            )
 
         await ctx.info(
             "Ontology generation complete; next call should be suggest_semantic_names to improve cryptic names"

--- a/src/handlers/ontology_generation.py
+++ b/src/handlers/ontology_generation.py
@@ -13,6 +13,7 @@ from ..handler_context import HandlerContext
 from ..lifecycle.artifacts import artifact_family_lock, prune_superseded_artifacts
 from ..lifecycle.metadata import (
     mark_ontology_persisted,
+    ontology_is_current,
     update_workspace_rdf,
     update_workspace_section,
 )
@@ -354,7 +355,17 @@ async def generate_ontology(
             + name_analysis["summary"]["relationships_needing_review"]
         )
 
-        # Auto-persist to RDF store
+        # Auto-persist to RDF store.
+        #
+        # Serialized per schema and gated on still being the current
+        # generation, because load_ontology() *replaces* the named graph: a
+        # stale request that reached this point would overwrite a newer
+        # generation's triples. Guarding only the metadata flag left the flag
+        # honest while the graph held the wrong ontology.
+        #
+        # The lock is taken here rather than extending the artifact family lock
+        # over the whole handler: the Oxigraph load is the expensive part and
+        # only conflicts with other loads into the same schema graph.
         if auto_persist and OXIGRAPH_AVAILABLE:
             try:
                 store = services.get_oxigraph_store(ctx)
@@ -362,23 +373,43 @@ async def generate_ontology(
                     if not graph_uri:
                         graph_uri = schema_graph_uri(schema_name or "default")
 
-                    triple_count = store.load_ontology(
-                        ontology_ttl, graph_uri, schema_name or "default"
-                    )
-                    logger.info(
-                        f"Auto-persisted ontology to Oxigraph: {triple_count} triples in graph <{graph_uri}>"
-                    )
+                    persist_schema = schema_name or "default"
+                    async with artifact_family_lock(
+                        conn_dir,
+                        f"rdf_{session.connection_id or 'default'}"
+                        f"_{persist_schema}",
+                    ):
+                        still_current = not session.connection_id or (
+                            await ontology_is_current(
+                                session.connection_id,
+                                OUTPUT_DIR,
+                                persist_schema,
+                                ontology_filename,
+                            )
+                        )
+                        if still_current:
+                            triple_count = await asyncio.to_thread(
+                                store.load_ontology,
+                                ontology_ttl,
+                                graph_uri,
+                                persist_schema,
+                            )
+                            logger.info(
+                                f"Auto-persisted ontology to Oxigraph: "
+                                f"{triple_count} triples in graph <{graph_uri}>"
+                            )
+                        else:
+                            logger.info(
+                                "Skipped RDF auto-persist: a newer ontology "
+                                f"generation superseded {ontology_filename}"
+                            )
 
                     # Update workspace: mark ontology as persisted + write rdf_store
-                    if session.connection_id:
+                    if still_current and session.connection_id:
                         try:
-                            # Generation-guarded: this runs outside the
-                            # artifact family lock, so a concurrent generation
-                            # may already have recorded a newer TTL. Marking
-                            # that one persisted on the strength of *this*
-                            # request's RDF load would be a lie, so the helper
-                            # sets the flag only while our file is still the
-                            # recorded one.
+                            # Re-checked inside the helper: the currency test
+                            # above happened before the load, and a newer
+                            # generation can land while it runs.
                             marked = await mark_ontology_persisted(
                                 connection_id=session.connection_id,
                                 output_dir=OUTPUT_DIR,

--- a/src/handlers/ontology_generation.py
+++ b/src/handlers/ontology_generation.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import os
-from datetime import datetime
 from typing import Any
 
 from fastmcp import Context
@@ -13,7 +12,7 @@ from ..handler_context import HandlerContext
 from ..lifecycle.metadata import update_workspace_rdf, update_workspace_section
 from ..oxigraph_store import OXIGRAPH_AVAILABLE, schema_graph_uri
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
-from ..utils import write_text_file
+from ..utils import utc_now, write_text_file
 
 logger = logging.getLogger(__name__)
 
@@ -304,7 +303,7 @@ async def generate_ontology(
                         "enriched": False,
                         "graph_uri": graph_uri,
                         "persisted_to_rdf": False,
-                        "generated_at": datetime.now().isoformat(),
+                        "generated_at": utc_now().isoformat(),
                     },
                 )
             except Exception as e:
@@ -355,7 +354,7 @@ async def generate_ontology(
                                     "enriched": False,
                                     "graph_uri": graph_uri,
                                     "persisted_to_rdf": True,
-                                    "generated_at": datetime.now().isoformat(),
+                                    "generated_at": utc_now().isoformat(),
                                 },
                             )
                             await update_workspace_rdf(
@@ -364,7 +363,7 @@ async def generate_ontology(
                                 data={
                                     "initialized": True,
                                     "graph_uris": [graph_uri],
-                                    "initialized_at": datetime.now().isoformat(),
+                                    "initialized_at": utc_now().isoformat(),
                                 },
                             )
                         except Exception as e:

--- a/src/handlers/ontology_generation.py
+++ b/src/handlers/ontology_generation.py
@@ -369,13 +369,16 @@ async def generate_ontology(
                                 output_dir=OUTPUT_DIR,
                                 schema_name=schema_name or "default",
                                 section="ontology",
+                                # Merge: this follow-up write only reports RDF
+                                # persistence. Replacing the section would
+                                # re-stamp ontology_file with this request's
+                                # name even if a concurrent generation has
+                                # already superseded it.
                                 data={
-                                    "ontology_file": ontology_filename,
-                                    "enriched": False,
                                     "graph_uri": graph_uri,
                                     "persisted_to_rdf": True,
-                                    "generated_at": utc_now().isoformat(),
                                 },
+                                merge=True,
                             )
                             await update_workspace_rdf(
                                 connection_id=session.connection_id,

--- a/src/handlers/ontology_generation.py
+++ b/src/handlers/ontology_generation.py
@@ -13,6 +13,7 @@ from ..handler_context import HandlerContext
 from ..lifecycle.metadata import update_workspace_rdf, update_workspace_section
 from ..oxigraph_store import OXIGRAPH_AVAILABLE, schema_graph_uri
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
+from ..utils import write_text_file
 
 logger = logging.getLogger(__name__)
 
@@ -280,8 +281,7 @@ async def generate_ontology(
         )
         ontology_file_path = conn_dir / ontology_filename
 
-        with open(ontology_file_path, "w", encoding="utf-8") as f:
-            f.write(ontology_ttl)
+        await write_text_file(ontology_file_path, ontology_ttl)
 
         logger.info(
             f"Generated ontology for schema '{schema_name or 'default'}': {len(tables_info)} tables"

--- a/src/handlers/ontology_generation.py
+++ b/src/handlers/ontology_generation.py
@@ -242,7 +242,9 @@ async def generate_ontology(
         return err
 
     generator = services.server_state.get_ontology_generator(base_uri=base_uri)
-    ontology_ttl = generator.generate_from_schema(tables_info)
+    # rdflib work is CPU-bound (~876 ms per 2.65 MB of Turtle); off the loop
+    # so it does not freeze every concurrent session.
+    ontology_ttl = await asyncio.to_thread(generator.generate_from_schema, tables_info)
 
     # Optional SHACL conformance check (Phase 4). Default on, gated by setting;
     # never hard-fails generation — surfaces violations as a warning only.
@@ -335,7 +337,9 @@ async def generate_ontology(
 
         # Analyze for cryptic names
         generator = services.server_state.get_ontology_generator(base_uri=base_uri)
-        generator.graph.parse(data=ontology_ttl, format="turtle")
+        await asyncio.to_thread(
+            generator.graph.parse, data=ontology_ttl, format="turtle"
+        )
         generator.graph.bind("ns", generator.base_uri)
         generator.graph.bind("oba", generator.oba_ns)
         name_analysis = generator.extract_names_for_review()
@@ -430,7 +434,7 @@ To improve ontology for business users:
         # Fallback: return minimal graph summary instead of full TTL
         result = f"Ontology generated and saved to file: {ontology_filename}\n"
         result += f"Schema: {schema_name or 'default'}, Tables: {len(tables_info)}\n"
-        result += _build_minimal_graph_summary(ontology_ttl)
+        result += await asyncio.to_thread(_build_minimal_graph_summary, ontology_ttl)
 
         if cryptic_count > 0:
             result += "\n\nSEMANTIC NAME RESOLUTION RECOMMENDED"
@@ -448,4 +452,4 @@ To improve ontology for business users:
         await ctx.info(
             "Ontology file save failed but ontology generated; next call should be suggest_semantic_names to improve cryptic names"
         )
-        return _build_minimal_graph_summary(ontology_ttl)
+        return await asyncio.to_thread(_build_minimal_graph_summary, ontology_ttl)

--- a/src/handlers/ontology_generation.py
+++ b/src/handlers/ontology_generation.py
@@ -10,6 +10,7 @@ from fastmcp import Context
 
 from ..database_manager import ColumnInfo, TableInfo
 from ..handler_context import HandlerContext
+from ..lifecycle.artifacts import prune_superseded_artifacts
 from ..lifecycle.metadata import update_workspace_rdf, update_workspace_section
 from ..oxigraph_store import OXIGRAPH_AVAILABLE, schema_graph_uri
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
@@ -282,6 +283,7 @@ async def generate_ontology(
         ontology_file_path = conn_dir / ontology_filename
 
         await write_text_file(ontology_file_path, ontology_ttl)
+        await prune_superseded_artifacts(ontology_file_path)
 
         logger.info(
             f"Generated ontology for schema '{schema_name or 'default'}': {len(tables_info)} tables"

--- a/src/handlers/ontology_generation.py
+++ b/src/handlers/ontology_generation.py
@@ -11,7 +11,11 @@ from fastmcp import Context
 from ..database_manager import ColumnInfo, TableInfo
 from ..handler_context import HandlerContext
 from ..lifecycle.artifacts import artifact_family_lock, prune_superseded_artifacts
-from ..lifecycle.metadata import update_workspace_rdf, update_workspace_section
+from ..lifecycle.metadata import (
+    mark_ontology_persisted,
+    update_workspace_rdf,
+    update_workspace_section,
+)
 from ..oxigraph_store import OXIGRAPH_AVAILABLE, schema_graph_uri
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
 from ..utils import utc_now, write_text_file
@@ -368,22 +372,26 @@ async def generate_ontology(
                     # Update workspace: mark ontology as persisted + write rdf_store
                     if session.connection_id:
                         try:
-                            await update_workspace_section(
+                            # Generation-guarded: this runs outside the
+                            # artifact family lock, so a concurrent generation
+                            # may already have recorded a newer TTL. Marking
+                            # that one persisted on the strength of *this*
+                            # request's RDF load would be a lie, so the helper
+                            # sets the flag only while our file is still the
+                            # recorded one.
+                            marked = await mark_ontology_persisted(
                                 connection_id=session.connection_id,
                                 output_dir=OUTPUT_DIR,
                                 schema_name=schema_name or "default",
-                                section="ontology",
-                                # Merge: this follow-up write only reports RDF
-                                # persistence. Replacing the section would
-                                # re-stamp ontology_file with this request's
-                                # name even if a concurrent generation has
-                                # already superseded it.
-                                data={
-                                    "graph_uri": graph_uri,
-                                    "persisted_to_rdf": True,
-                                },
-                                merge=True,
+                                ontology_file=ontology_filename,
+                                graph_uri=graph_uri,
                             )
+                            if not marked:
+                                logger.info(
+                                    "Skipped persisted_to_rdf flag: a newer "
+                                    "ontology generation superseded "
+                                    f"{ontology_filename}"
+                                )
                             await update_workspace_rdf(
                                 connection_id=session.connection_id,
                                 output_dir=OUTPUT_DIR,

--- a/src/handlers/ontology_generation.py
+++ b/src/handlers/ontology_generation.py
@@ -1,5 +1,6 @@
 """Ontology generation handler: build OWL/RDF from a database schema."""
 
+import asyncio
 import json
 import logging
 import os
@@ -248,7 +249,7 @@ async def generate_ontology(
         try:
             from ..shacl_validator import validate_ontology
 
-            shacl = validate_ontology(ontology_ttl)
+            shacl = await asyncio.to_thread(validate_ontology, ontology_ttl)
             if shacl["available"] and not shacl["conforms"]:
                 logger.warning(
                     "SHACL: generated ontology has %d violation(s):\n%s",

--- a/src/handlers/ontology_io.py
+++ b/src/handlers/ontology_io.py
@@ -3,7 +3,7 @@
 import logging
 import os
 from collections.abc import Callable
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -210,7 +210,7 @@ async def load_my_ontology(
         datatype_props = len(list(graph.subjects(RDF.type, OWL.DatatypeProperty)))
         object_props = len(list(graph.subjects(RDF.type, OWL.ObjectProperty)))
 
-        modified_time = datetime.fromtimestamp(file_stat.st_mtime).strftime(
+        modified_time = datetime.fromtimestamp(file_stat.st_mtime, tz=UTC).strftime(
             "%Y-%m-%d %H:%M:%S"
         )
 

--- a/src/handlers/ontology_io.py
+++ b/src/handlers/ontology_io.py
@@ -13,6 +13,7 @@ from ..constants import OBA_NAMESPACE
 from ..handler_context import HandlerContext
 from ..oxigraph_store import OXIGRAPH_AVAILABLE, schema_graph_uri
 from ..paths import PROJECT_ROOT
+from ..utils import read_text_file, write_text_file
 
 logger = logging.getLogger(__name__)
 
@@ -154,8 +155,7 @@ async def load_my_ontology(
 
             folder_path.mkdir(parents=True, exist_ok=True)
             saved_path = folder_path / effective_name
-            with open(saved_path, "w", encoding="utf-8") as f:
-                f.write(ontology_content)
+            await write_text_file(saved_path, ontology_content)
 
             newest_file = saved_path
             file_stat = saved_path.stat()
@@ -190,8 +190,7 @@ async def load_my_ontology(
             ttl_files.sort(key=lambda f: f.stat().st_mtime, reverse=True)
             newest_file = ttl_files[0]
 
-            with open(newest_file, encoding="utf-8") as f:
-                ontology_content = f.read()
+            ontology_content = await read_text_file(newest_file)
 
             file_stat = newest_file.stat()
 

--- a/src/handlers/ontology_io.py
+++ b/src/handlers/ontology_io.py
@@ -1,5 +1,6 @@
 """Ontology import/load handlers: load custom .ttl ontologies."""
 
+import asyncio
 import logging
 import os
 from collections.abc import Callable
@@ -196,7 +197,7 @@ async def load_my_ontology(
 
         graph = Graph()
         try:
-            graph.parse(data=ontology_content, format="turtle")
+            await asyncio.to_thread(graph.parse, data=ontology_content, format="turtle")
         except Exception as parse_error:
             return {
                 "success": False,

--- a/src/handlers/ontology_semantic.py
+++ b/src/handlers/ontology_semantic.py
@@ -1,5 +1,6 @@
 """Semantic-naming handlers: suggest and apply business-friendly names."""
 
+import asyncio
 import json
 import logging
 import re
@@ -295,7 +296,7 @@ async def suggest_semantic_names(
                         "hint": "Check the filename from generate_ontology response",
                     }
                 generator = OntologyGenerator()
-                generator.load_from_file(str(ontology_path))
+                await asyncio.to_thread(generator.load_from_file, str(ontology_path))
                 source_filename = ontology_file
                 logger.info(f"Loaded ontology from provided file: {ontology_file}")
             else:
@@ -430,7 +431,7 @@ async def apply_semantic_names(
                     )
                     return err
                 generator = OntologyGenerator()
-                generator.load_from_file(str(ontology_path))
+                await asyncio.to_thread(generator.load_from_file, str(ontology_path))
                 logger.info(f"Loaded ontology from provided file: {ontology_file}")
             else:
                 generator, _ = services.load_ontology_from_session(ctx)
@@ -461,7 +462,9 @@ async def apply_semantic_names(
             )
             return err
 
-        updated_ontology = generator.apply_semantic_names(name_suggestions)
+        updated_ontology = await asyncio.to_thread(
+            generator.apply_semantic_names, name_suggestions
+        )
 
         new_ontology_filename = None
         if save_to_file:
@@ -584,7 +587,9 @@ async def apply_semantic_names(
 
         if not persisted:
             # Without Oxigraph, return a minimal graph summary instead of full TTL
-            result += _build_minimal_graph_summary(updated_ontology)
+            result += await asyncio.to_thread(
+                _build_minimal_graph_summary, updated_ontology
+            )
 
         return result
 

--- a/src/handlers/ontology_semantic.py
+++ b/src/handlers/ontology_semantic.py
@@ -471,15 +471,32 @@ async def apply_semantic_names(
                     if session.connection_id
                     else ensure_output_dir()
                 )
+                # Scope the artifact family to the schema. Every other writer
+                # embeds schema_safe in the filename; this one used a bare
+                # "semantic" slot, so family_key() collapsed EVERY schema's
+                # enriched ontology into one connection-wide family and pruning
+                # deleted other schemas' files while metadata still named them.
+                enriched_schema = (
+                    session.current_schema
+                    or session.get_last_analyzed_schema()
+                    or "default"
+                )
+                enriched_schema_safe = enriched_schema.replace(" ", "_").replace(
+                    ".", "_"
+                )
+
                 # Serialize produce -> record -> prune for this family so an
                 # overlapping request cannot have its just-written ontology
                 # pruned as stale.
                 async with artifact_family_lock(
                     conn_dir,
-                    f"ontology_{session.connection_id or 'default'}_semantic",
+                    f"ontology_{session.connection_id or 'default'}"
+                    f"_{enriched_schema_safe}_semantic",
                 ):
                     new_ontology_filename = (
-                        services.get_session_safe_filename(ctx, "ontology", "semantic")
+                        services.get_session_safe_filename(
+                            ctx, "ontology", f"{enriched_schema_safe}_semantic"
+                        )
                         + ".ttl"
                     )
                     ontology_file_path = conn_dir / new_ontology_filename
@@ -495,9 +512,10 @@ async def apply_semantic_names(
                     # Update workspace: mark ontology as enriched
                     if session.connection_id:
                         try:
-                            schema_name = (
-                                session.get_last_analyzed_schema() or "default"
-                            )
+                            # Same schema the artifact family is scoped to --
+                            # these previously disagreed (current_schema here vs
+                            # get_last_analyzed_schema below).
+                            schema_name = enriched_schema
                             await update_workspace_section(
                                 connection_id=session.connection_id,
                                 output_dir=OUTPUT_DIR,

--- a/src/handlers/ontology_semantic.py
+++ b/src/handlers/ontology_semantic.py
@@ -9,7 +9,7 @@ from fastmcp import Context
 
 from ..config import config_manager
 from ..handler_context import HandlerContext
-from ..lifecycle.artifacts import prune_superseded_artifacts
+from ..lifecycle.artifacts import artifact_family_lock, prune_superseded_artifacts
 from ..lifecycle.metadata import update_workspace_section
 from ..ontology_generator import OntologyGenerator
 from ..oxigraph_store import OXIGRAPH_AVAILABLE, schema_graph_uri
@@ -471,47 +471,56 @@ async def apply_semantic_names(
                     if session.connection_id
                     else ensure_output_dir()
                 )
-                new_ontology_filename = (
-                    services.get_session_safe_filename(ctx, "ontology", "semantic")
-                    + ".ttl"
-                )
-                ontology_file_path = conn_dir / new_ontology_filename
+                # Serialize produce -> record -> prune for this family so an
+                # overlapping request cannot have its just-written ontology
+                # pruned as stale.
+                async with artifact_family_lock(
+                    conn_dir,
+                    f"ontology_{session.connection_id or 'default'}_semantic",
+                ):
+                    new_ontology_filename = (
+                        services.get_session_safe_filename(ctx, "ontology", "semantic")
+                        + ".ttl"
+                    )
+                    ontology_file_path = conn_dir / new_ontology_filename
 
-                await write_text_file(ontology_file_path, updated_ontology)
+                    await write_text_file(ontology_file_path, updated_ontology)
 
-                logger.info(f"Saved semantic ontology to: {ontology_file_path}")
-                previous_ontology_file = session.ontology_file
-                session.ontology_file = new_ontology_filename
-                session.ontology_enriched = True
-                session.obqc_validator = None
+                    logger.info(f"Saved semantic ontology to: {ontology_file_path}")
+                    previous_ontology_file = session.ontology_file
+                    session.ontology_file = new_ontology_filename
+                    session.ontology_enriched = True
+                    session.obqc_validator = None
 
-                # Update workspace: mark ontology as enriched
-                if session.connection_id:
-                    try:
-                        schema_name = session.get_last_analyzed_schema() or "default"
-                        await update_workspace_section(
-                            connection_id=session.connection_id,
-                            output_dir=OUTPUT_DIR,
-                            schema_name=schema_name,
-                            section="ontology",
-                            data={
-                                "ontology_file": new_ontology_filename,
-                                "enriched": True,
-                                "persisted_to_rdf": False,
-                                "generated_at": utc_now().isoformat(),
-                            },
-                        )
-                    except Exception as e:
-                        logger.warning(f"Failed to write workspace metadata: {e}")
+                    # Update workspace: mark ontology as enriched
+                    if session.connection_id:
+                        try:
+                            schema_name = (
+                                session.get_last_analyzed_schema() or "default"
+                            )
+                            await update_workspace_section(
+                                connection_id=session.connection_id,
+                                output_dir=OUTPUT_DIR,
+                                schema_name=schema_name,
+                                section="ontology",
+                                data={
+                                    "ontology_file": new_ontology_filename,
+                                    "enriched": True,
+                                    "persisted_to_rdf": False,
+                                    "generated_at": utc_now().isoformat(),
+                                },
+                            )
+                        except Exception as e:
+                            logger.warning(f"Failed to write workspace metadata: {e}")
 
-                # Prune only after metadata names the new file, protecting the
-                # one it referenced until now.
-                await prune_superseded_artifacts(
-                    ontology_file_path,
-                    protect=(
-                        [previous_ontology_file] if previous_ontology_file else []
-                    ),
-                )
+                    # Prune only after metadata names the new file, protecting the
+                    # one it referenced until now.
+                    await prune_superseded_artifacts(
+                        ontology_file_path,
+                        protect=(
+                            [previous_ontology_file] if previous_ontology_file else []
+                        ),
+                    )
             except Exception as e:
                 logger.warning(f"Failed to save ontology to file: {e}")
 

--- a/src/handlers/ontology_semantic.py
+++ b/src/handlers/ontology_semantic.py
@@ -478,9 +478,9 @@ async def apply_semantic_names(
                 ontology_file_path = conn_dir / new_ontology_filename
 
                 await write_text_file(ontology_file_path, updated_ontology)
-                await prune_superseded_artifacts(ontology_file_path)
 
                 logger.info(f"Saved semantic ontology to: {ontology_file_path}")
+                previous_ontology_file = session.ontology_file
                 session.ontology_file = new_ontology_filename
                 session.ontology_enriched = True
                 session.obqc_validator = None
@@ -503,6 +503,15 @@ async def apply_semantic_names(
                         )
                     except Exception as e:
                         logger.warning(f"Failed to write workspace metadata: {e}")
+
+                # Prune only after metadata names the new file, protecting the
+                # one it referenced until now.
+                await prune_superseded_artifacts(
+                    ontology_file_path,
+                    protect=(
+                        [previous_ontology_file] if previous_ontology_file else []
+                    ),
+                )
             except Exception as e:
                 logger.warning(f"Failed to save ontology to file: {e}")
 

--- a/src/handlers/ontology_semantic.py
+++ b/src/handlers/ontology_semantic.py
@@ -9,6 +9,7 @@ from fastmcp import Context
 
 from ..config import config_manager
 from ..handler_context import HandlerContext
+from ..lifecycle.artifacts import prune_superseded_artifacts
 from ..lifecycle.metadata import update_workspace_section
 from ..ontology_generator import OntologyGenerator
 from ..oxigraph_store import OXIGRAPH_AVAILABLE, schema_graph_uri
@@ -477,6 +478,7 @@ async def apply_semantic_names(
                 ontology_file_path = conn_dir / new_ontology_filename
 
                 await write_text_file(ontology_file_path, updated_ontology)
+                await prune_superseded_artifacts(ontology_file_path)
 
                 logger.info(f"Saved semantic ontology to: {ontology_file_path}")
                 session.ontology_file = new_ontology_filename

--- a/src/handlers/ontology_semantic.py
+++ b/src/handlers/ontology_semantic.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import re
-from datetime import datetime
 from typing import Any
 
 from fastmcp import Context
@@ -14,7 +13,7 @@ from ..lifecycle.metadata import update_workspace_section
 from ..ontology_generator import OntologyGenerator
 from ..oxigraph_store import OXIGRAPH_AVAILABLE, schema_graph_uri
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
-from ..utils import is_client_disconnect, safe_ctx_info, write_text_file
+from ..utils import is_client_disconnect, safe_ctx_info, utc_now, write_text_file
 from .ontology_generation import _build_minimal_graph_summary
 
 logger = logging.getLogger(__name__)
@@ -64,7 +63,7 @@ async def _maybe_sample_rename_suggestions(
         sum(len(v) for v in cryptic_props_by_table.values()),
         len(cryptic_relationships),
     )
-    started = datetime.now()
+    started = utc_now()
 
     prompt = _build_rename_prompt(items)
 
@@ -83,13 +82,13 @@ async def _maybe_sample_rename_suggestions(
         logger.warning(
             "MCP sampling unavailable or failed after %.2fs (%s: %s) — "
             "falling back to manual review path",
-            (datetime.now() - started).total_seconds(),
+            (utc_now() - started).total_seconds(),
             type(e).__name__,
             str(e)[:200],
         )
         return None
 
-    elapsed = (datetime.now() - started).total_seconds()
+    elapsed = (utc_now() - started).total_seconds()
     raw_text = getattr(result, "text", None) or ""
     parsed = _parse_rename_json(raw_text)
     suggestions = _normalize_structured_suggestions(parsed)
@@ -497,7 +496,7 @@ async def apply_semantic_names(
                                 "ontology_file": new_ontology_filename,
                                 "enriched": True,
                                 "persisted_to_rdf": False,
-                                "generated_at": datetime.now().isoformat(),
+                                "generated_at": utc_now().isoformat(),
                             },
                         )
                     except Exception as e:

--- a/src/handlers/ontology_semantic.py
+++ b/src/handlers/ontology_semantic.py
@@ -14,7 +14,7 @@ from ..lifecycle.metadata import update_workspace_section
 from ..ontology_generator import OntologyGenerator
 from ..oxigraph_store import OXIGRAPH_AVAILABLE, schema_graph_uri
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
-from ..utils import is_client_disconnect, safe_ctx_info
+from ..utils import is_client_disconnect, safe_ctx_info, write_text_file
 from .ontology_generation import _build_minimal_graph_summary
 
 logger = logging.getLogger(__name__)
@@ -477,8 +477,7 @@ async def apply_semantic_names(
                 )
                 ontology_file_path = conn_dir / new_ontology_filename
 
-                with open(ontology_file_path, "w", encoding="utf-8") as f:
-                    f.write(updated_ontology)
+                await write_text_file(ontology_file_path, updated_ontology)
 
                 logger.info(f"Saved semantic ontology to: {ontology_file_path}")
                 session.ontology_file = new_ontology_filename

--- a/src/handlers/rdf.py
+++ b/src/handlers/rdf.py
@@ -110,7 +110,7 @@ async def store_ontology_in_rdf(
         )
 
     except Exception as e:
-        logger.error(f"Failed to store ontology in RDF: {e}", exc_info=True)
+        logger.exception(f"Failed to store ontology in RDF: {e}")
         return RDFError(f"Failed to store ontology: {e!s}").to_response()
 
 
@@ -176,7 +176,7 @@ async def query_sparql(
             }
 
     except Exception as e:
-        logger.error(f"SPARQL query failed: {e}", exc_info=True)
+        logger.exception(f"SPARQL query failed: {e}")
         return RDFError(f"SPARQL query failed: {e!s}").to_response()
 
 
@@ -199,7 +199,7 @@ async def query_sparql_ask(
         return {"success": True, "result": result, "query": sparql_query}
 
     except Exception as e:
-        logger.error(f"SPARQL ASK query failed: {e}", exc_info=True)
+        logger.exception(f"SPARQL ASK query failed: {e}")
         return RDFError(f"SPARQL ASK query failed: {e!s}").to_response()
 
 
@@ -236,7 +236,7 @@ async def add_rdf_knowledge(
         )
 
     except Exception as e:
-        logger.error(f"Failed to add knowledge: {e}", exc_info=True)
+        logger.exception(f"Failed to add knowledge: {e}")
         return RDFError(f"Failed to add knowledge: {e!s}").to_response()
 
 
@@ -271,7 +271,7 @@ async def list_tables_sparql(
         }
 
     except Exception as e:
-        logger.error(f"SPARQL table listing failed: {e}", exc_info=True)
+        logger.exception(f"SPARQL table listing failed: {e}")
         return RDFError(f"Failed to list tables: {e!s}").to_response()
 
 
@@ -302,7 +302,7 @@ async def find_columns_by_type_sparql(
         }
 
     except Exception as e:
-        logger.error(f"SPARQL column search failed: {e}", exc_info=True)
+        logger.exception(f"SPARQL column search failed: {e}")
         return RDFError(f"Failed to find columns: {e!s}").to_response()
 
 
@@ -324,5 +324,5 @@ async def get_rdf_store_stats(
         return {"success": True, "stats": stats}
 
     except Exception as e:
-        logger.error(f"Failed to get store stats: {e}", exc_info=True)
+        logger.exception(f"Failed to get store stats: {e}")
         return RDFError(f"Failed to get stats: {e!s}").to_response()

--- a/src/handlers/rdf.py
+++ b/src/handlers/rdf.py
@@ -15,7 +15,7 @@ from ..handler_context import HandlerContext
 from ..lifecycle.metadata import update_workspace_rdf, update_workspace_section
 from ..oxigraph_store import OXIGRAPH_AVAILABLE, schema_graph_uri
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
-from ..utils import utc_now
+from ..utils import read_text_file, utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ async def store_ontology_in_rdf(
                 f"Ontology file not found: {session.ontology_file}"
             ).to_response()
 
-        ontology_ttl = ontology_path.read_text(encoding="utf-8")
+        ontology_ttl = await read_text_file(ontology_path)
 
         if not graph_uri:
             graph_uri = schema_graph_uri(effective_schema)

--- a/src/handlers/rdf.py
+++ b/src/handlers/rdf.py
@@ -15,6 +15,7 @@ from ..handler_context import HandlerContext
 from ..lifecycle.metadata import update_workspace_rdf, update_workspace_section
 from ..oxigraph_store import OXIGRAPH_AVAILABLE, schema_graph_uri
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
+from ..utils import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -74,8 +75,6 @@ async def store_ontology_in_rdf(
         # Update workspace: mark ontology as persisted + write rdf_store
         if session.connection_id:
             try:
-                from datetime import datetime
-
                 await update_workspace_section(
                     connection_id=session.connection_id,
                     output_dir=OUTPUT_DIR,
@@ -86,7 +85,7 @@ async def store_ontology_in_rdf(
                         "enriched": True,
                         "graph_uri": graph_uri,
                         "persisted_to_rdf": True,
-                        "generated_at": datetime.now().isoformat(),
+                        "generated_at": utc_now().isoformat(),
                     },
                 )
                 await update_workspace_rdf(
@@ -95,7 +94,7 @@ async def store_ontology_in_rdf(
                     data={
                         "initialized": True,
                         "graph_uris": [graph_uri],
-                        "initialized_at": datetime.now().isoformat(),
+                        "initialized_at": utc_now().isoformat(),
                     },
                 )
             except Exception as e:

--- a/src/handlers/rdf.py
+++ b/src/handlers/rdf.py
@@ -1,5 +1,6 @@
 """Oxigraph RDF store and SPARQL handler implementations."""
 
+import asyncio
 import logging
 from typing import Any
 
@@ -156,7 +157,7 @@ async def query_sparql(
                 "query": sparql_query,
             }
         elif query_type == "CONSTRUCT":
-            result = store.query_sparql_construct(sparql_query)
+            result = await asyncio.to_thread(store.query_sparql_construct, sparql_query)
             await ctx.info("SPARQL CONSTRUCT query completed")
             return {
                 "success": True,

--- a/src/handlers/schema.py
+++ b/src/handlers/schema.py
@@ -9,7 +9,7 @@ from typing import Any
 from fastmcp import Context
 
 from ..handler_context import HandlerContext
-from ..lifecycle.artifacts import prune_superseded_artifacts
+from ..lifecycle.artifacts import artifact_family_lock, prune_superseded_artifacts
 from ..lifecycle.metadata import update_workspace_section
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
 from ..r2rml_generator import R2RMLGenerator
@@ -314,202 +314,219 @@ async def discover_schema(
     session = services.get_session_data(ctx)
     session.cache_schema_analysis(schema_name or "", table_info_objects)
 
-    # Save schema analysis to connection-scoped output folder.
-    # Paths and the previously-referenced names are captured for the prune that
-    # runs only after workspace metadata durably names the new files.
-    schema_filename = None
-    schema_file_path: Path | None = None
-    r2rml_file_path: Path | None = None
-    previous_schema_file: str | None = None
-    previous_r2rml_file: str | None = None
-    try:
-        conn_dir = (
-            get_connection_dir(session.connection_id)
-            if session.connection_id
-            else ensure_output_dir()
-        )
-        schema_safe = (schema_name or "default").replace(" ", "_").replace(".", "_")
-        schema_filename = (
-            services.get_session_safe_filename(ctx, "schema", schema_safe) + ".json"
-        )
-        schema_file_path = conn_dir / schema_filename
-
-        await write_json_file(schema_file_path, full_schema_data)
-
-        logger.info(f"Saved schema analysis to: {schema_file_path}")
-        session_data = services.get_session_data(ctx)
-        previous_schema_file = session_data.schema_file
-        session_data.schema_file = schema_filename
-    except Exception as e:
-        logger.warning(f"Failed to save schema analysis to file: {e}")
-
-    # Full mode: return complete column details so the LLM has all metadata
-    relationships = {}
-    fan_trap_warnings = []
-    for t in table_info_objects:
-        if t.foreign_keys:
-            relationships[t.name] = t.foreign_keys
-            if len(t.foreign_keys) > 1:
-                fan_trap_warnings.append(
-                    {
-                        "table": t.name,
-                        "referenced_tables": [
-                            fk["referenced_table"] for fk in t.foreign_keys
-                        ],
-                    }
-                )
-
-    schema_result = {
-        "schema": schema_name or "default",
-        "table_count": len(all_table_info),
-        "tables": all_table_info,
-        "relationships": relationships,
-    }
-    if schema_filename:
-        schema_result["schema_file"] = schema_filename
-    if fan_trap_warnings:
-        schema_result["fan_trap_warnings"] = fan_trap_warnings
-
-    # Generate R2RML mapping
-    if table_info_objects:
+    # Both artifact families and the metadata naming them are produced under
+    # one lock. Two overlapping discover_schema calls for the same schema
+    # would otherwise each write files, and the loser's prune would delete the
+    # winner's just-written artifact -- or worse, metadata would end up naming
+    # a file the other request already pruned.
+    schema_safe_family = (schema_name or "default").replace(" ", "_").replace(".", "_")
+    family_dir = (
+        get_connection_dir(session.connection_id)
+        if session.connection_id
+        else ensure_output_dir()
+    )
+    async with artifact_family_lock(
+        family_dir, f"schema_{session.connection_id or 'default'}_{schema_safe_family}"
+    ):
+        # Save schema analysis to connection-scoped output folder.
+        # Paths and the previously-referenced names are captured for the prune that
+        # runs only after workspace metadata durably names the new files.
+        schema_filename = None
+        schema_file_path: Path | None = None
+        r2rml_file_path: Path | None = None
+        previous_schema_file: str | None = None
+        previous_r2rml_file: str | None = None
         try:
             conn_dir = (
                 get_connection_dir(session.connection_id)
                 if session.connection_id
                 else ensure_output_dir()
             )
-            from ..constants import DEFAULT_R2RML_BASE_IRI
-
-            effective_schema = schema_name or "default"
-            r2rml_base = os.getenv("R2RML_BASE_IRI", DEFAULT_R2RML_BASE_IRI)
-            if not r2rml_base.endswith("/"):
-                r2rml_base += "/"
-            base_iri = f"{r2rml_base}{effective_schema}/"
-
-            database_name = db_manager.connection_info.get("database", "database")
-
-            r2rml_generator = R2RMLGenerator(
-                base_iri=base_iri, database_name=database_name
+            schema_safe = (schema_name or "default").replace(" ", "_").replace(".", "_")
+            schema_filename = (
+                services.get_session_safe_filename(ctx, "schema", schema_safe) + ".json"
             )
-            r2rml_content = r2rml_generator.generate_from_schema(
-                table_info_objects, schema_name=effective_schema
-            )
+            schema_file_path = conn_dir / schema_filename
 
-            schema_safe = effective_schema.replace(" ", "_").replace(".", "_")
-            r2rml_filename = (
-                services.get_session_safe_filename(ctx, "r2rml", schema_safe) + ".ttl"
-            )
-            r2rml_file_path = conn_dir / r2rml_filename
+            await write_json_file(schema_file_path, full_schema_data)
 
-            await write_text_file(r2rml_file_path, r2rml_content)
-
-            logger.info(f"Generated R2RML mapping: {r2rml_file_path}")
-            r2rml_session = services.get_session_data(ctx)
-            previous_r2rml_file = r2rml_session.r2rml_file
-            r2rml_session.r2rml_file = r2rml_filename
-            schema_result["r2rml_file"] = r2rml_filename
-            schema_result["r2rml_base_iri"] = base_iri
-
-            await ctx.info(
-                f"R2RML mapping generated with {len(table_info_objects)} tables"
-            )
+            logger.info(f"Saved schema analysis to: {schema_file_path}")
+            session_data = services.get_session_data(ctx)
+            previous_schema_file = session_data.schema_file
+            session_data.schema_file = schema_filename
         except Exception as e:
-            logger.warning(f"Failed to generate R2RML mapping: {e}")
-            schema_result["r2rml_error"] = str(e)
+            logger.warning(f"Failed to save schema analysis to file: {e}")
 
-    # Add workflow guidance
-    if all_table_info:
-        schema_result["next_steps"] = {
-            "recommended": "generate_ontology",
-            "reason": "Generate ontology with database schema linking for accurate SQL generation and fan-trap prevention",
-            "workflow": [
-                "1. discover_schema (completed - schema is now CACHED)",
-                "2. generate_ontology (recommended next - will use cached schema automatically)",
-                "3. execute_sql_query (with ontology context)",
-            ],
-        }
-        schema_result["schema_cached"] = True
-        schema_result["cache_hint"] = (
-            "IMPORTANT: Schema analysis is now CACHED for this session. "
-            "Do NOT call discover_schema again - just call generate_ontology() directly. "
-            "It will automatically use the cached schema data."
-        )
-        schema_result["analytical_guidance"] = (
-            "Recommended next step: Run generate_ontology() - NO parameters needed!\n\n"
-            "The schema is CACHED - generate_ontology will use it automatically.\n"
-            "Do NOT call discover_schema again.\n\n"
-            "This will create an ontology with:\n"
-            "- Database schema linking (oba: namespace)\n"
-            "- SQL column references for queries\n"
-            "- JOIN conditions for relationships\n"
-            "- Metadata for fan-trap prevention\n\n"
-            "The ontology provides context for accurate SQL generation."
-        )
-        schema_result["next_tool"] = "generate_ontology"
-        await ctx.info(
-            f"Schema CACHED with {len(all_table_info)} tables. Next: generate_ontology() - no need to pass schema data, it's cached!"
-        )
-    else:
-        await ctx.info("Schema analysis found no tables")
-
-    # Auto-initialize GraphRAG in background (FULL MODE path)
-    auto_graphrag = os.getenv("AUTO_GRAPHRAG", "true").lower()
-
-    # Debug logging to diagnose auto-init issues
-    logger.debug("GraphRAG auto-init check (FULL MODE path):")
-    logger.debug(f"  AUTO_GRAPHRAG env: '{auto_graphrag}'")
-    logger.debug(
-        f"  table_info_objects exists: {bool(table_info_objects)} (count: {len(table_info_objects) if table_info_objects else 0})"
-    )
-    logger.debug(
-        f"  Will trigger: {auto_graphrag == 'true' and bool(table_info_objects)}"
-    )
-
-    if auto_graphrag == "true" and table_info_objects:
-        logger.info(
-            f"GraphRAG auto-init triggered for schema: {schema_name or 'default'}"
-        )
-        task = asyncio.create_task(
-            services.auto_initialize_graphrag_background(
-                schema_name=schema_name or "default",
-                tables_info=table_info_objects,
-                session=services.get_session_data(ctx),
-                ctx=ctx,
-            )
-        )
-        session = services.get_session_data(ctx)
-        session.graphrag._init_task = task
-        logger.info("GraphRAG auto-initialization started in background (full mode)")
-        schema_result["graphrag_auto_init"] = "started in background"
-
-    # Write workspace metadata for schema section
-    if session.connection_id and schema_filename:
-        try:
-            await update_workspace_section(
-                connection_id=session.connection_id,
-                output_dir=OUTPUT_DIR,
-                schema_name=schema_name or "default",
-                section="schema",
-                data={
-                    "schema_file": schema_filename,
-                    "r2rml_file": schema_result.get("r2rml_file"),
-                    "table_count": len(table_info_objects),
-                    "analyzed_at": utc_now().isoformat(),
-                },
-            )
-            # Prune only after metadata durably names the new files. Doing it
-            # earlier means a crash in this gap leaves metadata pointing at an
-            # artifact that has already been deleted.
-            for written, previous in (
-                (schema_file_path, previous_schema_file),
-                (r2rml_file_path, previous_r2rml_file),
-            ):
-                if written is not None:
-                    await prune_superseded_artifacts(
-                        written, protect=[previous] if previous else []
+        # Full mode: return complete column details so the LLM has all metadata
+        relationships = {}
+        fan_trap_warnings = []
+        for t in table_info_objects:
+            if t.foreign_keys:
+                relationships[t.name] = t.foreign_keys
+                if len(t.foreign_keys) > 1:
+                    fan_trap_warnings.append(
+                        {
+                            "table": t.name,
+                            "referenced_tables": [
+                                fk["referenced_table"] for fk in t.foreign_keys
+                            ],
+                        }
                     )
-        except Exception as e:
-            logger.warning(f"Failed to write workspace metadata: {e}")
+
+        schema_result = {
+            "schema": schema_name or "default",
+            "table_count": len(all_table_info),
+            "tables": all_table_info,
+            "relationships": relationships,
+        }
+        if schema_filename:
+            schema_result["schema_file"] = schema_filename
+        if fan_trap_warnings:
+            schema_result["fan_trap_warnings"] = fan_trap_warnings
+
+        # Generate R2RML mapping
+        if table_info_objects:
+            try:
+                conn_dir = (
+                    get_connection_dir(session.connection_id)
+                    if session.connection_id
+                    else ensure_output_dir()
+                )
+                from ..constants import DEFAULT_R2RML_BASE_IRI
+
+                effective_schema = schema_name or "default"
+                r2rml_base = os.getenv("R2RML_BASE_IRI", DEFAULT_R2RML_BASE_IRI)
+                if not r2rml_base.endswith("/"):
+                    r2rml_base += "/"
+                base_iri = f"{r2rml_base}{effective_schema}/"
+
+                database_name = db_manager.connection_info.get("database", "database")
+
+                r2rml_generator = R2RMLGenerator(
+                    base_iri=base_iri, database_name=database_name
+                )
+                r2rml_content = r2rml_generator.generate_from_schema(
+                    table_info_objects, schema_name=effective_schema
+                )
+
+                schema_safe = effective_schema.replace(" ", "_").replace(".", "_")
+                r2rml_filename = (
+                    services.get_session_safe_filename(ctx, "r2rml", schema_safe)
+                    + ".ttl"
+                )
+                r2rml_file_path = conn_dir / r2rml_filename
+
+                await write_text_file(r2rml_file_path, r2rml_content)
+
+                logger.info(f"Generated R2RML mapping: {r2rml_file_path}")
+                r2rml_session = services.get_session_data(ctx)
+                previous_r2rml_file = r2rml_session.r2rml_file
+                r2rml_session.r2rml_file = r2rml_filename
+                schema_result["r2rml_file"] = r2rml_filename
+                schema_result["r2rml_base_iri"] = base_iri
+
+                await ctx.info(
+                    f"R2RML mapping generated with {len(table_info_objects)} tables"
+                )
+            except Exception as e:
+                logger.warning(f"Failed to generate R2RML mapping: {e}")
+                schema_result["r2rml_error"] = str(e)
+
+        # Add workflow guidance
+        if all_table_info:
+            schema_result["next_steps"] = {
+                "recommended": "generate_ontology",
+                "reason": "Generate ontology with database schema linking for accurate SQL generation and fan-trap prevention",
+                "workflow": [
+                    "1. discover_schema (completed - schema is now CACHED)",
+                    "2. generate_ontology (recommended next - will use cached schema automatically)",
+                    "3. execute_sql_query (with ontology context)",
+                ],
+            }
+            schema_result["schema_cached"] = True
+            schema_result["cache_hint"] = (
+                "IMPORTANT: Schema analysis is now CACHED for this session. "
+                "Do NOT call discover_schema again - just call generate_ontology() directly. "
+                "It will automatically use the cached schema data."
+            )
+            schema_result["analytical_guidance"] = (
+                "Recommended next step: Run generate_ontology() - NO parameters needed!\n\n"
+                "The schema is CACHED - generate_ontology will use it automatically.\n"
+                "Do NOT call discover_schema again.\n\n"
+                "This will create an ontology with:\n"
+                "- Database schema linking (oba: namespace)\n"
+                "- SQL column references for queries\n"
+                "- JOIN conditions for relationships\n"
+                "- Metadata for fan-trap prevention\n\n"
+                "The ontology provides context for accurate SQL generation."
+            )
+            schema_result["next_tool"] = "generate_ontology"
+            await ctx.info(
+                f"Schema CACHED with {len(all_table_info)} tables. Next: generate_ontology() - no need to pass schema data, it's cached!"
+            )
+        else:
+            await ctx.info("Schema analysis found no tables")
+
+        # Auto-initialize GraphRAG in background (FULL MODE path)
+        auto_graphrag = os.getenv("AUTO_GRAPHRAG", "true").lower()
+
+        # Debug logging to diagnose auto-init issues
+        logger.debug("GraphRAG auto-init check (FULL MODE path):")
+        logger.debug(f"  AUTO_GRAPHRAG env: '{auto_graphrag}'")
+        logger.debug(
+            f"  table_info_objects exists: {bool(table_info_objects)} (count: {len(table_info_objects) if table_info_objects else 0})"
+        )
+        logger.debug(
+            f"  Will trigger: {auto_graphrag == 'true' and bool(table_info_objects)}"
+        )
+
+        if auto_graphrag == "true" and table_info_objects:
+            logger.info(
+                f"GraphRAG auto-init triggered for schema: {schema_name or 'default'}"
+            )
+            task = asyncio.create_task(
+                services.auto_initialize_graphrag_background(
+                    schema_name=schema_name or "default",
+                    tables_info=table_info_objects,
+                    session=services.get_session_data(ctx),
+                    ctx=ctx,
+                )
+            )
+            session = services.get_session_data(ctx)
+            session.graphrag._init_task = task
+            logger.info(
+                "GraphRAG auto-initialization started in background (full mode)"
+            )
+            schema_result["graphrag_auto_init"] = "started in background"
+
+        # Write workspace metadata for schema section
+        if session.connection_id and schema_filename:
+            try:
+                await update_workspace_section(
+                    connection_id=session.connection_id,
+                    output_dir=OUTPUT_DIR,
+                    schema_name=schema_name or "default",
+                    section="schema",
+                    data={
+                        "schema_file": schema_filename,
+                        "r2rml_file": schema_result.get("r2rml_file"),
+                        "table_count": len(table_info_objects),
+                        "analyzed_at": utc_now().isoformat(),
+                    },
+                )
+                # Prune only after metadata durably names the new files. Doing it
+                # earlier means a crash in this gap leaves metadata pointing at an
+                # artifact that has already been deleted.
+                for written, previous in (
+                    (schema_file_path, previous_schema_file),
+                    (r2rml_file_path, previous_r2rml_file),
+                ):
+                    if written is not None:
+                        await prune_superseded_artifacts(
+                            written, protect=[previous] if previous else []
+                        )
+            except Exception as e:
+                logger.warning(f"Failed to write workspace metadata: {e}")
 
     return schema_result
 

--- a/src/handlers/schema.py
+++ b/src/handlers/schema.py
@@ -143,7 +143,7 @@ async def discover_schema(
                     ctx=ctx,
                 )
             )
-            session.graphrag._init_task = task
+            session.graphrag.track_init_task(task)
             logger.info(
                 "GraphRAG auto-initialization started in background (from cache)"
             )
@@ -265,7 +265,7 @@ async def discover_schema(
                     ctx=ctx,
                 )
             )
-            session.graphrag._init_task = task
+            session.graphrag.track_init_task(task)
             logger.info("GraphRAG auto-initialization started in background")
             lightweight_result["graphrag_auto_init"] = "started in background"
 
@@ -405,8 +405,10 @@ async def discover_schema(
                 r2rml_generator = R2RMLGenerator(
                     base_iri=base_iri, database_name=database_name
                 )
-                r2rml_content = r2rml_generator.generate_from_schema(
-                    table_info_objects, schema_name=effective_schema
+                r2rml_content = await asyncio.to_thread(
+                    r2rml_generator.generate_from_schema,
+                    table_info_objects,
+                    schema_name=effective_schema,
                 )
 
                 schema_safe = effective_schema.replace(" ", "_").replace(".", "_")
@@ -493,7 +495,7 @@ async def discover_schema(
                 )
             )
             session = services.get_session_data(ctx)
-            session.graphrag._init_task = task
+            session.graphrag.track_init_task(task)
             logger.info(
                 "GraphRAG auto-initialization started in background (full mode)"
             )

--- a/src/handlers/schema.py
+++ b/src/handlers/schema.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastmcp import Context
 
 from ..handler_context import HandlerContext
+from ..lifecycle.artifacts import prune_superseded_artifacts
 from ..lifecycle.metadata import update_workspace_section
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
 from ..r2rml_generator import R2RMLGenerator
@@ -327,6 +328,7 @@ async def discover_schema(
         schema_file_path = conn_dir / schema_filename
 
         await write_json_file(schema_file_path, full_schema_data)
+        await prune_superseded_artifacts(schema_file_path)
 
         logger.info(f"Saved schema analysis to: {schema_file_path}")
         services.get_session_data(ctx).schema_file = schema_filename
@@ -392,6 +394,7 @@ async def discover_schema(
             r2rml_file_path = conn_dir / r2rml_filename
 
             await write_text_file(r2rml_file_path, r2rml_content)
+            await prune_superseded_artifacts(r2rml_file_path)
 
             logger.info(f"Generated R2RML mapping: {r2rml_file_path}")
             services.get_session_data(ctx).r2rml_file = r2rml_filename

--- a/src/handlers/schema.py
+++ b/src/handlers/schema.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import os
+from pathlib import Path
 from typing import Any
 
 from fastmcp import Context
@@ -313,8 +314,14 @@ async def discover_schema(
     session = services.get_session_data(ctx)
     session.cache_schema_analysis(schema_name or "", table_info_objects)
 
-    # Save schema analysis to connection-scoped output folder
+    # Save schema analysis to connection-scoped output folder.
+    # Paths and the previously-referenced names are captured for the prune that
+    # runs only after workspace metadata durably names the new files.
     schema_filename = None
+    schema_file_path: Path | None = None
+    r2rml_file_path: Path | None = None
+    previous_schema_file: str | None = None
+    previous_r2rml_file: str | None = None
     try:
         conn_dir = (
             get_connection_dir(session.connection_id)
@@ -328,10 +335,11 @@ async def discover_schema(
         schema_file_path = conn_dir / schema_filename
 
         await write_json_file(schema_file_path, full_schema_data)
-        await prune_superseded_artifacts(schema_file_path)
 
         logger.info(f"Saved schema analysis to: {schema_file_path}")
-        services.get_session_data(ctx).schema_file = schema_filename
+        session_data = services.get_session_data(ctx)
+        previous_schema_file = session_data.schema_file
+        session_data.schema_file = schema_filename
     except Exception as e:
         logger.warning(f"Failed to save schema analysis to file: {e}")
 
@@ -394,10 +402,11 @@ async def discover_schema(
             r2rml_file_path = conn_dir / r2rml_filename
 
             await write_text_file(r2rml_file_path, r2rml_content)
-            await prune_superseded_artifacts(r2rml_file_path)
 
             logger.info(f"Generated R2RML mapping: {r2rml_file_path}")
-            services.get_session_data(ctx).r2rml_file = r2rml_filename
+            r2rml_session = services.get_session_data(ctx)
+            previous_r2rml_file = r2rml_session.r2rml_file
+            r2rml_session.r2rml_file = r2rml_filename
             schema_result["r2rml_file"] = r2rml_filename
             schema_result["r2rml_base_iri"] = base_iri
 
@@ -488,6 +497,17 @@ async def discover_schema(
                     "analyzed_at": utc_now().isoformat(),
                 },
             )
+            # Prune only after metadata durably names the new files. Doing it
+            # earlier means a crash in this gap leaves metadata pointing at an
+            # artifact that has already been deleted.
+            for written, previous in (
+                (schema_file_path, previous_schema_file),
+                (r2rml_file_path, previous_r2rml_file),
+            ):
+                if written is not None:
+                    await prune_superseded_artifacts(
+                        written, protect=[previous] if previous else []
+                    )
         except Exception as e:
             logger.warning(f"Failed to write workspace metadata: {e}")
 

--- a/src/handlers/schema.py
+++ b/src/handlers/schema.py
@@ -1,7 +1,6 @@
 """Schema analysis, table details, and cache management handler implementations."""
 
 import asyncio
-import json
 import logging
 import os
 from typing import Any
@@ -12,6 +11,7 @@ from ..handler_context import HandlerContext
 from ..lifecycle.metadata import update_workspace_section
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
 from ..r2rml_generator import R2RMLGenerator
+from ..utils import write_json_file, write_text_file
 
 logger = logging.getLogger(__name__)
 
@@ -326,8 +326,7 @@ async def discover_schema(
         )
         schema_file_path = conn_dir / schema_filename
 
-        with open(schema_file_path, "w", encoding="utf-8") as f:
-            json.dump(full_schema_data, f, indent=2, ensure_ascii=False)
+        await write_json_file(schema_file_path, full_schema_data)
 
         logger.info(f"Saved schema analysis to: {schema_file_path}")
         services.get_session_data(ctx).schema_file = schema_filename
@@ -392,8 +391,7 @@ async def discover_schema(
             )
             r2rml_file_path = conn_dir / r2rml_filename
 
-            with open(r2rml_file_path, "w", encoding="utf-8") as f:
-                f.write(r2rml_content)
+            await write_text_file(r2rml_file_path, r2rml_content)
 
             logger.info(f"Generated R2RML mapping: {r2rml_file_path}")
             services.get_session_data(ctx).r2rml_file = r2rml_filename

--- a/src/handlers/schema.py
+++ b/src/handlers/schema.py
@@ -11,7 +11,7 @@ from ..handler_context import HandlerContext
 from ..lifecycle.metadata import update_workspace_section
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
 from ..r2rml_generator import R2RMLGenerator
-from ..utils import write_json_file, write_text_file
+from ..utils import utc_now, write_json_file, write_text_file
 
 logger = logging.getLogger(__name__)
 
@@ -473,8 +473,6 @@ async def discover_schema(
     # Write workspace metadata for schema section
     if session.connection_id and schema_filename:
         try:
-            from datetime import datetime
-
             await update_workspace_section(
                 connection_id=session.connection_id,
                 output_dir=OUTPUT_DIR,
@@ -484,7 +482,7 @@ async def discover_schema(
                     "schema_file": schema_filename,
                     "r2rml_file": schema_result.get("r2rml_file"),
                     "table_count": len(table_info_objects),
-                    "analyzed_at": datetime.now().isoformat(),
+                    "analyzed_at": utc_now().isoformat(),
                 },
             )
         except Exception as e:

--- a/src/handlers/workspace.py
+++ b/src/handlers/workspace.py
@@ -1,6 +1,5 @@
 """Workspace restore, cleanup, and semantic model storage handler implementation."""
 
-import json
 import logging
 import shutil
 from datetime import datetime
@@ -15,6 +14,7 @@ from ..handler_context import HandlerContext
 from ..lifecycle.metadata import VersionMetadataManager
 from ..oxigraph_store import OXIGRAPH_AVAILABLE
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir, get_models_dir
+from ..utils import read_json_file, write_text_file
 
 logger = logging.getLogger(__name__)
 
@@ -84,8 +84,7 @@ async def _restore_workspace_core(
             schema_path = conn_dir / schema_file
             if schema_path.exists():
                 try:
-                    with open(schema_path, encoding="utf-8") as f:
-                        schema_json = json.load(f)
+                    schema_json = await read_json_file(schema_path)
 
                     tables_raw = schema_json.get("tables", [])
                     tables_info = [TableInfo.from_dict(t) for t in tables_raw]
@@ -397,8 +396,7 @@ async def save_semantic_model(
     model_path = models_dir / model_filename
 
     try:
-        with open(model_path, "w", encoding="utf-8") as f:
-            f.write(model_yaml)
+        await write_text_file(model_path, model_yaml)
         logger.info(f"Saved semantic model '{model_name}' to: {model_path}")
     except Exception as e:
         logger.error(f"Failed to save semantic model: {e}")

--- a/src/handlers/workspace.py
+++ b/src/handlers/workspace.py
@@ -1,5 +1,6 @@
 """Workspace restore, cleanup, and semantic model storage handler implementation."""
 
+import asyncio
 import logging
 import shutil
 from pathlib import Path
@@ -13,7 +14,7 @@ from ..handler_context import HandlerContext
 from ..lifecycle.metadata import VersionMetadataManager
 from ..oxigraph_store import OXIGRAPH_AVAILABLE
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir, get_models_dir
-from ..utils import read_json_file, utc_now, write_text_file
+from ..utils import read_json_file, read_text_file, utc_now, write_text_file
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +113,7 @@ async def _restore_workspace_core(
                     enriched_tag = " (enriched)" if is_enriched else ""
                     restored.append(f"Ontology '{sname}'{enriched_tag}")
 
-                    ontology_content = ontology_path.read_text(encoding="utf-8")
+                    ontology_content = await read_text_file(ontology_path)
                     session.loaded_ontology = ontology_content
                     session.loaded_ontology_path = str(ontology_path)
                 except Exception as e:
@@ -152,7 +153,7 @@ async def _restore_workspace_core(
                         connection_id=connection_id,
                         schema_name=sname,
                     )
-                    if manager.load_state(ensure_output_dir()):
+                    if await asyncio.to_thread(manager.load_state, ensure_output_dir()):
                         session.graphrag_manager = manager
                         session.graphrag_initialized = True
                         stats = manager.vector_store.get_statistics()
@@ -315,7 +316,7 @@ async def cleanup_workspace(
     for dir_path, label in dirs_to_remove:
         if dir_path.exists():
             try:
-                shutil.rmtree(dir_path, ignore_errors=True)
+                await asyncio.to_thread(shutil.rmtree, dir_path, ignore_errors=True)
                 removed.append(label)
                 logger.info(f"Cleaned up {label}: {dir_path}")
             except Exception as e:
@@ -405,8 +406,9 @@ async def save_semantic_model(
         )
         return err
 
-    # Update workspace metadata
-    try:
+    # Update workspace metadata. The whole read-modify-write is blocking disk
+    # I/O, so it runs off the event loop rather than stalling other sessions.
+    def _record_model() -> None:
         mgr = VersionMetadataManager(connection_id, OUTPUT_DIR)
         workspace = mgr.metadata.setdefault(
             "workspace",
@@ -423,6 +425,9 @@ async def save_semantic_model(
         }
         workspace["updated_at"] = utc_now().isoformat()
         mgr._save_metadata()
+
+    try:
+        await asyncio.to_thread(_record_model)
     except Exception as e:
         logger.warning(f"Failed to update workspace metadata for model: {e}")
 
@@ -501,7 +506,7 @@ async def get_semantic_model(
         return err
 
     try:
-        model_yaml = model_path.read_text(encoding="utf-8")
+        model_yaml = await read_text_file(model_path)
     except Exception as e:
         err = services.create_error_response(
             f"Failed to read model file: {e}",

--- a/src/handlers/workspace.py
+++ b/src/handlers/workspace.py
@@ -2,7 +2,6 @@
 
 import logging
 import shutil
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -14,7 +13,7 @@ from ..handler_context import HandlerContext
 from ..lifecycle.metadata import VersionMetadataManager
 from ..oxigraph_store import OXIGRAPH_AVAILABLE
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir, get_models_dir
-from ..utils import read_json_file, write_text_file
+from ..utils import read_json_file, utc_now, write_text_file
 
 logger = logging.getLogger(__name__)
 
@@ -412,7 +411,7 @@ async def save_semantic_model(
         workspace = mgr.metadata.setdefault(
             "workspace",
             {
-                "updated_at": datetime.now().isoformat(),
+                "updated_at": utc_now().isoformat(),
                 "schemas": {},
             },
         )
@@ -420,9 +419,9 @@ async def save_semantic_model(
         models[model_name] = {
             "file": model_filename,
             "schema_name": effective_schema,
-            "saved_at": datetime.now().isoformat(),
+            "saved_at": utc_now().isoformat(),
         }
-        workspace["updated_at"] = datetime.now().isoformat()
+        workspace["updated_at"] = utc_now().isoformat()
         mgr._save_metadata()
     except Exception as e:
         logger.warning(f"Failed to update workspace metadata for model: {e}")

--- a/src/handlers/workspace.py
+++ b/src/handlers/workspace.py
@@ -13,7 +13,13 @@ from ..graphrag import GraphRAGManager
 from ..handler_context import HandlerContext
 from ..lifecycle.metadata import VersionMetadataManager, mutate_workspace_metadata
 from ..oxigraph_store import OXIGRAPH_AVAILABLE
-from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir, get_models_dir
+from ..paths import (
+    OUTPUT_DIR,
+    ensure_output_dir,
+    get_connection_dir,
+    get_connection_store_dirs,
+    get_models_dir,
+)
 from ..utils import read_json_file, read_text_file, utc_now, write_text_file
 
 logger = logging.getLogger(__name__)
@@ -307,20 +313,28 @@ async def cleanup_workspace(
     # Drop GraphRAG reference (connection-scoped, releases ChromaDB handle)
     session.graphrag_manager = None
 
-    # 2. Delete workspace directories
-    dirs_to_remove = [
-        (OUTPUT_DIR / connection_id, "workspace"),
-        (OUTPUT_DIR / "oxigraph" / connection_id, "Oxigraph RDF store"),
-        (OUTPUT_DIR / "chromadb" / connection_id, "ChromaDB vector store"),
+    # 2. Delete the workspace and the satellite stores keyed to this connection.
+    # The store paths come from get_connection_store_dirs() so this list cannot
+    # drift from the one the startup cleanup uses.
+    labels = {"chromadb": "ChromaDB vector store", "oxigraph": "Oxigraph RDF store"}
+    dirs_to_remove: list[tuple[Path, str]] = [(OUTPUT_DIR / connection_id, "workspace")]
+    dirs_to_remove += [
+        (store_dir, labels.get(store_dir.parent.name, store_dir.parent.name))
+        for store_dir in get_connection_store_dirs(connection_id)
     ]
+
     for dir_path, label in dirs_to_remove:
+        if not dir_path.exists():
+            continue
+        await asyncio.to_thread(shutil.rmtree, dir_path, ignore_errors=True)
+        # rmtree(ignore_errors=True) never raises, so success cannot be inferred
+        # from "it didn't throw" -- a locked or read-only tree silently survives.
+        # Check, so the response does not claim a deletion that did not happen.
         if dir_path.exists():
-            try:
-                await asyncio.to_thread(shutil.rmtree, dir_path, ignore_errors=True)
-                removed.append(label)
-                logger.info(f"Cleaned up {label}: {dir_path}")
-            except Exception as e:
-                logger.warning(f"Failed to remove {label}: {e}")
+            logger.warning(f"Failed to remove {label}: {dir_path} still present")
+        else:
+            removed.append(label)
+            logger.info(f"Cleaned up {label}: {dir_path}")
 
     # 3. Clear all in-memory session state (keep connection alive)
     session.clear_schema_cache()

--- a/src/handlers/workspace.py
+++ b/src/handlers/workspace.py
@@ -11,7 +11,7 @@ from fastmcp import Context
 from ..database_manager import TableInfo
 from ..graphrag import GraphRAGManager
 from ..handler_context import HandlerContext
-from ..lifecycle.metadata import VersionMetadataManager
+from ..lifecycle.metadata import VersionMetadataManager, mutate_workspace_metadata
 from ..oxigraph_store import OXIGRAPH_AVAILABLE
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir, get_models_dir
 from ..utils import read_json_file, read_text_file, utc_now, write_text_file
@@ -406,10 +406,10 @@ async def save_semantic_model(
         )
         return err
 
-    # Update workspace metadata. The whole read-modify-write is blocking disk
-    # I/O, so it runs off the event loop rather than stalling other sessions.
-    def _record_model() -> None:
-        mgr = VersionMetadataManager(connection_id, OUTPUT_DIR)
+    # Update workspace metadata through the shared locked helper. Doing this
+    # read-modify-write outside the per-connection lock races every other
+    # workspace writer -- reproducibly dropping sections and tearing the file.
+    def _record_model(mgr: VersionMetadataManager) -> None:
         workspace = mgr.metadata.setdefault(
             "workspace",
             {
@@ -427,7 +427,7 @@ async def save_semantic_model(
         mgr._save_metadata()
 
     try:
-        await asyncio.to_thread(_record_model)
+        await mutate_workspace_metadata(connection_id, OUTPUT_DIR, _record_model)
     except Exception as e:
         logger.warning(f"Failed to update workspace metadata for model: {e}")
 

--- a/src/lifecycle/artifacts.py
+++ b/src/lifecycle/artifacts.py
@@ -1,0 +1,137 @@
+"""Pruning of superseded per-schema artifacts.
+
+Every ``generate_ontology`` / ``discover_schema`` call writes a *new* file:
+filenames carry a microsecond timestamp (see ``get_session_safe_filename``), so
+each run produces a distinct name. Workspace metadata records only the latest
+filename per schema, which leaves every earlier file unreferenced and, until
+now, permanently on disk. On a large schema an ontology TTL is megabytes, so
+regenerating a handful of times quietly costs hundreds.
+
+``AUTO_CLEANUP_ON_STARTUP`` does not help: it deletes whole workspaces by age,
+never files inside a workspace that is still in use.
+
+This module prunes the older files in the same *family* as the one just
+written -- same artifact kind, same connection, same schema -- keeping the most
+recent ``keep`` of them. It is deliberately conservative: if a filename does not
+match the expected shape, nothing is deleted.
+"""
+
+import asyncio
+import logging
+import os
+import re
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Trailing timestamp produced by get_session_safe_filename ("%Y%m%d_%H%M%S%f")
+# and by the background ontology path ("%Y%m%d_%H%M%S"). Note it contains an
+# underscore itself, so stripping "the last _ component" would be wrong.
+_TIMESTAMP_SUFFIX = re.compile(r"_\d{8}_\d{6,12}$")
+
+DEFAULT_KEEP_VERSIONS = 3
+
+
+def get_keep_versions() -> int:
+    """How many generations of each artifact to retain, including the current one.
+
+    Returns:
+        Value of ARTIFACT_KEEP_VERSIONS, or the default. Values below 1 are
+        clamped to 1 so the file in use is never a deletion candidate.
+    """
+    raw = os.getenv("ARTIFACT_KEEP_VERSIONS")
+    if raw is None:
+        return DEFAULT_KEEP_VERSIONS
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        logger.warning(
+            f"Invalid ARTIFACT_KEEP_VERSIONS={raw!r}; using {DEFAULT_KEEP_VERSIONS}"
+        )
+        return DEFAULT_KEEP_VERSIONS
+
+
+def family_glob(filename: str) -> str | None:
+    """Return a glob matching every generation of *filename*'s artifact family.
+
+    ``ontology_ab12cd34_public_20260727_132056962941.ttl`` becomes
+    ``ontology_ab12cd34_public_*.ttl`` -- same kind, connection and schema, any
+    timestamp.
+
+    Args:
+        filename: Base name of a freshly written artifact.
+
+    Returns:
+        A glob pattern, or None if the name has no recognizable timestamp, in
+        which case the caller must not prune.
+    """
+    path = Path(filename)
+    stem, suffix = path.stem, path.suffix
+    if not _TIMESTAMP_SUFFIX.search(stem):
+        return None
+    return f"{_TIMESTAMP_SUFFIX.sub('', stem)}_*{suffix}"
+
+
+def prune_superseded_sync(current_file: Path, keep: int | None = None) -> list[Path]:
+    """Delete older artifacts superseded by *current_file*.
+
+    Args:
+        current_file: The artifact just written. Never deleted, whatever its
+            modification time says.
+        keep: Generations to retain including *current_file*. Defaults to
+            :func:`get_keep_versions`.
+
+    Returns:
+        The paths actually deleted.
+    """
+    keep = get_keep_versions() if keep is None else max(1, keep)
+    pattern = family_glob(current_file.name)
+    if pattern is None:
+        logger.debug(f"No timestamp in {current_file.name}; skipping prune")
+        return []
+
+    directory = current_file.parent
+    try:
+        siblings = [p for p in directory.glob(pattern) if p.is_file()]
+    except OSError as e:
+        logger.warning(f"Could not scan {directory} for superseded artifacts: {e}")
+        return []
+
+    # Newest first, with the current file pinned to the front so it survives
+    # even if another generation has a newer mtime.
+    others = [p for p in siblings if p != current_file]
+    others.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    ordered = [current_file, *others]
+
+    removed: list[Path] = []
+    for stale in ordered[keep:]:
+        try:
+            stale.unlink()
+            removed.append(stale)
+        except OSError as e:
+            logger.warning(f"Failed to prune superseded artifact {stale}: {e}")
+
+    if removed:
+        logger.info(
+            f"Pruned {len(removed)} superseded artifact(s) matching {pattern} "
+            f"(keeping {keep})"
+        )
+    return removed
+
+
+async def prune_superseded_artifacts(
+    current_file: Path, keep: int | None = None
+) -> list[Path]:
+    """Async wrapper for :func:`prune_superseded_sync`.
+
+    Globbing and unlinking are blocking, and callers are request handlers, so
+    the work runs in a worker thread.
+
+    Args:
+        current_file: The artifact just written.
+        keep: Generations to retain including *current_file*.
+
+    Returns:
+        The paths actually deleted.
+    """
+    return await asyncio.to_thread(prune_superseded_sync, current_file, keep)

--- a/src/lifecycle/artifacts.py
+++ b/src/lifecycle/artifacts.py
@@ -20,6 +20,7 @@ import asyncio
 import logging
 import os
 import re
+from collections.abc import Iterable
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -51,28 +52,39 @@ def get_keep_versions() -> int:
         return DEFAULT_KEEP_VERSIONS
 
 
-def family_glob(filename: str) -> str | None:
-    """Return a glob matching every generation of *filename*'s artifact family.
+def family_key(filename: str) -> tuple[str, str] | None:
+    """Identify the artifact family *filename* belongs to.
 
-    ``ontology_ab12cd34_public_20260727_132056962941.ttl`` becomes
-    ``ontology_ab12cd34_public_*.ttl`` -- same kind, connection and schema, any
-    timestamp.
+    ``ontology_ab12cd34_public_20260727_132056962941.ttl`` maps to
+    ``("ontology_ab12cd34_public", ".ttl")`` -- same kind, connection and
+    schema, any timestamp.
+
+    Deliberately not a glob. Schema names may legally contain ``*``, ``?`` or
+    ``[``, and those survive the ``schema_safe`` sanitizing (which only
+    replaces spaces and dots). A glob built from such a name matches sibling
+    schemas: a prune for ``sales*`` would delete ``sales_eu``'s artifacts.
+    Comparing parsed keys removes that class of bug entirely rather than
+    relying on escaping.
 
     Args:
-        filename: Base name of a freshly written artifact.
+        filename: Base name of an artifact.
 
     Returns:
-        A glob pattern, or None if the name has no recognizable timestamp, in
-        which case the caller must not prune.
+        ``(family, extension)``, or None if the name carries no recognizable
+        timestamp, in which case the caller must not prune.
     """
     path = Path(filename)
     stem, suffix = path.stem, path.suffix
     if not _TIMESTAMP_SUFFIX.search(stem):
         return None
-    return f"{_TIMESTAMP_SUFFIX.sub('', stem)}_*{suffix}"
+    return _TIMESTAMP_SUFFIX.sub("", stem), suffix
 
 
-def prune_superseded_sync(current_file: Path, keep: int | None = None) -> list[Path]:
+def prune_superseded_sync(
+    current_file: Path,
+    keep: int | None = None,
+    protect: Iterable[Path | str] = (),
+) -> list[Path]:
     """Delete older artifacts superseded by *current_file*.
 
     Args:
@@ -80,28 +92,38 @@ def prune_superseded_sync(current_file: Path, keep: int | None = None) -> list[P
             modification time says.
         keep: Generations to retain including *current_file*. Defaults to
             :func:`get_keep_versions`.
+        protect: Additional names never to delete -- in particular whatever
+            workspace metadata still points at. Until metadata durably names
+            the new file, deleting the old one would leave restore chasing a
+            file that no longer exists.
 
     Returns:
         The paths actually deleted.
     """
     keep = get_keep_versions() if keep is None else max(1, keep)
-    pattern = family_glob(current_file.name)
-    if pattern is None:
+    key = family_key(current_file.name)
+    if key is None:
         logger.debug(f"No timestamp in {current_file.name}; skipping prune")
         return []
 
     directory = current_file.parent
+    protected = {Path(p).name for p in protect} | {current_file.name}
     try:
-        siblings = [p for p in directory.glob(pattern) if p.is_file()]
+        siblings = [
+            entry
+            for entry in directory.iterdir()
+            if entry.is_file()
+            and entry.name not in protected
+            and family_key(entry.name) == key
+        ]
     except OSError as e:
         logger.warning(f"Could not scan {directory} for superseded artifacts: {e}")
         return []
 
     # Newest first, with the current file pinned to the front so it survives
     # even if another generation has a newer mtime.
-    others = [p for p in siblings if p != current_file]
-    others.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-    ordered = [current_file, *others]
+    siblings.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    ordered = [current_file, *siblings]
 
     removed: list[Path] = []
     for stale in ordered[keep:]:
@@ -113,14 +135,16 @@ def prune_superseded_sync(current_file: Path, keep: int | None = None) -> list[P
 
     if removed:
         logger.info(
-            f"Pruned {len(removed)} superseded artifact(s) matching {pattern} "
-            f"(keeping {keep})"
+            f"Pruned {len(removed)} superseded artifact(s) from family "
+            f"{key[0]}{key[1]} (keeping {keep})"
         )
     return removed
 
 
 async def prune_superseded_artifacts(
-    current_file: Path, keep: int | None = None
+    current_file: Path,
+    keep: int | None = None,
+    protect: Iterable[Path | str] = (),
 ) -> list[Path]:
     """Async wrapper for :func:`prune_superseded_sync`.
 
@@ -130,8 +154,10 @@ async def prune_superseded_artifacts(
     Args:
         current_file: The artifact just written.
         keep: Generations to retain including *current_file*.
+        protect: Additional names never to delete (e.g. the artifact workspace
+            metadata still references).
 
     Returns:
         The paths actually deleted.
     """
-    return await asyncio.to_thread(prune_superseded_sync, current_file, keep)
+    return await asyncio.to_thread(prune_superseded_sync, current_file, keep, protect)

--- a/src/lifecycle/artifacts.py
+++ b/src/lifecycle/artifacts.py
@@ -20,10 +20,57 @@ import asyncio
 import logging
 import os
 import re
-from collections.abc import Iterable
+import weakref
+from collections.abc import AsyncIterator, Iterable
+from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# Serializes the produce -> record -> prune sequence for one artifact family.
+#
+# Without it, two overlapping requests for the same schema each write a file and
+# each treat its own as authoritative: workspace metadata ends up naming
+# whichever wrote last, and pruning turns the other request's live artifact into
+# a deletion. Holding this from before the filename is minted until after the
+# prune makes the sequence atomic per family.
+#
+# Keyed per event loop only, unlike the metadata locks. Artifact writers are
+# request handlers, which all run on the server's single loop; nothing writes
+# artifacts from a second loop the way get_registered_tool_names spins one up
+# for tool listing.
+_family_locks: "weakref.WeakKeyDictionary[Any, dict[str, asyncio.Lock]]" = (
+    weakref.WeakKeyDictionary()
+)
+
+
+@asynccontextmanager
+async def artifact_family_lock(directory: Path, family: str) -> AsyncIterator[None]:
+    """Serialize artifact production for one family within a directory.
+
+    Wrap the whole sequence -- mint the timestamped filename, write it, update
+    workspace metadata, prune superseded generations -- so a concurrent request
+    for the same schema cannot interleave and have its just-written file pruned
+    as though it were stale.
+
+    Args:
+        directory: Connection directory the artifacts live in.
+        family: Family prefix, e.g. ``"ontology_ab12cd34_public"``.
+
+    Yields:
+        None, with the family lock held.
+    """
+    loop = asyncio.get_running_loop()
+    per_loop = _family_locks.setdefault(loop, {})
+    key = f"{directory}::{family}"
+    lock = per_loop.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        per_loop[key] = lock
+    async with lock:
+        yield
+
 
 # Trailing timestamp produced by get_session_safe_filename ("%Y%m%d_%H%M%S%f")
 # and by the background ontology path ("%Y%m%d_%H%M%S"). Note it contains an

--- a/src/lifecycle/cleanup.py
+++ b/src/lifecycle/cleanup.py
@@ -16,16 +16,27 @@ logger = logging.getLogger(__name__)
 
 
 class DataCleanupManager:
-    # NOTE: this class mutates metadata.json directly via
-    # metadata_mgr.mark_version_deleted(), which bypasses the per-connection
-    # lock in lifecycle/metadata.py. That is safe only because the API is
-    # synchronous and nothing instantiates it today. Before calling it from an
-    # async path, route the write through mutate_workspace_metadata() -- an
-    # unserialized read-modify-write of metadata.json reproducibly drops other
-    # writers' sections. tests/test_metadata_concurrency.py exempts this file
-    # by name; remove that exemption at the same time.
-    """
-    Manages cleanup of old GraphRAG and RDF data based on retention policies.
+    """Manages cleanup of old GraphRAG and RDF data based on retention policies.
+
+    Currently unwired. This is the per-version retention design from Phase 3B,
+    whose entry points (``cleanup_all``, ``cleanup_all_connections``) were
+    removed as dead code once ``AUTO_CLEANUP_ON_STARTUP`` shipped separately in
+    ``server.py`` as simpler whole-workspace-age retention. Nothing instantiates
+    this class today.
+
+    .. warning::
+       Reviving it requires a concurrency fix first. The methods below mutate
+       metadata.json through ``metadata_mgr.mark_version_deleted()``, which
+       bypasses the per-connection lock in ``lifecycle/metadata.py``. That is
+       only harmless while the API stays synchronous and uncalled -- and the
+       original design invoked it from async paths (startup, post-analysis, and
+       an MCP tool), which is exactly where it would race. An unserialized
+       read-modify-write of metadata.json reproducibly drops other writers'
+       sections and can leave the file unparseable.
+
+       Route the writes through ``mutate_workspace_metadata()`` before calling
+       any of this from async code, and drop the matching exemption in
+       ``tests/test_metadata_concurrency.py`` at the same time.
     """
 
     def __init__(self, connection_id: str, output_dir: Path):

--- a/src/lifecycle/cleanup.py
+++ b/src/lifecycle/cleanup.py
@@ -16,6 +16,14 @@ logger = logging.getLogger(__name__)
 
 
 class DataCleanupManager:
+    # NOTE: this class mutates metadata.json directly via
+    # metadata_mgr.mark_version_deleted(), which bypasses the per-connection
+    # lock in lifecycle/metadata.py. That is safe only because the API is
+    # synchronous and nothing instantiates it today. Before calling it from an
+    # async path, route the write through mutate_workspace_metadata() -- an
+    # unserialized read-modify-write of metadata.json reproducibly drops other
+    # writers' sections. tests/test_metadata_concurrency.py exempts this file
+    # by name; remove that exemption at the same time.
     """
     Manages cleanup of old GraphRAG and RDF data based on retention policies.
     """

--- a/src/lifecycle/cleanup.py
+++ b/src/lifecycle/cleanup.py
@@ -6,10 +6,10 @@ based on retention policies.
 """
 
 import logging
-from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from ..utils import parse_timestamp, utc_now
 from .metadata import VersionMetadataManager
 
 logger = logging.getLogger(__name__)
@@ -71,9 +71,7 @@ class DataCleanupManager:
                         schema_name, version.version, "graphrag"
                     )
 
-                age_days = (
-                    datetime.now() - datetime.fromisoformat(version.created_at)
-                ).days
+                age_days = (utc_now() - parse_timestamp(version.created_at)).days
 
                 deleted.append(
                     {
@@ -145,9 +143,7 @@ class DataCleanupManager:
                         schema_name, version.version, "ontology"
                     )
 
-                age_days = (
-                    datetime.now() - datetime.fromisoformat(version.created_at)
-                ).days
+                age_days = (utc_now() - parse_timestamp(version.created_at)).days
 
                 deleted.append(
                     {

--- a/src/lifecycle/metadata.py
+++ b/src/lifecycle/metadata.py
@@ -404,6 +404,7 @@ class VersionMetadataManager:
         schema_name: str,
         section: str,
         data: dict[str, Any],
+        merge: bool = False,
     ) -> None:
         """Update a workspace section for a schema.
 
@@ -411,6 +412,11 @@ class VersionMetadataManager:
             schema_name: Database schema name (e.g. "public")
             section: Section key ("schema", "ontology", "graphrag")
             data: Section data dict
+            merge: Update the existing section in place instead of replacing
+                it. Use this for follow-up writes that only report on part of
+                the section -- replacing would re-stamp fields the caller did
+                not intend to own, such as an ontology_file that a later
+                request has already superseded.
         """
         if "workspace" not in self.metadata:
             self.metadata["workspace"] = {
@@ -423,7 +429,10 @@ class VersionMetadataManager:
         if schema_name not in workspace.get("schemas", {}):
             workspace.setdefault("schemas", {})[schema_name] = {}
 
-        workspace["schemas"][schema_name][section] = data
+        if merge:
+            workspace["schemas"][schema_name].setdefault(section, {}).update(data)
+        else:
+            workspace["schemas"][schema_name][section] = data
         workspace["updated_at"] = utc_now().isoformat()
 
         self._save_metadata()
@@ -526,6 +535,7 @@ async def update_workspace_section(
     schema_name: str,
     section: str,
     data: dict[str, Any],
+    merge: bool = False,
 ) -> None:
     """Thread-safe workspace section update with per-connection locking.
 
@@ -543,7 +553,7 @@ async def update_workspace_section(
     await mutate_workspace_metadata(
         connection_id,
         output_dir,
-        lambda mgr: mgr.update_workspace(schema_name, section, data),
+        lambda mgr: mgr.update_workspace(schema_name, section, data, merge=merge),
     )
 
 

--- a/src/lifecycle/metadata.py
+++ b/src/lifecycle/metadata.py
@@ -40,6 +40,13 @@ logger = logging.getLogger(__name__)
 _metadata_locks: "weakref.WeakKeyDictionary[Any, dict[str, asyncio.Lock]]" = (
     weakref.WeakKeyDictionary()
 )
+#
+# Neither registry is evicted. Keys are connection fingerprints (a truncated
+# sha256 of type/host/port/database/schema), so the count is bounded by the
+# distinct databases this server connects to, at roughly 100 bytes each. Adding
+# eviction would risk handing two writers different locks for one connection --
+# reintroducing precisely the race these exist to prevent -- for a saving of
+# well under a megabyte. Left deliberately.
 _metadata_thread_locks: dict[str, threading.Lock] = {}
 _thread_lock_registry_guard = threading.Lock()
 
@@ -485,13 +492,16 @@ async def mutate_workspace_metadata(
     cycle, not just the save: the per-loop asyncio lock, and the process-wide
     threading lock that actually provides mutual exclusion between event loops.
 
-    Scope: this serializes writers **within one process**. Two server processes
-    sharing an OUTPUT_DIR are not serialized against each other. The save itself
-    is atomic (unique temp file plus os.replace), so a cross-process race cannot
-    corrupt or tear metadata.json -- but it can still lose an update, because
-    the loser wrote from a stale read. Serializing across processes would need a
-    file lock; that is not implemented, since the supported deployment is one
-    server per output directory.
+    Scope: this serializes writers **within one process**, which is sufficient
+    because two processes cannot share an OUTPUT_DIR in the first place --
+    Oxigraph's store is RocksDB-backed and takes an exclusive OS lock on its
+    directory, so a second server fails to open it outright ("IO error: While
+    lock file"). A cross-process file lock here would guard metadata.json while
+    the RDF store remained unusable, so it is deliberately not implemented.
+
+    The save is atomic regardless (unique temp file plus os.replace), so even an
+    unexpected concurrent writer cannot corrupt or tear metadata.json -- the
+    worst case is a lost update from a stale read.
 
     Args:
         connection_id: Database connection fingerprint.

--- a/src/lifecycle/metadata.py
+++ b/src/lifecycle/metadata.py
@@ -405,10 +405,18 @@ async def update_workspace_section(
         section: Section key ("schema", "ontology", "graphrag")
         data: Section data dict
     """
+
+    def _update() -> None:
+        VersionMetadataManager(connection_id, output_dir).update_workspace(
+            schema_name, section, data
+        )
+
     lock = _metadata_locks.setdefault(connection_id, asyncio.Lock())
     async with lock:
-        mgr = VersionMetadataManager(connection_id, output_dir)
-        mgr.update_workspace(schema_name, section, data)
+        # Read-modify-write of metadata.json is blocking; run it off the loop so
+        # a large workspace does not stall every other session -- and so the lock
+        # above is not held by a thread that is busy doing disk I/O.
+        await asyncio.to_thread(_update)
 
 
 async def update_workspace_rdf(
@@ -423,7 +431,12 @@ async def update_workspace_rdf(
         output_dir: Base output directory
         data: RDF store state dict
     """
+
+    def _update() -> None:
+        VersionMetadataManager(connection_id, output_dir).update_workspace_rdf_store(
+            data
+        )
+
     lock = _metadata_locks.setdefault(connection_id, asyncio.Lock())
     async with lock:
-        mgr = VersionMetadataManager(connection_id, output_dir)
-        mgr.update_workspace_rdf_store(data)
+        await asyncio.to_thread(_update)

--- a/src/lifecycle/metadata.py
+++ b/src/lifecycle/metadata.py
@@ -11,6 +11,8 @@ import contextlib
 import json
 import logging
 import os
+import tempfile
+import threading
 import weakref
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
@@ -21,19 +23,29 @@ from ..utils import parse_timestamp, utc_now
 
 logger = logging.getLogger(__name__)
 
-# Locks serializing concurrent metadata writes, keyed by event loop and then by
-# connection. Keyed by loop because an asyncio.Lock binds to whichever loop first
-# awaits it and raises RuntimeError if reused from another -- and this process
-# does run more than one loop (see get_registered_tool_names in main.py, which
-# calls asyncio.run). A WeakKeyDictionary also means a finished loop's locks are
-# collected instead of accumulating for the process lifetime.
+# Metadata writes are serialized in two tiers, because neither lock type alone
+# is sufficient.
+#
+# Tier 1 -- asyncio.Lock, per (event loop, connection). An asyncio.Lock binds to
+# whichever loop first awaits it and raises RuntimeError if reused from another,
+# and this process does run more than one loop (get_registered_tool_names in
+# main.py calls asyncio.run), so these cannot be shared across loops. Their job
+# is to keep a single loop from queueing many worker threads on the same file.
+# The WeakKeyDictionary lets a finished loop's locks be collected.
+#
+# Tier 2 -- threading.Lock, per connection, process-wide, taken inside the
+# worker thread. This is what actually guarantees mutual exclusion: tier 1 locks
+# in different loops know nothing about each other, so without this two loops
+# would read-modify-write the same metadata.json concurrently and lose updates.
 _metadata_locks: "weakref.WeakKeyDictionary[Any, dict[str, asyncio.Lock]]" = (
     weakref.WeakKeyDictionary()
 )
+_metadata_thread_locks: dict[str, threading.Lock] = {}
+_thread_lock_registry_guard = threading.Lock()
 
 
 def _get_metadata_lock(connection_id: str) -> asyncio.Lock:
-    """Return the write lock for *connection_id* on the running event loop.
+    """Return the per-loop write lock for *connection_id*.
 
     Args:
         connection_id: Database connection fingerprint.
@@ -48,6 +60,26 @@ def _get_metadata_lock(connection_id: str) -> asyncio.Lock:
         lock = asyncio.Lock()
         per_loop[connection_id] = lock
     return lock
+
+
+def _get_metadata_thread_lock(connection_id: str) -> threading.Lock:
+    """Return the process-wide write lock for *connection_id*.
+
+    Held inside the worker thread so writers on different event loops -- whose
+    asyncio locks are independent -- still serialize against each other.
+
+    Args:
+        connection_id: Database connection fingerprint.
+
+    Returns:
+        A threading.Lock shared by every writer in this process.
+    """
+    with _thread_lock_registry_guard:
+        lock = _metadata_thread_locks.get(connection_id)
+        if lock is None:
+            lock = threading.Lock()
+            _metadata_thread_locks[connection_id] = lock
+        return lock
 
 
 @dataclass
@@ -147,11 +179,16 @@ class VersionMetadataManager:
         JSON unparseable ("Extra data"). Readers now see either the old file or
         the new one, never a mixture.
         """
-        tmp_file = self.metadata_file.with_name(
-            f"{self.metadata_file.name}.{os.getpid()}.tmp"
+        # mkstemp gives every writer its own temp path. A shared name (e.g. one
+        # derived from the pid) means concurrent writers replace and unlink each
+        # other's file, which produced a storm of "No such file or directory"
+        # failures and lost nearly every update.
+        fd, tmp_name = tempfile.mkstemp(
+            dir=self.connection_dir, prefix="metadata.json.", suffix=".tmp"
         )
+        tmp_file = Path(tmp_name)
         try:
-            with open(tmp_file, "w") as f:
+            with os.fdopen(fd, "w") as f:
                 json.dump(self.metadata, f, indent=2)
                 f.flush()
                 os.fsync(f.fileno())
@@ -444,8 +481,17 @@ async def mutate_workspace_metadata(
     into an unparseable file. Both were reproducible before this existed.
 
     The mutation runs in a worker thread -- the file can be large and the loop
-    must not stall -- with the per-connection asyncio lock held across the whole
-    load/modify/save cycle, not just the save.
+    must not stall -- under two locks held across the whole load/modify/save
+    cycle, not just the save: the per-loop asyncio lock, and the process-wide
+    threading lock that actually provides mutual exclusion between event loops.
+
+    Scope: this serializes writers **within one process**. Two server processes
+    sharing an OUTPUT_DIR are not serialized against each other. The save itself
+    is atomic (unique temp file plus os.replace), so a cross-process race cannot
+    corrupt or tear metadata.json -- but it can still lose an update, because
+    the loser wrote from a stale read. Serializing across processes would need a
+    file lock; that is not implemented, since the supported deployment is one
+    server per output directory.
 
     Args:
         connection_id: Database connection fingerprint.
@@ -455,7 +501,10 @@ async def mutate_workspace_metadata(
     """
 
     def _apply() -> None:
-        mutate(VersionMetadataManager(connection_id, output_dir))
+        # Process-wide lock, held for the whole load/modify/save cycle. The
+        # asyncio lock below only covers writers on this event loop.
+        with _get_metadata_thread_lock(connection_id):
+            mutate(VersionMetadataManager(connection_id, output_dir))
 
     async with _get_metadata_lock(connection_id):
         await asyncio.to_thread(_apply)

--- a/src/lifecycle/metadata.py
+++ b/src/lifecycle/metadata.py
@@ -404,7 +404,6 @@ class VersionMetadataManager:
         schema_name: str,
         section: str,
         data: dict[str, Any],
-        merge: bool = False,
     ) -> None:
         """Update a workspace section for a schema.
 
@@ -412,11 +411,6 @@ class VersionMetadataManager:
             schema_name: Database schema name (e.g. "public")
             section: Section key ("schema", "ontology", "graphrag")
             data: Section data dict
-            merge: Update the existing section in place instead of replacing
-                it. Use this for follow-up writes that only report on part of
-                the section -- replacing would re-stamp fields the caller did
-                not intend to own, such as an ontology_file that a later
-                request has already superseded.
         """
         if "workspace" not in self.metadata:
             self.metadata["workspace"] = {
@@ -429,10 +423,7 @@ class VersionMetadataManager:
         if schema_name not in workspace.get("schemas", {}):
             workspace.setdefault("schemas", {})[schema_name] = {}
 
-        if merge:
-            workspace["schemas"][schema_name].setdefault(section, {}).update(data)
-        else:
-            workspace["schemas"][schema_name][section] = data
+        workspace["schemas"][schema_name][section] = data
         workspace["updated_at"] = utc_now().isoformat()
 
         self._save_metadata()
@@ -535,7 +526,6 @@ async def update_workspace_section(
     schema_name: str,
     section: str,
     data: dict[str, Any],
-    merge: bool = False,
 ) -> None:
     """Thread-safe workspace section update with per-connection locking.
 
@@ -553,8 +543,60 @@ async def update_workspace_section(
     await mutate_workspace_metadata(
         connection_id,
         output_dir,
-        lambda mgr: mgr.update_workspace(schema_name, section, data, merge=merge),
+        lambda mgr: mgr.update_workspace(schema_name, section, data),
     )
+
+
+async def mark_ontology_persisted(
+    connection_id: str,
+    output_dir: Path,
+    schema_name: str,
+    ontology_file: str,
+    graph_uri: str,
+) -> bool:
+    """Flag an ontology as persisted to RDF, only while it is still current.
+
+    The RDF load happens outside the artifact family lock -- it is expensive,
+    and holding the lock across it would serialize generation for the schema.
+    That leaves a window: two overlapping generate_ontology calls can record
+    A.ttl then B.ttl, and A's slower auto-persist can land last. A blind merge
+    would then mark B.ttl as persisted on the strength of A's RDF load.
+
+    So the check and the write happen together under the metadata lock: the
+    flag is set only if the recorded ontology_file is still the generation that
+    was actually loaded.
+
+    Args:
+        connection_id: Database connection fingerprint.
+        output_dir: Base output directory.
+        schema_name: Schema whose ontology section to update.
+        ontology_file: The generation this caller persisted.
+        graph_uri: Named graph it was loaded into.
+
+    Returns:
+        True if the flag was set, False if a newer generation had superseded
+        this one.
+    """
+    applied = False
+
+    def _mutate(mgr: VersionMetadataManager) -> None:
+        nonlocal applied
+        section = (
+            mgr.metadata.get("workspace", {})
+            .get("schemas", {})
+            .get(schema_name, {})
+            .get("ontology")
+        )
+        if not section or section.get("ontology_file") != ontology_file:
+            return
+        section["graph_uri"] = graph_uri
+        section["persisted_to_rdf"] = True
+        mgr.metadata["workspace"]["updated_at"] = utc_now().isoformat()
+        mgr._save_metadata()
+        applied = True
+
+    await mutate_workspace_metadata(connection_id, output_dir, _mutate)
+    return applied
 
 
 async def update_workspace_rdf(

--- a/src/lifecycle/metadata.py
+++ b/src/lifecycle/metadata.py
@@ -10,9 +10,10 @@ import asyncio
 import json
 import logging
 from dataclasses import asdict, dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import Any
+
+from ..utils import parse_timestamp, utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -245,11 +246,11 @@ class VersionMetadataManager:
         to_check = sorted_versions[:-keep_count]  # Exclude latest N
 
         # Check age
-        now = datetime.now()
+        now = utc_now()
         to_delete = []
 
         for version in to_check:
-            created = datetime.fromisoformat(version.created_at)
+            created = parse_timestamp(version.created_at)
             age_days = (now - created).days
 
             if age_days > max_age_days:
@@ -324,7 +325,7 @@ class VersionMetadataManager:
         """
         if "workspace" not in self.metadata:
             self.metadata["workspace"] = {
-                "updated_at": datetime.now().isoformat(),
+                "updated_at": utc_now().isoformat(),
                 "schemas": {},
             }
 
@@ -334,7 +335,7 @@ class VersionMetadataManager:
             workspace.setdefault("schemas", {})[schema_name] = {}
 
         workspace["schemas"][schema_name][section] = data
-        workspace["updated_at"] = datetime.now().isoformat()
+        workspace["updated_at"] = utc_now().isoformat()
 
         self._save_metadata()
         logger.debug(
@@ -355,14 +356,14 @@ class VersionMetadataManager:
         """
         if "workspace" not in self.metadata:
             self.metadata["workspace"] = {
-                "updated_at": datetime.now().isoformat(),
+                "updated_at": utc_now().isoformat(),
                 "schemas": {},
             }
 
         workspace = self.metadata["workspace"]
         workspace["db_type"] = db_type
         workspace["db_name"] = db_name
-        workspace["updated_at"] = datetime.now().isoformat()
+        workspace["updated_at"] = utc_now().isoformat()
 
         self._save_metadata()
 
@@ -374,12 +375,12 @@ class VersionMetadataManager:
         """
         if "workspace" not in self.metadata:
             self.metadata["workspace"] = {
-                "updated_at": datetime.now().isoformat(),
+                "updated_at": utc_now().isoformat(),
                 "schemas": {},
             }
 
         self.metadata["workspace"]["rdf_store"] = data
-        self.metadata["workspace"]["updated_at"] = datetime.now().isoformat()
+        self.metadata["workspace"]["updated_at"] = utc_now().isoformat()
 
         self._save_metadata()
         logger.debug(f"Updated workspace.rdf_store (connection {self.connection_id})")

--- a/src/lifecycle/metadata.py
+++ b/src/lifecycle/metadata.py
@@ -547,6 +547,47 @@ async def update_workspace_section(
     )
 
 
+async def ontology_is_current(
+    connection_id: str,
+    output_dir: Path,
+    schema_name: str,
+    ontology_file: str,
+) -> bool:
+    """True if *ontology_file* is still the generation metadata records.
+
+    Checked before loading into the RDF store, not only before flipping the
+    persisted flag. load_ontology() replaces the schema's named graph, so a
+    stale request that got as far as loading would overwrite a newer
+    generation's triples -- and guarding only the flag left exactly that hole:
+    the flag stayed honest while the graph held the wrong ontology.
+
+    Args:
+        connection_id: Database connection fingerprint.
+        output_dir: Base output directory.
+        schema_name: Schema to check.
+        ontology_file: The generation the caller holds.
+
+    Returns:
+        True if the caller's generation is still current.
+    """
+
+    def _read() -> bool:
+        mgr = VersionMetadataManager(connection_id, output_dir)
+        section = (
+            mgr.metadata.get("workspace", {})
+            .get("schemas", {})
+            .get(schema_name, {})
+            .get("ontology")
+        )
+        # Nothing recorded yet means this caller is the first -- proceed.
+        if not section or "ontology_file" not in section:
+            return True
+        return bool(section["ontology_file"] == ontology_file)
+
+    async with _get_metadata_lock(connection_id):
+        return await asyncio.to_thread(_read)
+
+
 async def mark_ontology_persisted(
     connection_id: str,
     output_dir: Path,

--- a/src/lifecycle/metadata.py
+++ b/src/lifecycle/metadata.py
@@ -7,8 +7,12 @@ Also manages workspace state for session restore across reconnections.
 """
 
 import asyncio
+import contextlib
 import json
 import logging
+import os
+import weakref
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
@@ -17,8 +21,33 @@ from ..utils import parse_timestamp, utc_now
 
 logger = logging.getLogger(__name__)
 
-# Module-level lock dict for serializing concurrent metadata writes per connection
-_metadata_locks: dict[str, asyncio.Lock] = {}
+# Locks serializing concurrent metadata writes, keyed by event loop and then by
+# connection. Keyed by loop because an asyncio.Lock binds to whichever loop first
+# awaits it and raises RuntimeError if reused from another -- and this process
+# does run more than one loop (see get_registered_tool_names in main.py, which
+# calls asyncio.run). A WeakKeyDictionary also means a finished loop's locks are
+# collected instead of accumulating for the process lifetime.
+_metadata_locks: "weakref.WeakKeyDictionary[Any, dict[str, asyncio.Lock]]" = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def _get_metadata_lock(connection_id: str) -> asyncio.Lock:
+    """Return the write lock for *connection_id* on the running event loop.
+
+    Args:
+        connection_id: Database connection fingerprint.
+
+    Returns:
+        An asyncio.Lock scoped to the current loop and connection.
+    """
+    loop = asyncio.get_running_loop()
+    per_loop = _metadata_locks.setdefault(loop, {})
+    lock = per_loop.get(connection_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        per_loop[connection_id] = lock
+    return lock
 
 
 @dataclass
@@ -109,13 +138,29 @@ class VersionMetadataManager:
         }
 
     def _save_metadata(self) -> None:
-        """Save metadata to disk."""
+        """Save metadata to disk atomically.
+
+        Written to a sibling temp file and moved into place with os.replace,
+        which is atomic on POSIX and Windows. A plain open(..., "w") truncates
+        first, so a concurrent or interrupted write leaves a torn file -- in
+        practice a short write over a longer one, whose leftover tail makes the
+        JSON unparseable ("Extra data"). Readers now see either the old file or
+        the new one, never a mixture.
+        """
+        tmp_file = self.metadata_file.with_name(
+            f"{self.metadata_file.name}.{os.getpid()}.tmp"
+        )
         try:
-            with open(self.metadata_file, "w") as f:
+            with open(tmp_file, "w") as f:
                 json.dump(self.metadata, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_file, self.metadata_file)
             logger.debug(f"Saved metadata for connection {self.connection_id}")
         except Exception as e:
             logger.error(f"Failed to save metadata: {e}")
+            with contextlib.suppress(OSError):
+                tmp_file.unlink()
 
     def get_schema_metadata(self, schema_name: str) -> dict[str, Any] | None:
         """Get metadata for a specific schema."""
@@ -386,6 +431,36 @@ class VersionMetadataManager:
         logger.debug(f"Updated workspace.rdf_store (connection {self.connection_id})")
 
 
+async def mutate_workspace_metadata(
+    connection_id: str,
+    output_dir: Path,
+    mutate: Callable[["VersionMetadataManager"], None],
+) -> None:
+    """Run a metadata.json read-modify-write serialized per connection, off-loop.
+
+    Every writer must go through here. metadata.json is a single file holding
+    all workspace sections, so two unserialized read-modify-write cycles either
+    drop one another's section (last writer wins on a stale read) or interleave
+    into an unparseable file. Both were reproducible before this existed.
+
+    The mutation runs in a worker thread -- the file can be large and the loop
+    must not stall -- with the per-connection asyncio lock held across the whole
+    load/modify/save cycle, not just the save.
+
+    Args:
+        connection_id: Database connection fingerprint.
+        output_dir: Base output directory (usually OUTPUT_DIR).
+        mutate: Callback applied to a freshly loaded manager. It is responsible
+            for persisting, which every ``update_*`` method already does.
+    """
+
+    def _apply() -> None:
+        mutate(VersionMetadataManager(connection_id, output_dir))
+
+    async with _get_metadata_lock(connection_id):
+        await asyncio.to_thread(_apply)
+
+
 async def update_workspace_section(
     connection_id: str,
     output_dir: Path,
@@ -406,17 +481,11 @@ async def update_workspace_section(
         data: Section data dict
     """
 
-    def _update() -> None:
-        VersionMetadataManager(connection_id, output_dir).update_workspace(
-            schema_name, section, data
-        )
-
-    lock = _metadata_locks.setdefault(connection_id, asyncio.Lock())
-    async with lock:
-        # Read-modify-write of metadata.json is blocking; run it off the loop so
-        # a large workspace does not stall every other session -- and so the lock
-        # above is not held by a thread that is busy doing disk I/O.
-        await asyncio.to_thread(_update)
+    await mutate_workspace_metadata(
+        connection_id,
+        output_dir,
+        lambda mgr: mgr.update_workspace(schema_name, section, data),
+    )
 
 
 async def update_workspace_rdf(
@@ -432,11 +501,8 @@ async def update_workspace_rdf(
         data: RDF store state dict
     """
 
-    def _update() -> None:
-        VersionMetadataManager(connection_id, output_dir).update_workspace_rdf_store(
-            data
-        )
-
-    lock = _metadata_locks.setdefault(connection_id, asyncio.Lock())
-    async with lock:
-        await asyncio.to_thread(_update)
+    await mutate_workspace_metadata(
+        connection_id,
+        output_dir,
+        lambda mgr: mgr.update_workspace_rdf_store(data),
+    )

--- a/src/oxigraph_store.py
+++ b/src/oxigraph_store.py
@@ -45,6 +45,11 @@ logger = logging.getLogger(__name__)
 # find (see issue: graph-URI mismatch).
 SCHEMA_GRAPH_PREFIX = "http://example.com/schema/"
 
+# Private namespace for the transient graphs load_ontology() stages replacements
+# in. Deliberately unrelated to any caller-supplied graph URI: deriving it from
+# one produced invalid IRIs for URIs that already contained a fragment.
+_STAGING_IRI_PREFIX = "urn:orionbelt:staging:"
+
 
 def schema_graph_uri(schema_name: str) -> str:
     """Return the canonical named-graph URI for a schema's RDF.
@@ -161,7 +166,15 @@ class OxigraphStoreManager:
         """
         try:
             target = NamedNode(graph_uri)
-            staging = NamedNode(f"{graph_uri}#__staging_{uuid4().hex}")
+            # Staging IRI comes from a private URN namespace rather than being
+            # derived from graph_uri. Appending "#..." to the caller's URI
+            # produced a second fragment for any graph URI that already had one
+            # -- e.g. http://example.com/schema#public, which is perfectly valid
+            # and reachable through the user-facing graph_uri tool parameter --
+            # and pyoxigraph rejects that with "Invalid IRI code point '#'".
+            # A uuid alone gives the uniqueness staging needs; the name never
+            # escapes this method.
+            staging = NamedNode(f"{_STAGING_IRI_PREFIX}{uuid4().hex}")
 
             def _clear(graph: NamedNode) -> None:
                 """Remove a graph's quads, leaving the graph itself in place."""

--- a/src/oxigraph_store.py
+++ b/src/oxigraph_store.py
@@ -182,7 +182,7 @@ class OxigraphStoreManager:
             return triples_loaded
 
         except Exception as e:
-            logger.error(f"Failed to load ontology: {e}", exc_info=True)
+            logger.exception(f"Failed to load ontology: {e}")
             raise
 
     def query_sparql(
@@ -278,7 +278,7 @@ class OxigraphStoreManager:
             return results
 
         except Exception as e:
-            logger.error(f"SPARQL query failed: {e}", exc_info=True)
+            logger.exception(f"SPARQL query failed: {e}")
             raise
 
     def query_sparql_ask(self, sparql_query: str) -> bool:
@@ -307,7 +307,7 @@ class OxigraphStoreManager:
             # (older versions); both support bool().
             return bool(self.store.query(sparql_query))
         except Exception as e:
-            logger.error(f"SPARQL ASK query failed: {e}", exc_info=True)
+            logger.exception(f"SPARQL ASK query failed: {e}")
             raise
 
     def query_sparql_construct(self, sparql_query: str) -> str:
@@ -343,7 +343,7 @@ class OxigraphStoreManager:
             serialized = results.serialize(format=RdfFormat.TURTLE)
             return serialized.decode("utf-8") if serialized is not None else ""
         except Exception as e:
-            logger.error(f"SPARQL CONSTRUCT query failed: {e}", exc_info=True)
+            logger.exception(f"SPARQL CONSTRUCT query failed: {e}")
             raise
 
     def add_triple(
@@ -388,7 +388,7 @@ class OxigraphStoreManager:
             logger.debug(f"Added triple: <{subject}> <{predicate}> {object}")
 
         except Exception as e:
-            logger.error(f"Failed to add triple: {e}", exc_info=True)
+            logger.exception(f"Failed to add triple: {e}")
             raise
 
     def add_knowledge(
@@ -445,7 +445,7 @@ class OxigraphStoreManager:
             logger.info(f"Added knowledge: {subject} -> {predicate}")
 
         except Exception as e:
-            logger.error(f"Failed to add knowledge: {e}", exc_info=True)
+            logger.exception(f"Failed to add knowledge: {e}")
             raise
 
     def get_ontology_stats(self, graph_uri: str | None = None) -> dict[str, Any]:
@@ -495,7 +495,7 @@ class OxigraphStoreManager:
                 }
 
         except Exception as e:
-            logger.error(f"Failed to get stats: {e}", exc_info=True)
+            logger.exception(f"Failed to get stats: {e}")
             return {"error": str(e)}
 
     def list_tables_sparql(self, schema_graph: str) -> list[str]:
@@ -605,7 +605,7 @@ class OxigraphStoreManager:
             }
             logger.info(f"Deleted named graph <{graph_uri}>")
         except Exception as e:
-            logger.error(f"Failed to delete graph {graph_uri}: {e}", exc_info=True)
+            logger.exception(f"Failed to delete graph {graph_uri}: {e}")
             raise
 
     def close(self) -> None:

--- a/src/oxigraph_store.py
+++ b/src/oxigraph_store.py
@@ -5,10 +5,12 @@ Provides persistent RDF storage with SPARQL 1.1 query support using Oxigraph.
 Stores ontologies, schema metadata, and accumulated knowledge across sessions.
 """
 
+import contextlib
 import logging
 import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
+from uuid import uuid4
 
 if TYPE_CHECKING:
     from pyoxigraph import (
@@ -137,6 +139,14 @@ class OxigraphStoreManager:
         schema's current ontology, so loading a new generation must supersede
         the old one.
 
+        The replacement is staged. Clearing the target first meant a malformed
+        TTL destroyed the last good ontology: the clear had already happened
+        when the parser raised, leaving the graph empty and SPARQL answering
+        nothing. So the new data is parsed into a temporary graph and swapped
+        in only once it has loaded successfully -- a failed load leaves the
+        previous generation exactly as it was. pyoxigraph's Store has no
+        transaction API, so this is the available approximation.
+
         Args:
             ontology_ttl: Ontology in Turtle format
             graph_uri: Named graph URI for this ontology
@@ -144,51 +154,80 @@ class OxigraphStoreManager:
 
         Returns:
             Number of triples in the graph after loading.
+
+        Raises:
+            Exception: Whatever the parser raises for malformed input. The
+                existing graph is left untouched in that case.
         """
         try:
             target = NamedNode(graph_uri)
+            staging = NamedNode(f"{graph_uri}#__staging_{uuid4().hex}")
 
-            # Drop the previous generation before loading this one.
-            existing = list(self.store.quads_for_pattern(None, None, None, target))
-            for quad in existing:
-                self.store.remove(quad)
-            if existing:
-                logger.debug(
-                    f"Replaced {len(existing)} triple(s) in graph <{graph_uri}>"
-                )
+            def _clear(graph: NamedNode) -> None:
+                """Remove a graph's quads, leaving the graph itself in place."""
+                for quad in list(self.store.quads_for_pattern(None, None, None, graph)):
+                    self.store.remove(quad)
 
-            # Use RdfFormat.TURTLE for newer versions, fall back to strings for older versions
+            def _drop_staging() -> None:
+                """Remove the staging graph entirely.
+
+                Emptying it is not enough: pyoxigraph tracks graph existence
+                separately from its contents, so a cleared staging graph still
+                appears in named_graphs() and one would accumulate per load.
+                """
+                _clear(staging)
+                with contextlib.suppress(Exception):
+                    self.store.remove_graph(staging)
+
+            # Parse into staging first; a failure here must not touch target.
             try:
-                # Try with RdfFormat object (pyoxigraph >= 0.4.0)
-                self.store.load(
-                    ontology_ttl.encode("utf-8"),
-                    format=RdfFormat.TURTLE,
-                    base_iri=graph_uri,
-                    to_graph=target,
-                )
-            except (TypeError, AttributeError):
-                # Fallback for older pyoxigraph versions
+                # Use RdfFormat.TURTLE for newer versions, fall back to strings
+                # for older versions
                 try:
+                    # Try with RdfFormat object (pyoxigraph >= 0.4.0)
                     self.store.load(
                         ontology_ttl.encode("utf-8"),
-                        format="text/turtle",  # type: ignore[arg-type]
+                        format=RdfFormat.TURTLE,
                         base_iri=graph_uri,
-                        to_graph=target,
+                        to_graph=staging,
                     )
-                except TypeError:
-                    # Final fallback for very old versions using mime_type
-                    self.store.load(  # type: ignore[call-arg]
-                        ontology_ttl.encode("utf-8"),
-                        mime_type="text/turtle",
-                        base_iri=graph_uri,
-                        to_graph=target,
-                    )
+                except (TypeError, AttributeError):
+                    # Fallback for older pyoxigraph versions
+                    try:
+                        self.store.load(
+                            ontology_ttl.encode("utf-8"),
+                            format="text/turtle",  # type: ignore[arg-type]
+                            base_iri=graph_uri,
+                            to_graph=staging,
+                        )
+                    except TypeError:
+                        # Final fallback for very old versions using mime_type
+                        self.store.load(  # type: ignore[call-arg]
+                            ontology_ttl.encode("utf-8"),
+                            mime_type="text/turtle",
+                            base_iri=graph_uri,
+                            to_graph=staging,
+                        )
+            except Exception:
+                _drop_staging()
+                logger.warning(
+                    f"Ontology load failed for graph <{graph_uri}>; "
+                    "previous generation left in place"
+                )
+                raise
 
-            # Count the graph, not the store delta: a replacement can shrink
-            # the store, and the old delta reported 0 for an unchanged reload.
-            triples_loaded = sum(
-                1 for _ in self.store.quads_for_pattern(None, None, None, target)
-            )
+            # Swap: the new generation parsed cleanly, so it may supersede.
+            staged = list(self.store.quads_for_pattern(None, None, None, staging))
+            try:
+                _clear(target)
+                for quad in staged:
+                    self.store.add(
+                        Quad(quad.subject, quad.predicate, quad.object, target)
+                    )
+            finally:
+                _drop_staging()
+
+            triples_loaded = len(staged)
 
             self._loaded_ontologies[schema_name] = graph_uri
 

--- a/src/oxigraph_store.py
+++ b/src/oxigraph_store.py
@@ -130,17 +130,32 @@ class OxigraphStoreManager:
         """
         Load ontology into the store.
 
+        The named graph is **replaced**, not appended to. store.load() unions
+        into the target graph, so repeated generations accumulated: regenerate
+        after dropping a table and the dropped table stayed queryable forever,
+        because nothing ever removed its triples. A named graph represents one
+        schema's current ontology, so loading a new generation must supersede
+        the old one.
+
         Args:
             ontology_ttl: Ontology in Turtle format
             graph_uri: Named graph URI for this ontology
             schema_name: Schema identifier
 
         Returns:
-            Number of triples loaded
+            Number of triples in the graph after loading.
         """
         try:
-            # Parse and load into named graph
-            triples_before = len(self.store)
+            target = NamedNode(graph_uri)
+
+            # Drop the previous generation before loading this one.
+            existing = list(self.store.quads_for_pattern(None, None, None, target))
+            for quad in existing:
+                self.store.remove(quad)
+            if existing:
+                logger.debug(
+                    f"Replaced {len(existing)} triple(s) in graph <{graph_uri}>"
+                )
 
             # Use RdfFormat.TURTLE for newer versions, fall back to strings for older versions
             try:
@@ -149,7 +164,7 @@ class OxigraphStoreManager:
                     ontology_ttl.encode("utf-8"),
                     format=RdfFormat.TURTLE,
                     base_iri=graph_uri,
-                    to_graph=NamedNode(graph_uri),
+                    to_graph=target,
                 )
             except (TypeError, AttributeError):
                 # Fallback for older pyoxigraph versions
@@ -158,7 +173,7 @@ class OxigraphStoreManager:
                         ontology_ttl.encode("utf-8"),
                         format="text/turtle",  # type: ignore[arg-type]
                         base_iri=graph_uri,
-                        to_graph=NamedNode(graph_uri),
+                        to_graph=target,
                     )
                 except TypeError:
                     # Final fallback for very old versions using mime_type
@@ -166,11 +181,14 @@ class OxigraphStoreManager:
                         ontology_ttl.encode("utf-8"),
                         mime_type="text/turtle",
                         base_iri=graph_uri,
-                        to_graph=NamedNode(graph_uri),
+                        to_graph=target,
                     )
 
-            triples_after = len(self.store)
-            triples_loaded = triples_after - triples_before
+            # Count the graph, not the store delta: a replacement can shrink
+            # the store, and the old delta reported 0 for an unchanged reload.
+            triples_loaded = sum(
+                1 for _ in self.store.quads_for_pattern(None, None, None, target)
+            )
 
             self._loaded_ontologies[schema_name] = graph_uri
 

--- a/src/paths.py
+++ b/src/paths.py
@@ -12,8 +12,57 @@ from .constants import DEFAULT_OUTPUT_DIR
 # Project root: parent of the src/ directory
 PROJECT_ROOT = Path(__file__).parent.parent
 
+
+def _resolve_output_dir() -> Path:
+    """Resolve OUTPUT_DIR, refusing values that would make cleanup destructive.
+
+    Startup cleanup deletes loose files directly under this directory, and with
+    AUTO_CLEANUP_ON_STARTUP=true it removes every subdirectory lacking a
+    metadata.json. That is safe for a dedicated output directory and
+    catastrophic for anything else: pathlib collapses "" and "." onto
+    PROJECT_ROOT, so a blanked-out ``OUTPUT_DIR=`` in .env would target the
+    installation itself -- unlinking .env and pyproject.toml, then removing
+    src/, tests/ and .git/.
+
+    Rejected at import rather than defaulted, because silently substituting a
+    different directory than the operator configured is its own surprise.
+
+    Returns:
+        The configured output directory.
+
+    Raises:
+        ValueError: If the value is blank, or resolves to PROJECT_ROOT or any
+            of its parents.
+    """
+    raw = os.getenv("OUTPUT_DIR")
+    if raw is None:
+        return PROJECT_ROOT / DEFAULT_OUTPUT_DIR
+
+    if not raw.strip():
+        raise ValueError(
+            "OUTPUT_DIR is set but empty. Remove it to use the default "
+            f"('{DEFAULT_OUTPUT_DIR}') or give it a real path; an empty value "
+            "resolves to the project root, which startup cleanup would delete."
+        )
+
+    candidate = Path(raw.strip())
+    if not candidate.is_absolute():
+        candidate = PROJECT_ROOT / candidate
+    resolved = candidate.resolve()
+    root = PROJECT_ROOT.resolve()
+
+    if resolved == root or resolved in root.parents:
+        raise ValueError(
+            f"OUTPUT_DIR={raw!r} resolves to {resolved}, which contains the "
+            "installation. Startup cleanup deletes loose files and unrecognized "
+            "directories there. Point it at a dedicated directory such as "
+            f"'{DEFAULT_OUTPUT_DIR}' or '/var/lib/orionbelt'."
+        )
+    return resolved
+
+
 # Output directory for generated files (configurable via OUTPUT_DIR env var)
-OUTPUT_DIR = PROJECT_ROOT / os.getenv("OUTPUT_DIR", DEFAULT_OUTPUT_DIR)
+OUTPUT_DIR = _resolve_output_dir()
 
 # Directories directly under OUTPUT_DIR that are NOT per-connection workspaces.
 # They hold satellite stores keyed by connection one level deeper

--- a/src/paths.py
+++ b/src/paths.py
@@ -15,6 +15,14 @@ PROJECT_ROOT = Path(__file__).parent.parent
 # Output directory for generated files (configurable via OUTPUT_DIR env var)
 OUTPUT_DIR = PROJECT_ROOT / os.getenv("OUTPUT_DIR", DEFAULT_OUTPUT_DIR)
 
+# Directories directly under OUTPUT_DIR that are NOT per-connection workspaces.
+# They hold satellite stores keyed by connection one level deeper
+# (chromadb/{connection_id}, oxigraph/{connection_id}/store), plus the legacy
+# global Oxigraph store. Anything walking OUTPUT_DIR looking for workspaces must
+# skip these -- they have no metadata.json, so treating them as workspaces makes
+# them look orphaned and gets every connection's vectors and triples deleted.
+NON_WORKSPACE_DIRS = frozenset({"chromadb", "oxigraph", "oxigraph_store"})
+
 
 def ensure_output_dir() -> Path:
     """Get the output directory, creating it if needed."""
@@ -55,6 +63,25 @@ def get_oxigraph_store_dir(connection_id: str | None = None) -> Path:
         store_dir = OUTPUT_DIR / "oxigraph_store"
     store_dir.mkdir(parents=True, exist_ok=True)
     return store_dir
+
+
+def get_connection_store_dirs(connection_id: str) -> list[Path]:
+    """Satellite store directories belonging to a single connection.
+
+    These live outside the connection's workspace directory, so removing a
+    workspace does not remove them -- they have to be cleaned explicitly or the
+    vectors and triples for a deleted connection linger forever.
+
+    Args:
+        connection_id: Database connection fingerprint.
+
+    Returns:
+        Paths that may or may not exist, one per satellite store.
+    """
+    return [
+        OUTPUT_DIR / "chromadb" / connection_id,
+        OUTPUT_DIR / "oxigraph" / connection_id,
+    ]
 
 
 def get_connection_dir(connection_id: str) -> Path:

--- a/src/paths.py
+++ b/src/paths.py
@@ -74,8 +74,17 @@ NON_WORKSPACE_DIRS = frozenset({"chromadb", "oxigraph", "oxigraph_store"})
 
 
 def ensure_output_dir() -> Path:
-    """Get the output directory, creating it if needed."""
-    OUTPUT_DIR.mkdir(exist_ok=True)
+    """Get the output directory, creating it and any missing parents.
+
+    ``parents=True`` because OUTPUT_DIR may legitimately be nested (say
+    ``output/data`` or ``/var/lib/orionbelt/data``) -- the resolver accepts
+    those, so creation has to as well or a fresh deployment fails with
+    FileNotFoundError on the first write.
+
+    Returns:
+        The output directory, guaranteed to exist.
+    """
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     return OUTPUT_DIR
 
 

--- a/src/server_state.py
+++ b/src/server_state.py
@@ -14,7 +14,7 @@ import hashlib
 import json
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any, cast
 
 from fastmcp import Context
@@ -26,6 +26,7 @@ from .ontology_generator import OntologyGenerator
 from .oxigraph_store import OXIGRAPH_AVAILABLE, OxigraphStoreManager
 from .paths import ensure_output_dir, get_connection_dir, get_oxigraph_store_dir
 from .session import SessionData
+from .utils import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -216,7 +217,7 @@ class ServerState:
 
     def _evict_idle_sessions(self, idle_timeout: int) -> None:
         """Scan sessions and evict those idle beyond the timeout."""
-        now = datetime.now()
+        now = utc_now()
         cutoff = now - timedelta(seconds=idle_timeout)
 
         to_evict = []
@@ -314,7 +315,7 @@ def get_session_safe_filename(ctx: Context, prefix: str, suffix: str = "") -> st
         if session.connection_id and len(session.connection_id) >= 8
         else "default"
     )
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S%f")
+    timestamp = utc_now().strftime("%Y%m%d_%H%M%S%f")
     if suffix:
         return f"{prefix}_{connection_prefix}_{suffix}_{timestamp}"
     return f"{prefix}_{connection_prefix}_{timestamp}"

--- a/src/server_state.py
+++ b/src/server_state.py
@@ -145,42 +145,86 @@ class ServerState:
         """Create a new ontology generator instance."""
         return OntologyGenerator(base_uri=base_uri)
 
+    def _cancel_init_tasks(self, session_id: str) -> list["asyncio.Task[Any]"]:
+        """Request cancellation of a session's background init tasks.
+
+        Cancellation is only *scheduled* here -- a cancelled task keeps running
+        until it next reaches a suspension point. Callers that can await should
+        use :meth:`aclose_session`, which waits before tearing down the
+        resources those tasks are still touching.
+
+        Args:
+            session_id: Session whose tasks should be cancelled.
+
+        Returns:
+            The tasks that were still running, for the caller to await.
+        """
+        session = self._sessions.get(session_id)
+        if session is None:
+            return []
+
+        pending = [t for t in session.graphrag.init_tasks if not t.done()]
+        for task in pending:
+            task.cancel()
+        if pending:
+            logger.debug(
+                f"Cancelled {len(pending)} pending GraphRAG init task(s) "
+                f"for session {session_id}"
+            )
+        return pending
+
+    def _release_session(self, session_id: str) -> None:
+        """Close a session's resources and drop it. Assumes tasks are done."""
+        session = self._sessions.get(session_id)
+        if session is None:
+            return
+
+        if session.db_manager:
+            try:
+                session.db_manager.disconnect()
+            except Exception as e:
+                logger.warning(f"Error disconnecting db for session {session_id}: {e}")
+        if session.rdf_store.oxigraph_store:
+            try:
+                session.rdf_store.oxigraph_store.close()
+            except Exception as e:
+                logger.warning(f"Error closing Oxigraph for session {session_id}: {e}")
+
+        del self._sessions[session_id]
+        logger.debug(f"Cleaned up session: {session_id}")
+
+    async def aclose_session(self, session_id: str) -> None:
+        """Clean up a session, waiting for its background tasks to stop first.
+
+        Preferred over :meth:`cleanup_session` wherever a loop is running. A
+        background init task can be mid ``save_state`` or mid metadata write;
+        closing the Oxigraph store and dropping the session out from under it
+        is how a cancelled-but-not-yet-stopped task ends up writing to a closed
+        store.
+
+        Args:
+            session_id: Session to close.
+        """
+        pending = self._cancel_init_tasks(session_id)
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        self._release_session(session_id)
+
     def cleanup_session(self, session_id: str) -> None:
-        """Clean up a specific session's resources."""
-        if session_id in self._sessions:
-            session = self._sessions[session_id]
-            # Background init tasks outlive the session otherwise: they are
-            # fire-and-forget, so an evicted session leaves one still running
-            # against state that no longer exists.
-            for state, label in (
-                (session.graphrag, "GraphRAG"),
-                (session.rdf_store, "RDF store"),
-            ):
-                task = getattr(state, "_init_task", None)
-                if task is not None and not task.done():
-                    task.cancel()
-                    logger.debug(
-                        f"Cancelled pending {label} init task for session {session_id}"
-                    )
-            if session.db_manager:
-                try:
-                    session.db_manager.disconnect()
-                except Exception as e:
-                    logger.warning(
-                        f"Error disconnecting db for session {session_id}: {e}"
-                    )
-            if session.rdf_store.oxigraph_store:
-                try:
-                    session.rdf_store.oxigraph_store.close()
-                except Exception as e:
-                    logger.warning(
-                        f"Error closing Oxigraph for session {session_id}: {e}"
-                    )
-            del self._sessions[session_id]
-            logger.debug(f"Cleaned up session: {session_id}")
+        """Clean up a session from synchronous context.
+
+        Best-effort: cancellation cannot be awaited here, so a background task
+        may still be running when the store closes. Used from the atexit hook,
+        where the loop is already gone. Prefer :meth:`aclose_session`.
+
+        Args:
+            session_id: Session to close.
+        """
+        self._cancel_init_tasks(session_id)
+        self._release_session(session_id)
 
     def cleanup(self) -> None:
-        """Clean up all resources."""
+        """Clean up all resources from synchronous context (atexit)."""
         if self._eviction_task and not self._eviction_task.done():
             self._eviction_task.cancel()
             logger.debug("Cancelled session eviction task")
@@ -220,7 +264,7 @@ class ServerState:
         while True:
             try:
                 await asyncio.sleep(scan_interval)
-                self._evict_idle_sessions(idle_timeout)
+                await self._evict_idle_sessions(idle_timeout)
             except asyncio.CancelledError:
                 logger.info("Session eviction task cancelled")
                 break
@@ -228,8 +272,12 @@ class ServerState:
                 logger.exception(f"Error in session eviction loop: {e}")
                 await asyncio.sleep(scan_interval)
 
-    def _evict_idle_sessions(self, idle_timeout: int) -> None:
-        """Scan sessions and evict those idle beyond the timeout."""
+    async def _evict_idle_sessions(self, idle_timeout: int) -> None:
+        """Scan sessions and evict those idle beyond the timeout.
+
+        Awaits each session's background tasks before releasing its resources,
+        so an in-flight GraphRAG init cannot outlive the store it writes to.
+        """
         now = utc_now()
         cutoff = now - timedelta(seconds=idle_timeout)
 
@@ -252,7 +300,7 @@ class ServerState:
                 f"Evicting idle session {session_id} "
                 f"(idle {idle_secs:.0f}s, timeout={idle_timeout}s)"
             )
-            self.cleanup_session(session_id)
+            await self.aclose_session(session_id)
 
         if evicting > 0:
             logger.info(

--- a/src/server_state.py
+++ b/src/server_state.py
@@ -212,7 +212,7 @@ class ServerState:
                 logger.info("Session eviction task cancelled")
                 break
             except Exception as e:
-                logger.error(f"Error in session eviction loop: {e}", exc_info=True)
+                logger.exception(f"Error in session eviction loop: {e}")
                 await asyncio.sleep(scan_interval)
 
     def _evict_idle_sessions(self, idle_timeout: int) -> None:

--- a/src/server_state.py
+++ b/src/server_state.py
@@ -149,6 +149,19 @@ class ServerState:
         """Clean up a specific session's resources."""
         if session_id in self._sessions:
             session = self._sessions[session_id]
+            # Background init tasks outlive the session otherwise: they are
+            # fire-and-forget, so an evicted session leaves one still running
+            # against state that no longer exists.
+            for state, label in (
+                (session.graphrag, "GraphRAG"),
+                (session.rdf_store, "RDF store"),
+            ):
+                task = getattr(state, "_init_task", None)
+                if task is not None and not task.done():
+                    task.cancel()
+                    logger.debug(
+                        f"Cancelled pending {label} init task for session {session_id}"
+                    )
             if session.db_manager:
                 try:
                     session.db_manager.disconnect()

--- a/src/session.py
+++ b/src/session.py
@@ -93,12 +93,25 @@ class SchemaCache:
 
 
 class GraphRAGState:
-    """GraphRAG integration state with Future-based init tracking."""
+    """GraphRAG integration state with background init tracking."""
 
     def __init__(self) -> None:
         self.graphrag_manager: Any | None = None  # GraphRAGManager
         self.graphrag_initialized: bool = False
-        self._init_task: asyncio.Task[Any] | None = None
+        # Every in-flight background init, not just the newest. A single slot
+        # lost earlier tasks whenever discover_schema overlapped -- normal in
+        # the accumulative multi-schema flow -- leaving them running against a
+        # session that teardown had already finished with.
+        self.init_tasks: set[asyncio.Task[Any]] = set()
+
+    def track_init_task(self, task: "asyncio.Task[Any]") -> None:
+        """Register a background init task and forget it once it finishes.
+
+        Args:
+            task: The task to track until completion.
+        """
+        self.init_tasks.add(task)
+        task.add_done_callback(self.init_tasks.discard)
 
 
 class RDFStoreState:

--- a/src/session.py
+++ b/src/session.py
@@ -13,6 +13,8 @@ import logging
 from datetime import datetime
 from typing import Any, Optional
 
+from .utils import utc_now
+
 logger = logging.getLogger(__name__)
 
 
@@ -147,12 +149,12 @@ class SessionData:
         self._current_schema: str | None = None
 
         # Activity tracking for idle eviction
-        self.created_at: datetime = datetime.now()
-        self.last_activity: datetime = datetime.now()
+        self.created_at: datetime = utc_now()
+        self.last_activity: datetime = utc_now()
 
     def touch(self) -> None:
         """Update last activity timestamp."""
-        self.last_activity = datetime.now()
+        self.last_activity = utc_now()
 
     # --- Multi-schema management ---
 

--- a/src/shacl_validator.py
+++ b/src/shacl_validator.py
@@ -28,7 +28,10 @@ def shacl_available() -> bool:
         return False
     try:
         import pyshacl  # noqa: F401
-    except Exception:
+    except Exception as exc:
+        # Broad on purpose: a broken install can fail at import with more than
+        # ImportError. Logged so "SHACL silently unavailable" is diagnosable.
+        logger.debug("pyshacl unavailable (%s): %s", type(exc).__name__, exc)
         return False
     return True
 
@@ -56,7 +59,8 @@ def validate_ontology(ontology_ttl: str) -> dict[str, Any]:
 
     try:
         from pyshacl import validate as _pyshacl_validate
-    except Exception:
+    except Exception as exc:
+        logger.debug("pyshacl import failed (%s): %s", type(exc).__name__, exc)
         return {
             "available": False,
             "conforms": None,

--- a/src/tools/chart.py
+++ b/src/tools/chart.py
@@ -1,10 +1,10 @@
 """Chart generation tool."""
 
 import logging
-from datetime import datetime
 from typing import Any
 
 from ..chart_utils import create_plotly_chart
+from ..utils import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -186,7 +186,7 @@ def generate_chart(
                 title = f"Chart of {x_column}"
 
         # Create chart ID for file naming and logging
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        timestamp = utc_now().strftime("%Y%m%d_%H%M%S")
         safe_title = "".join(
             c for c in title.replace(" ", "_") if c.isalnum() or c in "_-"
         )

--- a/src/utils.py
+++ b/src/utils.py
@@ -261,7 +261,9 @@ def validate_uri(uri: str) -> bool:
         parsed = urlparse(uri)
         # Check scheme is http or https and has a netloc (domain)
         return parsed.scheme in ("http", "https") and bool(parsed.netloc)
-    except Exception:
+    except ValueError:
+        # urlparse raises ValueError on malformed input (e.g. a bad IPv6
+        # literal). Anything else is a caller bug and should surface.
         return False
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,9 +4,51 @@ import asyncio
 import json
 import logging
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
+
+# ---------------------------------------------------------------------------
+# Timestamps
+#
+# Workspace metadata is persisted as ISO strings and later compared against the
+# current time to decide retention. Naive local timestamps make that comparison
+# wrong across DST shifts and meaningless if the workspace moves between
+# machines in different zones, so everything written from here on is
+# timezone-aware UTC.
+# ---------------------------------------------------------------------------
+
+
+def utc_now() -> datetime:
+    """Return the current time as a timezone-aware UTC datetime.
+
+    Returns:
+        The current UTC time, with tzinfo set.
+    """
+    return datetime.now(UTC)
+
+
+def parse_timestamp(value: str) -> datetime:
+    """Parse a persisted ISO timestamp, treating naive values as UTC.
+
+    Workspaces written before timestamps became timezone-aware hold naive ISO
+    strings. Comparing one of those against an aware ``utc_now()`` raises
+    ``TypeError``, which would break retention cleanup on startup for every
+    existing workspace on disk. Naive inputs are therefore assumed to be UTC
+    rather than rejected.
+
+    Args:
+        value: ISO 8601 timestamp, with or without an offset.
+
+    Returns:
+        A timezone-aware datetime.
+    """
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
 
 # ---------------------------------------------------------------------------
 # Non-blocking file I/O

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,9 +1,86 @@
 """Utility functions for OrionBelt Analytics."""
 
+import asyncio
+import json
 import logging
 import sys
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
+
+# ---------------------------------------------------------------------------
+# Non-blocking file I/O
+#
+# Handlers run on the event loop, and the artifacts they touch (ontology TTL,
+# schema JSON) are routinely megabytes on a large schema. A plain open()/read()
+# there stalls the loop for every concurrent session, so these helpers push the
+# whole operation -- including JSON encode/decode, which is CPU-bound in its own
+# right -- into a worker thread. Exceptions propagate exactly as the blocking
+# calls would.
+# ---------------------------------------------------------------------------
+
+
+async def read_text_file(path: Path | str, encoding: str = "utf-8") -> str:
+    """Read a text file without blocking the event loop.
+
+    Args:
+        path: File to read.
+        encoding: Text encoding.
+
+    Returns:
+        The file's contents.
+    """
+    return await asyncio.to_thread(Path(path).read_text, encoding=encoding)
+
+
+async def write_text_file(
+    path: Path | str, content: str, encoding: str = "utf-8"
+) -> None:
+    """Write a text file without blocking the event loop.
+
+    Args:
+        path: File to write.
+        content: Text to write.
+        encoding: Text encoding.
+    """
+    await asyncio.to_thread(Path(path).write_text, content, encoding=encoding)
+
+
+async def read_json_file(path: Path | str, encoding: str = "utf-8") -> Any:
+    """Read and parse a JSON file without blocking the event loop.
+
+    Args:
+        path: File to read.
+        encoding: Text encoding.
+
+    Returns:
+        The decoded JSON payload.
+    """
+
+    def _read() -> Any:
+        return json.loads(Path(path).read_text(encoding=encoding))
+
+    return await asyncio.to_thread(_read)
+
+
+async def write_json_file(
+    path: Path | str, data: Any, encoding: str = "utf-8", indent: int = 2
+) -> None:
+    """Serialize data to a JSON file without blocking the event loop.
+
+    Args:
+        path: File to write.
+        data: JSON-serializable payload.
+        encoding: Text encoding.
+        indent: Indentation passed to :func:`json.dumps`.
+    """
+
+    def _write() -> None:
+        Path(path).write_text(
+            json.dumps(data, indent=indent, ensure_ascii=False), encoding=encoding
+        )
+
+    await asyncio.to_thread(_write)
 
 
 async def safe_ctx_info(ctx: Any, message: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,33 @@ Patches OUTPUT_DIR to use pytest's tmp_path for all tests, preventing
 test artifacts from polluting the real tmp/ directory.
 """
 
+import asyncio
 import contextlib
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+async def drain_background_tasks():
+    """Cancel fire-and-forget tasks a test leaves behind.
+
+    Handlers spawn GraphRAG and RDF initialization as background tasks and
+    stash the handle on the session. Production cancels those in
+    ServerState.cleanup_session(), but tests drive the handlers with Mock
+    sessions that never go through that path -- so without this the task
+    survives the test and gets destroyed mid-await at loop teardown
+    ("Task was destroyed but it is pending!"), which both adds noise and
+    hides whether the background path completed.
+    """
+    yield
+    current = asyncio.current_task()
+    leftover = [
+        task for task in asyncio.all_tasks() if task is not current and not task.done()
+    ]
+    for task in leftover:
+        task.cancel()
+    if leftover:
+        await asyncio.gather(*leftover, return_exceptions=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ Patches OUTPUT_DIR to use pytest's tmp_path for all tests, preventing
 test artifacts from polluting the real tmp/ directory.
 """
 
+import contextlib
+
 import pytest
 
 
@@ -35,9 +37,8 @@ def isolate_output_dir(tmp_path, monkeypatch):
         "src.graphrag.vector_store_chromadb",
     ]
     for mod in targets:
-        try:
+        # Module may not be imported yet -- nothing to patch in that case.
+        with contextlib.suppress(AttributeError):
             monkeypatch.setattr(f"{mod}.OUTPUT_DIR", test_output)
-        except AttributeError:
-            pass  # Module may not be imported yet
 
     return test_output

--- a/tests/test_artifact_pruning.py
+++ b/tests/test_artifact_pruning.py
@@ -1,0 +1,173 @@
+"""Tests for pruning of superseded per-schema artifacts.
+
+Artifact filenames carry a microsecond timestamp, so every regeneration writes
+a new file while workspace metadata records only the latest. Before pruning,
+every earlier generation stayed on disk unreferenced -- megabytes per ontology
+on a large schema, and never reclaimed, because AUTO_CLEANUP_ON_STARTUP only
+removes whole workspaces by age, not files inside a live one.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from src.lifecycle.artifacts import (
+    DEFAULT_KEEP_VERSIONS,
+    family_glob,
+    get_keep_versions,
+    prune_superseded_artifacts,
+    prune_superseded_sync,
+)
+
+CONN = "ab12cd34"
+
+
+def _write(directory: Path, name: str, mtime: float | None = None) -> Path:
+    path = directory / name
+    path.write_text("x", encoding="utf-8")
+    if mtime is not None:
+        import os
+
+        os.utime(path, (mtime, mtime))
+    return path
+
+
+def _generation(schema: str, stamp: str, kind: str = "ontology", ext: str = ".ttl"):
+    return f"{kind}_{CONN}_{schema}_{stamp}{ext}"
+
+
+class TestFamilyGlob:
+    """The glob must isolate one artifact kind, connection and schema."""
+
+    def test_strips_the_full_timestamp_including_its_underscore(self):
+        """The timestamp is %Y%m%d_%H%M%S%f -- it contains an underscore."""
+        assert (
+            family_glob("ontology_ab12cd34_public_20260727_132056962941.ttl")
+            == "ontology_ab12cd34_public_*.ttl"
+        )
+
+    def test_handles_the_shorter_background_timestamp(self):
+        """The background ontology path uses %Y%m%d_%H%M%S (no microseconds)."""
+        assert (
+            family_glob("ontology_public_20260727_132056.ttl")
+            == "ontology_public_*.ttl"
+        )
+
+    def test_returns_none_when_there_is_no_timestamp(self):
+        """Unrecognized names must not be pruned against."""
+        assert family_glob("ontology_upload.ttl") is None
+        assert family_glob("metadata.json") is None
+
+
+class TestPruning:
+    def test_keeps_current_plus_previous_generations(self, tmp_path):
+        """Older generations beyond `keep` are removed."""
+        files = [
+            _write(
+                tmp_path, _generation("public", f"20260727_1320569629{i:02d}"), mtime=i
+            )
+            for i in range(6)
+        ]
+        current = files[-1]
+
+        removed = prune_superseded_sync(current, keep=3)
+
+        assert current.exists()
+        surviving = sorted(p.name for p in tmp_path.glob("ontology_*"))
+        assert len(surviving) == 3
+        assert len(removed) == 3
+
+    def test_never_deletes_the_current_file_even_if_it_is_oldest(self, tmp_path):
+        """The freshly written file is pinned regardless of mtime.
+
+        Clock skew or a slow write must not make the file just referenced by
+        metadata a deletion candidate.
+        """
+        current = _write(
+            tmp_path, _generation("public", "20260727_132056000000"), mtime=1
+        )
+        for i in range(2, 6):
+            _write(
+                tmp_path, _generation("public", f"20260727_1320560000{i:02d}"), mtime=i
+            )
+
+        prune_superseded_sync(current, keep=2)
+
+        assert current.exists(), "current artifact was pruned"
+
+    def test_does_not_touch_other_schemas(self, tmp_path):
+        """Pruning is scoped to one schema's family."""
+        for i in range(4):
+            _write(tmp_path, _generation("public", f"2026072{i}_132056962941"), mtime=i)
+        other = [
+            _write(tmp_path, _generation("sales", f"2026072{i}_132056962941"), mtime=i)
+            for i in range(4)
+        ]
+        current = tmp_path / _generation("public", "20260723_132056962941")
+
+        prune_superseded_sync(current, keep=1)
+
+        assert all(p.exists() for p in other), "another schema's artifacts were pruned"
+
+    def test_does_not_touch_other_artifact_kinds(self, tmp_path):
+        """An ontology prune must not remove schema JSON or R2RML."""
+        current = _write(
+            tmp_path, _generation("public", "20260727_132056962941"), mtime=9
+        )
+        _write(tmp_path, _generation("public", "20260726_132056962941"), mtime=1)
+        keep_json = _write(
+            tmp_path, _generation("public", "20260726_132056962941", "schema", ".json")
+        )
+        keep_r2rml = _write(
+            tmp_path, _generation("public", "20260726_132056962941", "r2rml", ".ttl")
+        )
+
+        prune_superseded_sync(current, keep=1)
+
+        assert keep_json.exists()
+        assert keep_r2rml.exists()
+
+    def test_unrecognized_name_prunes_nothing(self, tmp_path):
+        """Without a parseable timestamp the function must be inert."""
+        current = _write(tmp_path, "ontology_upload.ttl")
+        _write(tmp_path, "ontology_other.ttl")
+
+        assert prune_superseded_sync(current, keep=1) == []
+        assert len(list(tmp_path.glob("*.ttl"))) == 2
+
+    def test_keep_is_clamped_to_at_least_one(self, tmp_path):
+        """keep=0 must not delete the file currently in use."""
+        current = _write(tmp_path, _generation("public", "20260727_132056962941"))
+        prune_superseded_sync(current, keep=0)
+        assert current.exists()
+
+    async def test_async_wrapper_prunes(self, tmp_path):
+        """The handler-facing entry point works off the event loop."""
+        for i in range(4):
+            _write(tmp_path, _generation("public", f"2026072{i}_132056962941"), mtime=i)
+        current = tmp_path / _generation("public", "20260723_132056962941")
+
+        removed = await prune_superseded_artifacts(current, keep=2)
+
+        assert len(removed) == 2
+        assert current.exists()
+
+
+class TestKeepVersionsSetting:
+    def test_defaults_when_unset(self, monkeypatch):
+        monkeypatch.delenv("ARTIFACT_KEEP_VERSIONS", raising=False)
+        assert get_keep_versions() == DEFAULT_KEEP_VERSIONS
+
+    def test_reads_the_env_var(self, monkeypatch):
+        monkeypatch.setenv("ARTIFACT_KEEP_VERSIONS", "7")
+        assert get_keep_versions() == 7
+
+    @pytest.mark.parametrize("value", ["0", "-3"])
+    def test_clamps_to_one(self, monkeypatch, value):
+        """Retaining zero generations would delete the file in use."""
+        monkeypatch.setenv("ARTIFACT_KEEP_VERSIONS", value)
+        assert get_keep_versions() == 1
+
+    def test_falls_back_on_garbage(self, monkeypatch):
+        monkeypatch.setenv("ARTIFACT_KEEP_VERSIONS", "not-a-number")
+        assert get_keep_versions() == DEFAULT_KEEP_VERSIONS

--- a/tests/test_artifact_pruning.py
+++ b/tests/test_artifact_pruning.py
@@ -13,7 +13,7 @@ import pytest
 
 from src.lifecycle.artifacts import (
     DEFAULT_KEEP_VERSIONS,
-    family_glob,
+    family_key,
     get_keep_versions,
     prune_superseded_artifacts,
     prune_superseded_sync,
@@ -36,27 +36,38 @@ def _generation(schema: str, stamp: str, kind: str = "ontology", ext: str = ".tt
     return f"{kind}_{CONN}_{schema}_{stamp}{ext}"
 
 
-class TestFamilyGlob:
-    """The glob must isolate one artifact kind, connection and schema."""
+class TestFamilyKey:
+    """The key must isolate one artifact kind, connection and schema."""
 
     def test_strips_the_full_timestamp_including_its_underscore(self):
         """The timestamp is %Y%m%d_%H%M%S%f -- it contains an underscore."""
-        assert (
-            family_glob("ontology_ab12cd34_public_20260727_132056962941.ttl")
-            == "ontology_ab12cd34_public_*.ttl"
+        assert family_key("ontology_ab12cd34_public_20260727_132056962941.ttl") == (
+            "ontology_ab12cd34_public",
+            ".ttl",
         )
 
     def test_handles_the_shorter_background_timestamp(self):
         """The background ontology path uses %Y%m%d_%H%M%S (no microseconds)."""
-        assert (
-            family_glob("ontology_public_20260727_132056.ttl")
-            == "ontology_public_*.ttl"
+        assert family_key("ontology_public_20260727_132056.ttl") == (
+            "ontology_public",
+            ".ttl",
         )
 
     def test_returns_none_when_there_is_no_timestamp(self):
         """Unrecognized names must not be pruned against."""
-        assert family_glob("ontology_upload.ttl") is None
-        assert family_glob("metadata.json") is None
+        assert family_key("ontology_upload.ttl") is None
+        assert family_key("metadata.json") is None
+
+    def test_schema_names_with_glob_metacharacters_stay_distinct(self):
+        """Schema names may contain *, ? or [ -- they must not match siblings.
+
+        schema_safe only replaces spaces and dots, so these survive into the
+        filename. A glob built from such a name matched other schemas: a prune
+        for "sales*" deleted "sales_eu"'s artifacts. Keys compare exactly.
+        """
+        star = family_key("ontology_ab12cd34_sales*_20260727_132056962941.ttl")
+        sibling = family_key("ontology_ab12cd34_sales_eu_20260727_132056962941.ttl")
+        assert star != sibling
 
 
 class TestPruning:
@@ -126,6 +137,56 @@ class TestPruning:
 
         assert keep_json.exists()
         assert keep_r2rml.exists()
+
+    def test_glob_metacharacters_in_schema_do_not_match_siblings(self, tmp_path):
+        """Regression: pruning schema "sales*" must not delete "sales_eu".
+
+        Reproduced against the previous glob-based implementation.
+        """
+        victim = _write(
+            tmp_path, _generation("sales_eu", "20260101_120000000000"), mtime=1
+        )
+        for i in range(4):
+            _write(tmp_path, _generation("sales*", f"2026010{i}_120000000000"), mtime=i)
+        current = tmp_path / _generation("sales*", "20260103_120000000000")
+
+        removed = prune_superseded_sync(current, keep=1)
+
+        assert victim.exists(), "another schema's artifact was pruned"
+        assert victim not in removed
+
+    def test_protected_names_are_never_deleted(self, tmp_path):
+        """Whatever metadata still references must survive any prune.
+
+        Pruning runs after the metadata write, but if that write failed the old
+        filename is still the one on disk that restore will look for.
+        """
+        still_referenced = _write(
+            tmp_path, _generation("public", "20260101_120000000000"), mtime=1
+        )
+        for i in range(2, 5):
+            _write(tmp_path, _generation("public", f"2026010{i}_120000000000"), mtime=i)
+        current = tmp_path / _generation("public", "20260104_120000000000")
+
+        removed = prune_superseded_sync(
+            current, keep=1, protect=[still_referenced.name]
+        )
+
+        assert still_referenced.exists(), "the referenced artifact was pruned"
+        assert still_referenced not in removed
+
+    def test_protect_accepts_paths_as_well_as_names(self, tmp_path):
+        """Callers hold either form; both must work."""
+        referenced = _write(
+            tmp_path, _generation("public", "20260101_120000000000"), mtime=1
+        )
+        current = _write(
+            tmp_path, _generation("public", "20260102_120000000000"), mtime=2
+        )
+
+        prune_superseded_sync(current, keep=1, protect=[referenced])
+
+        assert referenced.exists()
 
     def test_unrecognized_name_prunes_nothing(self, tmp_path):
         """Without a parseable timestamp the function must be inert."""

--- a/tests/test_artifact_pruning.py
+++ b/tests/test_artifact_pruning.py
@@ -7,12 +7,14 @@ on a large schema, and never reclaimed, because AUTO_CLEANUP_ON_STARTUP only
 removes whole workspaces by age, not files inside a live one.
 """
 
+import asyncio
 from pathlib import Path
 
 import pytest
 
 from src.lifecycle.artifacts import (
     DEFAULT_KEEP_VERSIONS,
+    artifact_family_lock,
     family_key,
     get_keep_versions,
     prune_superseded_artifacts,
@@ -232,3 +234,117 @@ class TestKeepVersionsSetting:
     def test_falls_back_on_garbage(self, monkeypatch):
         monkeypatch.setenv("ARTIFACT_KEEP_VERSIONS", "not-a-number")
         assert get_keep_versions() == DEFAULT_KEEP_VERSIONS
+
+
+class TestFamilySerialization:
+    """Overlapping producers for one family must not prune each other's files.
+
+    Each handler writes a timestamped file, records it in metadata, then prunes
+    older generations. Run concurrently for the same schema, request A's prune
+    saw request B's freshly written file as an unprotected sibling and deleted
+    it -- before or after B recorded it. Protecting only A's own previous
+    filename does not help, because B's file is unknown to A.
+
+    artifact_family_lock() makes the whole produce -> record -> prune sequence
+    atomic per family, so the interleaving cannot arise.
+    """
+
+    async def test_lock_serializes_producers_for_one_family(self, tmp_path):
+        """Concurrent producers each keep the file they wrote."""
+        order: list[str] = []
+        survivors: dict[str, Path] = {}
+
+        async def producer(tag: str, stamp: str) -> None:
+            async with artifact_family_lock(tmp_path, "ontology_conn_public"):
+                order.append(f"{tag}:start")
+                path = _write(tmp_path, _generation("public", stamp))
+                survivors[tag] = path
+                await asyncio.sleep(0)  # force a scheduling point inside the lock
+                await prune_superseded_artifacts(path, keep=1)
+                order.append(f"{tag}:end")
+
+        await asyncio.gather(
+            producer("A", "20260101_120000000000"),
+            producer("B", "20260102_120000000000"),
+        )
+
+        # Never interleaved: each producer ran start..end without the other cutting in.
+        assert order in (
+            ["A:start", "A:end", "B:start", "B:end"],
+            ["B:start", "B:end", "A:start", "A:end"],
+        ), order
+
+        # The producer that ran last is the surviving generation, and exactly
+        # one file remains for keep=1 -- nobody's file vanished mid-flight.
+        remaining = list(tmp_path.glob("ontology_*"))
+        assert len(remaining) == 1
+        last = order[-2].split(":")[0]
+        assert remaining[0] == survivors[last]
+
+    async def test_different_families_are_not_serialized(self, tmp_path):
+        """The lock must be per family, not global."""
+        inside = asyncio.Event()
+        released = asyncio.Event()
+
+        async def hold() -> None:
+            async with artifact_family_lock(tmp_path, "ontology_conn_public"):
+                inside.set()
+                await released.wait()
+
+        async def other() -> bool:
+            await inside.wait()
+            async with artifact_family_lock(tmp_path, "ontology_conn_sales"):
+                return True
+
+        holder = asyncio.create_task(hold())
+        got_other = await asyncio.wait_for(other(), timeout=2)
+        released.set()
+        await holder
+
+        assert got_other, "a different family blocked on an unrelated lock"
+
+
+def test_every_prune_call_sits_inside_a_family_lock():
+    """Structural guard: pruning outside the lock reintroduces the race.
+
+    A prune that is not serialized against concurrent producers for the same
+    family can delete another in-flight request's just-written artifact. The
+    lock is only load-bearing if every call site is inside one.
+    """
+    import ast
+
+    handlers = Path(__file__).resolve().parent.parent / "src" / "handlers"
+    offenders = []
+
+    for module in sorted(handlers.glob("*.py")):
+        tree = ast.parse(module.read_text(encoding="utf-8"))
+
+        spans = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.AsyncWith):
+                continue
+            for item in node.items:
+                call = item.context_expr
+                if (
+                    isinstance(call, ast.Call)
+                    and getattr(call.func, "id", "") == "artifact_family_lock"
+                ):
+                    last = max(
+                        getattr(child, "lineno", node.lineno)
+                        for child in ast.walk(node)
+                    )
+                    spans.append((node.lineno, last))
+
+        offenders.extend(
+            f"src/handlers/{module.name}:{node.lineno}"
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "id", "") == "prune_superseded_artifacts"
+            and not any(lo <= node.lineno <= hi for lo, hi in spans)
+        )
+
+    assert not offenders, (
+        "prune_superseded_artifacts() called outside artifact_family_lock():\n  "
+        + "\n  ".join(offenders)
+        + "\n\nWrap the produce -> record -> prune sequence in the family lock."
+    )

--- a/tests/test_artifact_pruning.py
+++ b/tests/test_artifact_pruning.py
@@ -348,3 +348,36 @@ def test_every_prune_call_sits_inside_a_family_lock():
         + "\n  ".join(offenders)
         + "\n\nWrap the produce -> record -> prune sequence in the family lock."
     )
+
+
+def test_enriched_ontologies_are_scoped_per_schema(tmp_path):
+    """apply_semantic_names must not prune across schemas.
+
+    Its filename slot used a bare "semantic" instead of the schema, so
+    family_key() collapsed every schema's enriched ontology into one
+    connection-wide family. With the default keep of 3, enriching a 4th schema
+    deleted the 1st schema's file while workspace metadata still named it.
+    """
+    families = {
+        schema: family_key(
+            f"ontology_{CONN}_{schema}_semantic_2026072{i}_120000000000.ttl"
+        )
+        for i, schema in enumerate(["sales", "hr", "finance", "ops"])
+    }
+    assert len(set(families.values())) == 4, f"schemas share a family: {families}"
+
+
+def test_enriching_many_schemas_keeps_every_recorded_file(tmp_path):
+    """End-to-end: keep+1 schemas enriched, every recorded artifact survives."""
+    recorded = {}
+    for i, schema in enumerate(["sales", "hr", "finance", "ops"]):
+        path = _write(
+            tmp_path,
+            f"ontology_{CONN}_{schema}_semantic_2026072{i}_120000000000.ttl",
+            mtime=i,
+        )
+        recorded[schema] = path
+        prune_superseded_sync(path, keep=3)
+
+    missing = [s for s, p in recorded.items() if not p.exists()]
+    assert not missing, f"metadata would dangle for: {missing}"

--- a/tests/test_async_file_io.py
+++ b/tests/test_async_file_io.py
@@ -1,0 +1,94 @@
+"""Tests for the non-blocking file I/O helpers in src.utils.
+
+These back the ASYNC230 fix: handlers must not call blocking open() on the
+event loop. The helpers have to behave exactly like the blocking calls they
+replaced -- same encoding, same JSON formatting, same exceptions.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from src.utils import read_json_file, read_text_file, write_json_file, write_text_file
+
+UNICODE_SAMPLE = "hello äöü — ünicode ✓"
+
+
+async def test_text_round_trip(tmp_path):
+    """Text written by the helper reads back identically."""
+    target = tmp_path / "ontology.ttl"
+    await write_text_file(target, UNICODE_SAMPLE)
+    assert await read_text_file(target) == UNICODE_SAMPLE
+
+
+async def test_text_helpers_accept_str_paths(tmp_path):
+    """Call sites pass both Path and str; both must work."""
+    target = tmp_path / "ontology.ttl"
+    await write_text_file(str(target), UNICODE_SAMPLE)
+    assert await read_text_file(str(target)) == UNICODE_SAMPLE
+
+
+async def test_json_round_trip(tmp_path):
+    """JSON payloads survive the encode/decode hop unchanged."""
+    target = tmp_path / "schema.json"
+    payload = {"tables": [{"name": "users", "row_count": 3}], "note": "ü"}
+    await write_json_file(target, payload)
+    assert await read_json_file(target) == payload
+
+
+async def test_json_formatting_matches_previous_json_dump(tmp_path):
+    """Preserve indent=2 and ensure_ascii=False from the replaced json.dump call.
+
+    The on-disk format is user-visible (workspace files are inspected and
+    diffed), so the migration must not silently reformat it.
+    """
+    target = tmp_path / "schema.json"
+    await write_json_file(target, {"note": "ü", "n": 1})
+    raw = target.read_text(encoding="utf-8")
+
+    assert raw.startswith("{\n  ")  # indent=2
+    assert "ü" in raw  # ensure_ascii=False, not ü
+    assert raw == json.dumps({"note": "ü", "n": 1}, indent=2, ensure_ascii=False)
+
+
+async def test_missing_file_raises_like_blocking_open(tmp_path):
+    """Errors propagate identically to the blocking calls these replaced."""
+    with pytest.raises(FileNotFoundError):
+        await read_text_file(tmp_path / "absent.ttl")
+    with pytest.raises(FileNotFoundError):
+        await read_json_file(tmp_path / "absent.json")
+
+
+async def test_invalid_json_raises(tmp_path):
+    """A corrupt workspace file still surfaces a JSONDecodeError."""
+    target = tmp_path / "broken.json"
+    await write_text_file(target, "{not json")
+    with pytest.raises(json.JSONDecodeError):
+        await read_json_file(target)
+
+
+async def test_does_not_block_the_event_loop(tmp_path):
+    """The whole point: other tasks keep running during file I/O.
+
+    Writes a payload large enough to be non-trivial while a ticker task runs,
+    and asserts the ticker was scheduled meanwhile -- which cannot happen if
+    the write holds the loop.
+    """
+    ticks = 0
+
+    async def ticker():
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0)
+
+    spinner = asyncio.create_task(ticker())
+    try:
+        target = tmp_path / "big.json"
+        await write_json_file(target, {"rows": [{"i": i} for i in range(50_000)]})
+        assert await read_json_file(target) is not None
+    finally:
+        spinner.cancel()
+
+    assert ticks > 0, "event loop was blocked during file I/O"

--- a/tests/test_metadata_concurrency.py
+++ b/tests/test_metadata_concurrency.py
@@ -17,7 +17,10 @@ Both failure modes were reproducible. These tests pin the fixes:
 import ast
 import asyncio
 import json
+import tempfile
+import threading
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -124,6 +127,69 @@ async def test_metadata_file_stays_parseable_under_concurrent_writes(tmp_path):
     await watcher
 
     assert not parse_failures, f"reader saw a torn file: {parse_failures[:3]}"
+
+
+def test_writers_on_separate_event_loops_do_not_lose_updates(tmp_path):
+    """Two tiers of lock are needed; the asyncio one alone is not enough.
+
+    asyncio.Lock cannot be shared across event loops, so the per-loop locks are
+    mutually invisible. Without the process-wide threading.Lock held inside the
+    worker thread, threads each running asyncio.run() bypass one another
+    entirely -- the original reproduction kept 31 of 240 updates and logged a
+    storm of failed os.replace calls.
+    """
+    connection_id = "crossloop-test-conn"
+    threads, per_thread = 8, 30
+
+    def writer(tid: int) -> None:
+        async def go() -> None:
+            for i in range(per_thread):
+
+                def _mutate(mgr: VersionMetadataManager, tid=tid, i=i) -> None:
+                    workspace = mgr.metadata.setdefault("workspace", {"schemas": {}})
+                    workspace["schemas"][f"s_{tid}_{i}"] = {"n": i}
+                    mgr._save_metadata()
+
+                await mutate_workspace_metadata(connection_id, tmp_path, _mutate)
+
+        asyncio.run(go())  # a fresh event loop per thread
+
+    workers = [threading.Thread(target=writer, args=(t,)) for t in range(threads)]
+    for w in workers:
+        w.start()
+    for w in workers:
+        w.join()
+
+    raw = (tmp_path / connection_id / "metadata.json").read_text(encoding="utf-8")
+    data = json.loads(raw)
+    assert len(data["workspace"]["schemas"]) == threads * per_thread
+
+
+def test_concurrent_saves_use_distinct_temp_files(tmp_path):
+    """Each save must get its own temp path.
+
+    A shared temp name (one derived from the pid, say) means concurrent writers
+    replace and unlink each other's file mid-flight.
+    """
+    connection_id = "tempname-test-conn"
+    seen: set[str] = set()
+    lock = threading.Lock()
+    real_mkstemp = tempfile.mkstemp
+
+    def recording_mkstemp(*args, **kwargs):
+        fd, name = real_mkstemp(*args, **kwargs)
+        with lock:
+            seen.add(name)
+        return fd, name
+
+    with mock.patch.object(tempfile, "mkstemp", recording_mkstemp):
+        mgr = VersionMetadataManager(connection_id, tmp_path)
+        for i in range(20):
+            mgr.metadata["workspace"] = {"schemas": {f"s{i}": {}}}
+            mgr._save_metadata()
+
+    assert len(seen) == 20, "temp file names were reused across saves"
+    assert not list((tmp_path / connection_id).glob("*.tmp")), "temp file left behind"
 
 
 def test_save_metadata_is_atomic(tmp_path):

--- a/tests/test_metadata_concurrency.py
+++ b/tests/test_metadata_concurrency.py
@@ -26,6 +26,7 @@ import pytest
 
 from src.lifecycle.metadata import (
     VersionMetadataManager,
+    mark_ontology_persisted,
     mutate_workspace_metadata,
     update_workspace_section,
 )
@@ -315,3 +316,70 @@ def test_public_async_wrappers_use_the_lock(name):
         assert (
             "mutate_workspace_metadata" in body
         ), f"{wrapper.name} must route through mutate_workspace_metadata"
+
+
+class TestGenerationGuardedPersistFlag:
+    """persisted_to_rdf must describe the generation that was actually loaded.
+
+    The Oxigraph load runs outside the artifact family lock -- it is expensive,
+    and holding the lock across it would serialize generation for the schema.
+    That leaves a window where two overlapping generate_ontology calls record
+    A.ttl then B.ttl, and A's slower auto-persist lands last. A blind merge
+    marked B.ttl persisted on the strength of A's load.
+    """
+
+    async def test_stale_persist_does_not_flag_a_newer_generation(self, tmp_path):
+        """A's late flag must not land on B's record."""
+        cid, schema = "genguard", "public"
+        await update_workspace_section(
+            cid,
+            tmp_path,
+            schema,
+            "ontology",
+            {"ontology_file": "A.ttl", "persisted_to_rdf": False},
+        )
+        await update_workspace_section(
+            cid,
+            tmp_path,
+            schema,
+            "ontology",
+            {"ontology_file": "B.ttl", "persisted_to_rdf": False},
+        )
+
+        applied = await mark_ontology_persisted(cid, tmp_path, schema, "A.ttl", "g:u")
+
+        section = json.loads(
+            (tmp_path / cid / "metadata.json").read_text(encoding="utf-8")
+        )["workspace"]["schemas"][schema]["ontology"]
+        assert applied is False
+        assert section["ontology_file"] == "B.ttl"
+        assert (
+            section["persisted_to_rdf"] is False
+        ), "B was marked persisted on the strength of A's RDF load"
+
+    async def test_current_generation_is_flagged(self, tmp_path):
+        """The guard must not block the normal path."""
+        cid, schema = "genguard-ok", "public"
+        await update_workspace_section(
+            cid,
+            tmp_path,
+            schema,
+            "ontology",
+            {"ontology_file": "B.ttl", "persisted_to_rdf": False},
+        )
+
+        applied = await mark_ontology_persisted(cid, tmp_path, schema, "B.ttl", "g:u")
+
+        section = json.loads(
+            (tmp_path / cid / "metadata.json").read_text(encoding="utf-8")
+        )["workspace"]["schemas"][schema]["ontology"]
+        assert applied is True
+        assert section["persisted_to_rdf"] is True
+        assert section["graph_uri"] == "g:u"
+
+    async def test_missing_section_is_not_invented(self, tmp_path):
+        """No ontology recorded yet means nothing to flag."""
+        applied = await mark_ontology_persisted(
+            "genguard-empty", tmp_path, "public", "A.ttl", "g:u"
+        )
+        assert applied is False

--- a/tests/test_metadata_concurrency.py
+++ b/tests/test_metadata_concurrency.py
@@ -31,11 +31,14 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 SRC = PROJECT_ROOT / "src"
 METADATA_MODULE = SRC / "lifecycle" / "metadata.py"
 
-# DataCleanupManager exposes a *synchronous* API and is currently not
-# instantiated anywhere in src/, tests/, or server.py -- so it cannot take the
-# asyncio lock and cannot presently race anything. Exempted deliberately and
-# narrowly rather than async-ifying dead code on speculation. cleanup.py carries
-# a matching warning; wiring it into an async path means routing it through
+# DataCleanupManager is the unwired remnant of the Phase 3B per-version
+# retention design -- its entry points were removed as dead code once
+# AUTO_CLEANUP_ON_STARTUP shipped separately in server.py. Its API is
+# synchronous and nothing instantiates it, so it cannot take the asyncio lock
+# and cannot presently race anything. Exempted deliberately and narrowly rather
+# than async-ifying dead code on speculation -- but note the original design
+# called it from async paths, which is precisely where it would race. cleanup.py
+# carries the matching warning; reviving it means routing through
 # mutate_workspace_metadata first, and deleting this exemption.
 UNWIRED_SYNC_MODULES = {SRC / "lifecycle" / "cleanup.py"}
 

--- a/tests/test_metadata_concurrency.py
+++ b/tests/test_metadata_concurrency.py
@@ -1,0 +1,248 @@
+"""Concurrency and integrity guarantees for workspace metadata.json.
+
+metadata.json is a single file holding every workspace section (connection,
+per-schema state, RDF store, semantic models). Any writer that does an
+unserialized read-modify-write can drop another writer's section, and because
+the save used to truncate-then-write, two overlapping saves could also leave a
+torn file that fails to parse.
+
+Both failure modes were reproducible. These tests pin the fixes:
+
+  * every mutation goes through ``mutate_workspace_metadata``, which holds the
+    per-connection lock across the whole load/modify/save cycle
+  * ``_save_metadata`` writes to a temp file and ``os.replace``s it into place,
+    so a reader sees either the old file or the new one
+"""
+
+import ast
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from src.lifecycle.metadata import (
+    VersionMetadataManager,
+    mutate_workspace_metadata,
+    update_workspace_section,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC = PROJECT_ROOT / "src"
+METADATA_MODULE = SRC / "lifecycle" / "metadata.py"
+
+# DataCleanupManager exposes a *synchronous* API and is currently not
+# instantiated anywhere in src/, tests/, or server.py -- so it cannot take the
+# asyncio lock and cannot presently race anything. Exempted deliberately and
+# narrowly rather than async-ifying dead code on speculation. cleanup.py carries
+# a matching warning; wiring it into an async path means routing it through
+# mutate_workspace_metadata first, and deleting this exemption.
+UNWIRED_SYNC_MODULES = {SRC / "lifecycle" / "cleanup.py"}
+
+# Methods that mutate and persist metadata.json.
+MUTATORS = {
+    "_save_metadata",
+    "update_workspace",
+    "update_workspace_connection",
+    "update_workspace_rdf_store",
+    "mark_version_deleted",
+}
+
+CONNECTION_ID = "concurrency-test-conn"
+WRITERS = 40
+
+
+async def _record_model(output_dir: Path, name: str) -> None:
+    """Mirror what save_semantic_model does, through the locked helper."""
+
+    def _mutate(mgr: VersionMetadataManager) -> None:
+        workspace = mgr.metadata.setdefault(
+            "workspace", {"updated_at": "x", "schemas": {}}
+        )
+        workspace.setdefault("models", {})[name] = {"file": f"{name}.yaml"}
+        mgr._save_metadata()
+
+    await mutate_workspace_metadata(CONNECTION_ID, output_dir, _mutate)
+
+
+async def test_concurrent_writers_do_not_lose_sections(tmp_path):
+    """Interleaved schema and model writers must all survive.
+
+    Before the fix this reliably lost updates -- in the original reproduction
+    every one of the model writes was clobbered by a concurrent schema write
+    reading stale state.
+    """
+    await asyncio.gather(
+        *(
+            coro
+            for i in range(WRITERS)
+            for coro in (
+                update_workspace_section(
+                    CONNECTION_ID, tmp_path, f"schema_{i}", "schema", {"n": i}
+                ),
+                _record_model(tmp_path, f"model_{i}"),
+            )
+        )
+    )
+
+    raw = (tmp_path / CONNECTION_ID / "metadata.json").read_text(encoding="utf-8")
+    data = json.loads(raw)  # must parse -- a torn file raises here
+    workspace = data["workspace"]
+
+    assert len(workspace["schemas"]) == WRITERS, "schema sections were lost"
+    assert len(workspace["models"]) == WRITERS, "model sections were lost"
+
+
+async def test_metadata_file_stays_parseable_under_concurrent_writes(tmp_path):
+    """A reader must never observe a partially written metadata.json."""
+    stop = False
+    parse_failures = []
+
+    async def reader():
+        target = tmp_path / CONNECTION_ID / "metadata.json"
+        while not stop:
+            if target.exists():
+                try:
+                    json.loads(target.read_text(encoding="utf-8"))
+                except json.JSONDecodeError as exc:
+                    parse_failures.append(str(exc))
+            await asyncio.sleep(0)
+
+    watcher = asyncio.create_task(reader())
+    await asyncio.gather(
+        *(
+            update_workspace_section(
+                CONNECTION_ID, tmp_path, f"schema_{i}", "schema", {"n": i}
+            )
+            for i in range(WRITERS)
+        )
+    )
+    stop = True
+    await watcher
+
+    assert not parse_failures, f"reader saw a torn file: {parse_failures[:3]}"
+
+
+def test_save_metadata_is_atomic(tmp_path):
+    """The save must land via os.replace, leaving no temp file behind."""
+    mgr = VersionMetadataManager(CONNECTION_ID, tmp_path)
+    mgr.metadata["workspace"] = {"schemas": {"a": {}}}
+    mgr._save_metadata()
+
+    conn_dir = tmp_path / CONNECTION_ID
+    assert (conn_dir / "metadata.json").exists()
+    assert not list(conn_dir.glob("*.tmp")), "temp file left behind"
+    assert json.loads((conn_dir / "metadata.json").read_text())["workspace"]["schemas"]
+
+
+def _mutating_calls_outside_metadata_module():
+    """Find metadata mutations in src/ that bypass the locked helper.
+
+    Attribution is to the *innermost* enclosing callable: the sanctioned place
+    to mutate is the callback handed to ``mutate_workspace_metadata``, which is
+    a nested def or a lambda inside the calling handler.
+    """
+    offenders = []
+
+    for path in sorted(SRC.rglob("*.py")):
+        if path == METADATA_MODULE or path in UNWIRED_SYNC_MODULES:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+
+        # Callables handed to mutate_workspace_metadata are allowed to mutate.
+        sanctioned: set[str] = set()
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "mutate_workspace_metadata"
+            ):
+                for arg in node.args:
+                    if isinstance(arg, ast.Name):
+                        sanctioned.add(arg.id)
+                    elif isinstance(arg, ast.Lambda):
+                        sanctioned.add(id(arg))
+
+        # innermost enclosing callable for every node
+        owner: dict[int, object] = {}
+
+        def annotate(node, current):
+            for child in ast.iter_child_nodes(node):
+                if isinstance(
+                    child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
+                ):
+                    annotate(child, child)
+                else:
+                    owner[id(child)] = current
+                    annotate(child, current)
+            owner.setdefault(id(node), current)
+
+        annotate(tree, None)
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not isinstance(func, ast.Attribute) or func.attr not in MUTATORS:
+                continue
+            enclosing = owner.get(id(node))
+            name = getattr(enclosing, "name", None)
+            if name in sanctioned or (
+                isinstance(enclosing, ast.Lambda) and id(enclosing) in sanctioned
+            ):
+                continue
+            rel = path.relative_to(PROJECT_ROOT)
+            label = name or type(enclosing).__name__
+            offenders.append(f"{rel}:{node.lineno}  {func.attr}()  in {label}")
+    return sorted(set(offenders))
+
+
+def test_no_metadata_mutation_bypasses_the_lock():
+    """Every metadata write must go through mutate_workspace_metadata.
+
+    A writer outside the per-connection lock races the ones inside it. This is
+    exactly the regression that shipped once already: save_semantic_model and
+    the connect_database workspace write both mutated metadata.json directly.
+    """
+    offenders = _mutating_calls_outside_metadata_module()
+    assert not offenders, (
+        "metadata.json mutated outside mutate_workspace_metadata():\n  "
+        + "\n  ".join(offenders)
+        + "\n\nRoute the read-modify-write through mutate_workspace_metadata()."
+    )
+
+
+def test_guard_flags_an_unlocked_mutation():
+    """The guard must fire on a bypassing writer, not vacuously pass."""
+    planted = ast.parse(
+        "async def handler():\n"
+        "    mgr = VersionMetadataManager(cid, out)\n"
+        "    mgr._save_metadata()\n"
+    )
+    found = [
+        call
+        for call in ast.walk(planted)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Attribute)
+        and call.func.attr in MUTATORS
+    ]
+    assert found, "guard would not have detected a direct _save_metadata() call"
+
+
+@pytest.mark.parametrize("name", ["update_workspace", "update_workspace_rdf_store"])
+def test_public_async_wrappers_use_the_lock(name):
+    """The async wrappers must delegate to the locked helper, not re-implement it."""
+    source = METADATA_MODULE.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    wrappers = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef)
+        and node.name in {"update_workspace_section", "update_workspace_rdf"}
+    ]
+    assert wrappers, "expected the async workspace wrappers to exist"
+    for wrapper in wrappers:
+        body = ast.unparse(wrapper)
+        assert (
+            "mutate_workspace_metadata" in body
+        ), f"{wrapper.name} must route through mutate_workspace_metadata"

--- a/tests/test_no_blocking_io_in_async.py
+++ b/tests/test_no_blocking_io_in_async.py
@@ -28,21 +28,19 @@ SRC = PROJECT_ROOT / "src"
 # indirection further in.
 OFFLOAD_DISPATCHERS = ("to_thread", "mutate_workspace_metadata")
 
-BLOCKING_METHODS = {"read_text", "write_text", "read_bytes", "write_bytes"}
+# rdflib Graph.parse/serialize dominate the loop stalls in this codebase:
+# roughly 876 ms for a 2.65 MB Turtle file versus ~1.2 ms to read the same
+# bytes. Converting the read while leaving the parse on the loop would fix only
+# the cheap half, so they are enforced here alongside the file operations.
+BLOCKING_METHODS = {
+    "read_text",
+    "write_text",
+    "read_bytes",
+    "write_bytes",
+    "parse",
+    "serialize",
+}
 
-# KNOWN GAP -- deliberately not enforced here yet.
-#
-# rdflib Graph.parse/serialize are the dominant loop stalls in this codebase:
-# roughly 876 ms for a 2.65 MB Turtle file, versus ~1.2 ms to read the same
-# bytes. So converting the read to read_text_file() while leaving parse() on the
-# loop fixes the cheap half. Adding "parse"/"serialize" to BLOCKING_METHODS
-# above immediately reports 11+ call sites (ontology_generation, ontology_io,
-# ontology_semantic, rdf, graphrag) -- all of which are byte-identical on main,
-# i.e. pre-existing rather than introduced here.
-#
-# Converting them is tracked separately rather than folded into this change.
-# This comment exists so the guard is not mistaken for proof that no blocking
-# work remains on the event loop: it covers file I/O, not CPU-bound parsing.
 BLOCKING_MODULE_CALLS = {
     ("json", "dump"),
     ("json", "load"),
@@ -210,8 +208,17 @@ def test_async_callers_do_not_invoke_blocking_sync_helpers():
         if not is_async:
             continue
         exempt = _dispatched_spans(node)
+        # An awaited call cannot be the sync helper we are hunting. Names are
+        # matched loosely (there is no type information here), and some are
+        # shared between an async handler and a sync method -- e.g.
+        # apply_semantic_names is both. Awaiting is the precise discriminator.
+        awaited = {
+            id(n.value)
+            for n in ast.walk(node)
+            if isinstance(n, ast.Await) and isinstance(n.value, ast.Call)
+        }
         for call in ast.walk(node):
-            if not isinstance(call, ast.Call):
+            if not isinstance(call, ast.Call) or id(call) in awaited:
                 continue
             func = call.func
             name = (

--- a/tests/test_no_blocking_io_in_async.py
+++ b/tests/test_no_blocking_io_in_async.py
@@ -23,6 +23,11 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 SRC = PROJECT_ROOT / "src"
 
+# Callables whose entire job is running work off the event loop. A blocking
+# helper reached through one of these is fine -- the thread hop just happens one
+# indirection further in.
+OFFLOAD_DISPATCHERS = ("to_thread", "mutate_workspace_metadata")
+
 BLOCKING_METHODS = {"read_text", "write_text", "read_bytes", "write_bytes"}
 BLOCKING_MODULE_CALLS = {
     ("json", "dump"),
@@ -162,8 +167,9 @@ def test_async_callers_do_not_invoke_blocking_sync_helpers():
             )
             if name not in blocking_helpers:
                 continue
-            # Accept it when the async function hands the helper to to_thread.
-            if "to_thread" in source and name in source:
+            # Accept it when the async function routes through a dispatcher
+            # that runs the work in a worker thread.
+            if any(d in source for d in OFFLOAD_DISPATCHERS) and name in source:
                 continue
             rel = path.relative_to(PROJECT_ROOT)
             offenders.append(f"{rel}:{call.lineno}  {name}()  from async {qualname}")

--- a/tests/test_no_blocking_io_in_async.py
+++ b/tests/test_no_blocking_io_in_async.py
@@ -29,6 +29,20 @@ SRC = PROJECT_ROOT / "src"
 OFFLOAD_DISPATCHERS = ("to_thread", "mutate_workspace_metadata")
 
 BLOCKING_METHODS = {"read_text", "write_text", "read_bytes", "write_bytes"}
+
+# KNOWN GAP -- deliberately not enforced here yet.
+#
+# rdflib Graph.parse/serialize are the dominant loop stalls in this codebase:
+# roughly 876 ms for a 2.65 MB Turtle file, versus ~1.2 ms to read the same
+# bytes. So converting the read to read_text_file() while leaving parse() on the
+# loop fixes the cheap half. Adding "parse"/"serialize" to BLOCKING_METHODS
+# above immediately reports 11+ call sites (ontology_generation, ontology_io,
+# ontology_semantic, rdf, graphrag) -- all of which are byte-identical on main,
+# i.e. pre-existing rather than introduced here.
+#
+# Converting them is tracked separately rather than folded into this change.
+# This comment exists so the guard is not mistaken for proof that no blocking
+# work remains on the event loop: it covers file I/O, not CPU-bound parsing.
 BLOCKING_MODULE_CALLS = {
     ("json", "dump"),
     ("json", "load"),
@@ -134,15 +148,57 @@ def test_no_direct_blocking_io_in_async_functions():
     )
 
 
+def _dispatched_spans(func) -> list[tuple[int, int]]:
+    """Line spans of nested callables handed to an off-loop dispatcher.
+
+    ``asyncio.to_thread(_apply)`` / ``mutate_workspace_metadata(cid, d, _record)``
+    run ``_apply`` / ``_record`` in a worker thread, so blocking calls *inside
+    those* are fine. Everything else in the async body is not.
+    """
+    dispatched: set[str] = set()
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Call):
+            continue
+        callee = node.func
+        label = (
+            callee.attr
+            if isinstance(callee, ast.Attribute)
+            else getattr(callee, "id", "")
+        )
+        if label not in OFFLOAD_DISPATCHERS:
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.Name):
+                dispatched.add(arg.id)
+
+    spans = []
+    for node in ast.walk(func):
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name in dispatched
+        ):
+            last = max(
+                getattr(child, "lineno", node.lineno) for child in ast.walk(node)
+            )
+            spans.append((node.lineno, last))
+    return spans
+
+
 def test_async_callers_do_not_invoke_blocking_sync_helpers():
-    """A sync helper doing file I/O must be reached via asyncio.to_thread.
+    """A sync helper doing file I/O must be reached via an off-loop dispatcher.
 
     This is the case ASYNC230 cannot see at all: the blocking call is one
     function away, so the lint rule reports nothing while the loop still
     stalls.
+
+    Exemption is per *call site*, not per function. An earlier version accepted
+    any async function that merely mentioned ``to_thread`` anywhere -- the
+    condition included ``name in source``, which is always true because ``name``
+    is the callee being examined. That exempted 16 of 93 async functions,
+    including every one this stack rewrote for off-loading.
     """
     functions = _index_functions()
-    # simple name -> called-from-async, for sync helpers that block
+
     blocking_helpers = {
         qualname.rsplit(".", 1)[-1]
         for (_p, qualname), (node, _path, is_async) in functions.items()
@@ -153,7 +209,7 @@ def test_async_callers_do_not_invoke_blocking_sync_helpers():
     for (_path, qualname), (node, path, is_async) in sorted(functions.items()):
         if not is_async:
             continue
-        source = ast.unparse(node)
+        exempt = _dispatched_spans(node)
         for call in ast.walk(node):
             if not isinstance(call, ast.Call):
                 continue
@@ -167,9 +223,7 @@ def test_async_callers_do_not_invoke_blocking_sync_helpers():
             )
             if name not in blocking_helpers:
                 continue
-            # Accept it when the async function routes through a dispatcher
-            # that runs the work in a worker thread.
-            if any(d in source for d in OFFLOAD_DISPATCHERS) and name in source:
+            if any(lo <= call.lineno <= hi for lo, hi in exempt):
                 continue
             rel = path.relative_to(PROJECT_ROOT)
             offenders.append(f"{rel}:{call.lineno}  {name}()  from async {qualname}")
@@ -177,6 +231,44 @@ def test_async_callers_do_not_invoke_blocking_sync_helpers():
     assert not offenders, (
         "Async functions calling blocking sync helpers without "
         "asyncio.to_thread:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_dispatcher_exemption_is_per_call_site_not_per_function():
+    """Mentioning to_thread elsewhere must not excuse an un-dispatched call.
+
+    Regression for the tautological exemption: this function dispatches one
+    helper properly and calls another directly. Only the dispatched one is
+    inside an exempt span.
+    """
+    tree = ast.parse(
+        "async def handler(d):\n"
+        "    def _apply():\n"
+        "        blocking_helper(d)\n"
+        "    await asyncio.to_thread(_apply)\n"
+        "    leaked_helper(d)\n"
+    )
+    func = tree.body[0]
+    spans = _dispatched_spans(func)
+
+    inside = [
+        c
+        for c in ast.walk(func)
+        if isinstance(c, ast.Call) and getattr(c.func, "id", "") == "blocking_helper"
+    ]
+    outside = [
+        c
+        for c in ast.walk(func)
+        if isinstance(c, ast.Call) and getattr(c.func, "id", "") == "leaked_helper"
+    ]
+    assert inside and outside
+
+    assert any(
+        lo <= inside[0].lineno <= hi for lo, hi in spans
+    ), "the dispatched payload should be exempt"
+    assert not any(lo <= outside[0].lineno <= hi for lo, hi in spans), (
+        "an un-dispatched call must NOT be exempt just because the function "
+        "also uses to_thread"
     )
 
 

--- a/tests/test_no_blocking_io_in_async.py
+++ b/tests/test_no_blocking_io_in_async.py
@@ -1,0 +1,195 @@
+"""Guard against blocking file I/O on the event loop.
+
+Ruff's ASYNC230 only matches a literal ``open()`` lexically inside an
+``async def``. That misses two large categories which stall the loop just as
+badly:
+
+  * ``Path.read_text() / write_text() / read_bytes() / write_bytes()``,
+    ``json.load/dump``, ``shutil.rmtree`` called directly in an async body
+  * a *sync* helper that does any of the above, called from an async function
+    without ``asyncio.to_thread``
+
+Both were present after the first pass at the ASYNC230 fix, which is why this
+test exists: the lint rule is not a sufficient check, so the invariant is
+enforced directly.
+
+Legitimate escape hatch: work wrapped in ``asyncio.to_thread``. Those payloads
+live in nested ``def``s, which this walker deliberately does not descend into.
+"""
+
+import ast
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC = PROJECT_ROOT / "src"
+
+BLOCKING_METHODS = {"read_text", "write_text", "read_bytes", "write_bytes"}
+BLOCKING_MODULE_CALLS = {
+    ("json", "dump"),
+    ("json", "load"),
+    ("shutil", "rmtree"),
+    ("shutil", "copy"),
+    ("shutil", "copytree"),
+    ("shutil", "move"),
+}
+
+
+def _describe_blocking_call(node: ast.Call) -> str | None:
+    """Name the blocking file operation this call performs, if any."""
+    func = node.func
+    if isinstance(func, ast.Name) and func.id == "open":
+        return "open()"
+    if isinstance(func, ast.Attribute):
+        if func.attr in BLOCKING_METHODS:
+            return f".{func.attr}()"
+        if isinstance(func.value, ast.Name):
+            pair = (func.value.id, func.attr)
+            if pair in BLOCKING_MODULE_CALLS:
+                return f"{pair[0]}.{pair[1]}()"
+    return None
+
+
+class _ShallowBlockingVisitor(ast.NodeVisitor):
+    """Collect blocking calls, refusing to descend into nested functions.
+
+    Nested defs are where ``asyncio.to_thread`` payloads live -- that code is
+    explicitly off the loop and must not be reported.
+    """
+
+    def __init__(self):
+        self.found: list[tuple[int, str]] = []
+
+    def visit_FunctionDef(self, node):
+        return
+
+    def visit_AsyncFunctionDef(self, node):
+        return
+
+    def visit_Call(self, node):
+        described = _describe_blocking_call(node)
+        if described:
+            self.found.append((node.lineno, described))
+        self.generic_visit(node)
+
+
+def _index_functions():
+    """Map (path, qualname) -> (node, path, is_async) for every function in src/.
+
+    Keyed by path as well as name: several handler functions share a name with
+    the thin ``@mcp.tool()`` wrapper in src/main.py, and a name-only key would
+    let one silently overwrite the other -- dropping real code from the scan.
+    """
+    functions = {}
+
+    class Indexer(ast.NodeVisitor):
+        def __init__(self, path):
+            self.path = path
+            self.stack: list[str] = []
+
+        def _record(self, node, is_async):
+            self.stack.append(node.name)
+            functions[(self.path, ".".join(self.stack))] = (node, self.path, is_async)
+            self.generic_visit(node)
+            self.stack.pop()
+
+        def visit_FunctionDef(self, node):
+            self._record(node, False)
+
+        def visit_AsyncFunctionDef(self, node):
+            self._record(node, True)
+
+    for path in sorted(SRC.rglob("*.py")):
+        Indexer(path).visit(ast.parse(path.read_text(encoding="utf-8")))
+    return functions
+
+
+def _blocking_in_body(node) -> list[tuple[int, str]]:
+    """Blocking calls in this function's own body (not nested defs)."""
+    visitor = _ShallowBlockingVisitor()
+    for statement in node.body:
+        visitor.visit(statement)
+    return visitor.found
+
+
+def test_no_direct_blocking_io_in_async_functions():
+    """An async function must not touch the filesystem synchronously."""
+    offenders = []
+    for (_path, qualname), (node, path, is_async) in sorted(_index_functions().items()):
+        if not is_async:
+            continue
+        for lineno, op in _blocking_in_body(node):
+            rel = path.relative_to(PROJECT_ROOT)
+            offenders.append(f"{rel}:{lineno}  {op}  in async {qualname}")
+
+    assert not offenders, (
+        "Blocking file I/O inside async functions -- this stalls the event "
+        "loop for every concurrent session:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nUse the helpers in src/utils.py or wrap in asyncio.to_thread()."
+    )
+
+
+def test_async_callers_do_not_invoke_blocking_sync_helpers():
+    """A sync helper doing file I/O must be reached via asyncio.to_thread.
+
+    This is the case ASYNC230 cannot see at all: the blocking call is one
+    function away, so the lint rule reports nothing while the loop still
+    stalls.
+    """
+    functions = _index_functions()
+    # simple name -> called-from-async, for sync helpers that block
+    blocking_helpers = {
+        qualname.rsplit(".", 1)[-1]
+        for (_p, qualname), (node, _path, is_async) in functions.items()
+        if not is_async and _blocking_in_body(node)
+    }
+
+    offenders = []
+    for (_path, qualname), (node, path, is_async) in sorted(functions.items()):
+        if not is_async:
+            continue
+        source = ast.unparse(node)
+        for call in ast.walk(node):
+            if not isinstance(call, ast.Call):
+                continue
+            func = call.func
+            name = (
+                func.id
+                if isinstance(func, ast.Name)
+                else func.attr
+                if isinstance(func, ast.Attribute)
+                else None
+            )
+            if name not in blocking_helpers:
+                continue
+            # Accept it when the async function hands the helper to to_thread.
+            if "to_thread" in source and name in source:
+                continue
+            rel = path.relative_to(PROJECT_ROOT)
+            offenders.append(f"{rel}:{call.lineno}  {name}()  from async {qualname}")
+
+    assert not offenders, (
+        "Async functions calling blocking sync helpers without "
+        "asyncio.to_thread:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_guard_detects_a_planted_blocking_call():
+    """The guard must actually fire, not vacuously pass."""
+    planted = ast.parse(
+        "async def handler(path):\n    return path.read_text(encoding='utf-8')\n"
+    )
+    fn = planted.body[0]
+    assert _blocking_in_body(fn) == [(2, ".read_text()")]
+
+
+def test_guard_ignores_to_thread_payloads():
+    """Work inside a nested def (the to_thread payload) is not a violation."""
+    ok = ast.parse(
+        "async def handler(path):\n"
+        "    def _read():\n"
+        "        return path.read_text(encoding='utf-8')\n"
+        "    return await asyncio.to_thread(_read)\n"
+    )
+    fn = ok.body[0]
+    assert _blocking_in_body(fn) == []

--- a/tests/test_no_silent_exceptions.py
+++ b/tests/test_no_silent_exceptions.py
@@ -1,0 +1,108 @@
+"""Guard against silently swallowed exceptions.
+
+`except Exception` is a legitimate and necessary pattern at the MCP tool
+boundary: a handler must convert failures into an error response rather than
+let an arbitrary exception escape into the protocol layer. Ruff's BLE001 flags
+every one of those (167 at the time of writing), so enabling it would mean 167
+`noqa` comments -- noise that buys no safety.
+
+What actually matters is narrower: a broad handler must not *discard* what it
+caught. This test encodes that invariant directly. A handler passes if it does
+any of:
+
+  * logs (logger.debug/info/warning/error/exception/critical), or
+  * re-raises, or
+  * references the bound exception (e.g. folds the message into a returned
+    error payload).
+
+A handler that does none of those has thrown information away, and the failure
+becomes undiagnosable in production. That is the real defect BLE001 gestures at.
+"""
+
+import ast
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+LOG_METHODS = {"debug", "info", "warning", "error", "exception", "critical"}
+
+
+def _python_sources():
+    """Every first-party module, including the root entry point."""
+    yield from sorted((PROJECT_ROOT / "src").rglob("*.py"))
+    yield PROJECT_ROOT / "server.py"
+
+
+def _is_broad(handler: ast.ExceptHandler) -> bool:
+    """True for `except:` and `except Exception:` (the catch-alls)."""
+    exc = handler.type
+    if exc is None:
+        return True
+    return isinstance(exc, ast.Name) and exc.id == "Exception"
+
+
+def _handles_exception(handler: ast.ExceptHandler) -> bool:
+    """True if the handler logs, re-raises, or uses the caught exception."""
+    body = ast.Module(body=handler.body, type_ignores=[])
+
+    for node in ast.walk(body):
+        if isinstance(node, ast.Raise):
+            return True
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in LOG_METHODS
+        ):
+            return True
+
+    if handler.name:
+        return any(
+            isinstance(node, ast.Name) and node.id == handler.name
+            for node in ast.walk(body)
+        )
+    return False
+
+
+def test_no_broad_handler_discards_its_exception():
+    """No `except Exception` may drop the error without a trace."""
+    offenders = []
+
+    for path in _python_sources():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.ExceptHandler)
+                and _is_broad(node)
+                and not _handles_exception(node)
+            ):
+                rel = path.relative_to(PROJECT_ROOT)
+                offenders.append(f"{rel}:{node.lineno}")
+
+    assert not offenders, (
+        "Broad `except Exception` handlers that discard the exception "
+        "(no log, no re-raise, never referenced):\n  "
+        + "\n  ".join(offenders)
+        + "\n\nLog it, re-raise it, or fold it into the returned error payload."
+    )
+
+
+def test_guard_detects_a_planted_silent_handler():
+    """The guard must actually catch a violation, not vacuously pass."""
+    planted = ast.parse(
+        "try:\n" "    risky()\n" "except Exception:\n" "    fallback = 0\n"
+    )
+    handlers = [n for n in ast.walk(planted) if isinstance(n, ast.ExceptHandler)]
+    assert len(handlers) == 1
+    assert _is_broad(handlers[0])
+    assert not _handles_exception(handlers[0]), "guard failed to flag a silent handler"
+
+
+def test_guard_accepts_a_handler_that_logs():
+    """A logging handler is accepted."""
+    ok = ast.parse(
+        "try:\n"
+        "    risky()\n"
+        "except Exception as exc:\n"
+        "    logger.warning('failed: %s', exc)\n"
+    )
+    handler = next(n for n in ast.walk(ok) if isinstance(n, ast.ExceptHandler))
+    assert _handles_exception(handler)

--- a/tests/test_output_dir_guard.py
+++ b/tests/test_output_dir_guard.py
@@ -1,0 +1,89 @@
+"""OUTPUT_DIR must never resolve onto the installation itself.
+
+Startup cleanup deletes loose files directly under OUTPUT_DIR, and with
+AUTO_CLEANUP_ON_STARTUP=true removes every subdirectory without a
+metadata.json. That is correct for a dedicated output directory and
+catastrophic anywhere else -- pathlib collapses "" and "." onto PROJECT_ROOT,
+so a blanked-out OUTPUT_DIR= in .env would target the checkout: unlinking
+.env and pyproject.toml, then removing src/, tests/ and .git/.
+
+The value cases call the resolver directly. Deliberately no sys.modules
+purging: reloading src.* mid-session gives other tests different module
+objects than their mocks were bound to, which silently broke 14 unrelated
+tests when this file first did that. Import-time behaviour is checked in a
+subprocess instead, which is both isolated and closer to what happens at
+startup.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+from src.paths import PROJECT_ROOT, _resolve_output_dir
+
+
+@pytest.mark.parametrize("value", ["", "   ", "\t"])
+def test_blank_output_dir_is_rejected(monkeypatch, value):
+    """An empty value resolves to the project root -- refuse it."""
+    monkeypatch.setenv("OUTPUT_DIR", value)
+    with pytest.raises(ValueError, match="empty"):
+        _resolve_output_dir()
+
+
+@pytest.mark.parametrize("value", [".", "..", "./", "src/.."])
+def test_output_dir_containing_the_installation_is_rejected(monkeypatch, value):
+    """Anything resolving to PROJECT_ROOT or above it is refused."""
+    monkeypatch.setenv("OUTPUT_DIR", value)
+    with pytest.raises(ValueError, match="contains the installation"):
+        _resolve_output_dir()
+
+
+def test_absolute_project_root_is_rejected(monkeypatch):
+    """The check is on the resolved path, not on the spelling."""
+    monkeypatch.setenv("OUTPUT_DIR", str(PROJECT_ROOT))
+    with pytest.raises(ValueError, match="contains the installation"):
+        _resolve_output_dir()
+
+
+def test_default_is_used_when_unset(monkeypatch):
+    """No OUTPUT_DIR means the packaged default."""
+    monkeypatch.delenv("OUTPUT_DIR", raising=False)
+    assert _resolve_output_dir().name == "tmp"
+
+
+@pytest.mark.parametrize("value", ["tmp", "output/data"])
+def test_relative_paths_below_the_root_are_accepted(monkeypatch, value):
+    """Normal configurations still work."""
+    monkeypatch.setenv("OUTPUT_DIR", value)
+    resolved = _resolve_output_dir()
+    assert PROJECT_ROOT.resolve() in resolved.parents
+
+
+def test_absolute_path_outside_the_project_is_accepted(monkeypatch, tmp_path):
+    """A production deployment pointing at /var/lib/... must work."""
+    monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
+    assert _resolve_output_dir() == tmp_path.resolve()
+
+
+def test_guard_fires_at_import_time():
+    """Startup must fail fast, not at the first destructive operation.
+
+    Run in a subprocess so importing src.paths with a hostile OUTPUT_DIR
+    cannot disturb this test session.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", "import src.paths"],
+        cwd=PROJECT_ROOT,
+        env={
+            "PATH": "/usr/bin:/bin",
+            "OUTPUT_DIR": ".",
+            "PYTHONPATH": str(PROJECT_ROOT),
+        },
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert proc.returncode != 0, "importing with OUTPUT_DIR=. should have failed"
+    assert "contains the installation" in proc.stderr

--- a/tests/test_output_dir_guard.py
+++ b/tests/test_output_dir_guard.py
@@ -87,3 +87,25 @@ def test_guard_fires_at_import_time():
     )
     assert proc.returncode != 0, "importing with OUTPUT_DIR=. should have failed"
     assert "contains the installation" in proc.stderr
+
+
+def test_nested_output_dir_is_created_with_missing_parents(monkeypatch, tmp_path):
+    """A nested OUTPUT_DIR the resolver accepts must also be creatable.
+
+    _resolve_output_dir() accepts values like "output/data" and
+    /var/lib/orionbelt/data, so ensure_output_dir() needs parents=True --
+    otherwise a fresh deployment passes validation and then dies with
+    FileNotFoundError on the first write.
+    """
+    target = tmp_path / "missing-parent" / "data"
+    assert not target.parent.exists()
+
+    monkeypatch.setenv("OUTPUT_DIR", str(target))
+    import src.paths as paths_module
+
+    monkeypatch.setattr(paths_module, "OUTPUT_DIR", paths_module._resolve_output_dir())
+
+    created = paths_module.ensure_output_dir()
+
+    assert created.is_dir()
+    assert created == target.resolve()

--- a/tests/test_rdf_graph_replacement.py
+++ b/tests/test_rdf_graph_replacement.py
@@ -87,3 +87,58 @@ async def test_superseded_generation_is_refused_before_it_can_load(tmp_path):
 async def test_first_generation_is_allowed_through(tmp_path):
     """Nothing recorded yet means this caller is the first -- do not block it."""
     assert await ontology_is_current("fresh", tmp_path, "public", "A.ttl") is True
+
+
+class TestFailedLoadPreservesPreviousGeneration:
+    """A failed refresh must not destroy the last queryable ontology.
+
+    Making the load a replacement introduced this: the target graph was cleared
+    before the new TTL had parsed, so a malformed ontology left the graph empty
+    and SPARQL answering nothing. The new data is now staged and swapped in only
+    after it loads successfully.
+    """
+
+    def test_malformed_turtle_leaves_the_existing_graph_intact(self, store):
+        store.load_ontology(_ttl("Customers"), GRAPH, "public")
+
+        with pytest.raises(Exception):
+            store.load_ontology("this is not valid turtle @@@", GRAPH, "public")
+
+        assert _classes(store) == {
+            "Customers"
+        }, "a failed load destroyed the previous ontology"
+
+    def test_graph_survives_repeated_failures(self, store):
+        """Retrying a bad ontology must not erode the good one."""
+        store.load_ontology(_ttl("Customers", "Orders"), GRAPH, "public")
+
+        for _ in range(5):
+            with pytest.raises(Exception):
+                store.load_ontology("@@@ broken", GRAPH, "public")
+
+        assert _classes(store) == {"Customers", "Orders"}
+
+    def test_staging_graphs_are_not_left_behind(self, store):
+        """Clearing a graph's quads does not unregister it in pyoxigraph.
+
+        Without an explicit remove_graph the store accumulated one empty
+        staging graph per load, which show up in named_graphs() and in
+        cross-graph SPARQL.
+        """
+        store.load_ontology(_ttl("Customers"), GRAPH, "public")
+        for _ in range(5):
+            with pytest.raises(Exception):
+                store.load_ontology("@@@ broken", GRAPH, "public")
+            store.load_ontology(_ttl("Customers"), GRAPH, "public")
+
+        graphs = [str(g) for g in store.store.named_graphs()]
+        assert not [
+            g for g in graphs if "__staging" in g
+        ], f"staging graphs leaked: {graphs}"
+        assert len(graphs) == 1
+
+    def test_successful_load_still_replaces(self, store):
+        """Staging must not accidentally turn replacement back into append."""
+        store.load_ontology(_ttl("Customers", "DroppedTable"), GRAPH, "public")
+        store.load_ontology(_ttl("Customers"), GRAPH, "public")
+        assert _classes(store) == {"Customers"}

--- a/tests/test_rdf_graph_replacement.py
+++ b/tests/test_rdf_graph_replacement.py
@@ -142,3 +142,55 @@ class TestFailedLoadPreservesPreviousGeneration:
         store.load_ontology(_ttl("Customers", "DroppedTable"), GRAPH, "public")
         store.load_ontology(_ttl("Customers"), GRAPH, "public")
         assert _classes(store) == {"Customers"}
+
+
+class TestCallerSuppliedGraphUris:
+    """graph_uri is a user-facing tool parameter and must not be string-surgeried.
+
+    Staging used to derive its IRI by appending "#__staging_..." to the
+    caller's graph_uri. Any URI that already carried a fragment -- perfectly
+    valid, and reachable through generate_ontology(graph_uri=...) -- then
+    produced two fragments, which pyoxigraph rejects outright with
+    "Invalid IRI code point '#'". The staging name now comes from a private
+    URN namespace and does not depend on the caller's URI at all.
+    """
+
+    @pytest.mark.parametrize(
+        "graph",
+        [
+            "http://example.com/schema/public",
+            "http://example.com/schema#public",
+            "http://example.com/schema?version=2",
+            "http://example.com/schema/public/",
+            "urn:example:schema:public",
+        ],
+    )
+    def test_valid_graph_uri_shapes_are_accepted(self, store, graph):
+        """Fragments, queries, trailing slashes and URNs must all load."""
+        assert store.load_ontology(_ttl("Customers"), graph, "public") == 1
+
+    def test_replacement_and_failure_handling_hold_for_fragment_uris(self, store):
+        """The staging guarantees must not be limited to path-style URIs."""
+        graph = "http://example.com/schema#public"
+        store.load_ontology(_ttl("Customers", "DroppedTable"), graph, "public")
+        store.load_ontology(_ttl("Customers"), graph, "public")
+        assert _classes(store, graph) == {"Customers"}
+
+        with pytest.raises(Exception):
+            store.load_ontology("@@@ broken", graph, "public")
+        assert _classes(store, graph) == {"Customers"}
+
+        graphs = [str(g) for g in store.store.named_graphs()]
+        assert not [g for g in graphs if "staging" in g], f"staging leaked: {graphs}"
+
+    def test_staging_iri_is_not_derived_from_the_caller_uri(self):
+        """A private URN namespace, so no caller URI shape can break it."""
+        from src.oxigraph_store import _STAGING_IRI_PREFIX
+
+        assert _STAGING_IRI_PREFIX.startswith("urn:")
+        assert "#" not in _STAGING_IRI_PREFIX
+
+    def test_malformed_caller_uri_is_rejected_not_silently_mangled(self, store):
+        """An invalid IRI from the caller must surface, not be patched over."""
+        with pytest.raises(ValueError):
+            store.load_ontology(_ttl("Customers"), "http://example.com/a#b#c", "public")

--- a/tests/test_rdf_graph_replacement.py
+++ b/tests/test_rdf_graph_replacement.py
@@ -1,0 +1,89 @@
+"""A schema's named graph holds one generation of its ontology, not a union.
+
+pyoxigraph's ``store.load(..., to_graph=...)`` unions into the target graph.
+Nothing cleared it, so every regeneration accumulated: drop a table, regenerate,
+and the dropped table stayed queryable through query_sparql() and RDF exports
+forever. No concurrency needed -- a single sequential regeneration was enough.
+
+That also made guarding only the metadata flag insufficient. A superseded
+request whose load had already landed left the graph holding the wrong
+ontology while the flag correctly named the newer one.
+"""
+
+import re
+
+import pytest
+
+from src.lifecycle.metadata import ontology_is_current, update_workspace_section
+from src.oxigraph_store import OxigraphStoreManager
+
+OWL_CLASS = "<http://www.w3.org/2002/07/owl#Class>"
+RDF_TYPE = "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>"
+GRAPH = "http://example.com/schema/public"
+
+
+def _ttl(*names: str) -> str:
+    return "\n".join(
+        f"<http://example.com/{n}> {RDF_TYPE} {OWL_CLASS} ." for n in names
+    )
+
+
+def _classes(store: OxigraphStoreManager, graph: str = GRAPH) -> set[str]:
+    rows = store.query_sparql(
+        f"SELECT ?c WHERE {{ GRAPH <{graph}> {{ ?c a {OWL_CLASS} }} }}"
+    )
+    return set(re.findall(r"example\.com/(\w+)", str(rows)))
+
+
+@pytest.fixture
+def store():
+    return OxigraphStoreManager()
+
+
+def test_regeneration_drops_entities_that_no_longer_exist(store):
+    """The headline case: a dropped table must stop being queryable."""
+    store.load_ontology(_ttl("Customers", "DroppedTable"), GRAPH, "public")
+    store.load_ontology(_ttl("Customers"), GRAPH, "public")
+
+    assert _classes(store) == {"Customers"}, "stale entity survived regeneration"
+
+
+def test_regeneration_reports_the_graph_size_not_the_delta(store):
+    """The old count was a store delta, so an unchanged reload reported 0."""
+    assert store.load_ontology(_ttl("A", "B"), GRAPH, "public") == 2
+    assert (
+        store.load_ontology(_ttl("A", "B"), GRAPH, "public") == 2
+    ), "reloading the same ontology should still report its size"
+    assert store.load_ontology(_ttl("A"), GRAPH, "public") == 1
+
+
+def test_replacement_is_scoped_to_one_schema_graph(store):
+    """Loading one schema must not disturb another."""
+    other = "http://example.com/schema/sales"
+    store.load_ontology(_ttl("Orders"), other, "sales")
+    store.load_ontology(_ttl("Customers", "Temp"), GRAPH, "public")
+    store.load_ontology(_ttl("Customers"), GRAPH, "public")
+
+    assert _classes(store) == {"Customers"}
+    assert _classes(store, other) == {"Orders"}, "another schema's graph was cleared"
+
+
+async def test_superseded_generation_is_refused_before_it_can_load(tmp_path):
+    """The currency check must gate the RDF write, not just the flag.
+
+    load_ontology replaces the graph, so a stale request reaching the load
+    would overwrite the newer generation's triples -- leaving the flag honest
+    and the graph wrong.
+    """
+    cid, schema = "rdfguard", "public"
+    await update_workspace_section(
+        cid, tmp_path, schema, "ontology", {"ontology_file": "B.ttl"}
+    )
+
+    assert await ontology_is_current(cid, tmp_path, schema, "B.ttl") is True
+    assert await ontology_is_current(cid, tmp_path, schema, "A.ttl") is False
+
+
+async def test_first_generation_is_allowed_through(tmp_path):
+    """Nothing recorded yet means this caller is the first -- do not block it."""
+    assert await ontology_is_current("fresh", tmp_path, "public", "A.ttl") is True

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 """Comprehensive tests for the OrionBelt Analytics MCP server."""
 
+import asyncio
 import json
 import unittest
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -424,6 +425,14 @@ class TestMCPToolsAsync:
             result = await main_module.discover_schema(
                 mock_ctx, "public", lightweight=False
             )
+
+            # discover_schema spawns GraphRAG init as a fire-and-forget task.
+            # Await it here so the test does not abandon a pending task at loop
+            # teardown (which surfaces as "Task was destroyed but it is
+            # pending!" and hides whether the background path actually worked).
+            init_task = getattr(mock_session_data.graphrag, "_init_task", None)
+            if isinstance(init_task, asyncio.Task):
+                await asyncio.gather(init_task, return_exceptions=True)
 
         assert isinstance(result, dict)
         assert result["schema"] == "public"

--- a/tests/test_server_state.py
+++ b/tests/test_server_state.py
@@ -90,11 +90,11 @@ class TestServerState(unittest.TestCase):
         gen = ServerState().get_ontology_generator(base_uri="http://x/")
         self.assertTrue(hasattr(gen, "generate_from_schema"))
 
-    def test_evict_idle_sessions(self):
+    async def test_evict_idle_sessions(self):
         ss = ServerState()
         s = ss.get_session("old")
         s.last_activity = utc_now() - timedelta(hours=1)
-        ss._evict_idle_sessions(idle_timeout=1)
+        await ss._evict_idle_sessions(idle_timeout=1)
         self.assertEqual(ss.session_count, 0)
 
     def test_cleanup_all(self):

--- a/tests/test_server_state.py
+++ b/tests/test_server_state.py
@@ -2,7 +2,7 @@
 
 import types
 import unittest
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from src.database_manager import ColumnInfo, TableInfo
 from src.server_state import (
@@ -14,6 +14,7 @@ from src.server_state import (
     get_session_id,
 )
 from src.session import SessionData
+from src.utils import utc_now
 
 
 def _table():
@@ -92,7 +93,7 @@ class TestServerState(unittest.TestCase):
     def test_evict_idle_sessions(self):
         ss = ServerState()
         s = ss.get_session("old")
-        s.last_activity = datetime.now() - timedelta(hours=1)
+        s.last_activity = utc_now() - timedelta(hours=1)
         ss._evict_idle_sessions(idle_timeout=1)
         self.assertEqual(ss.session_count, 0)
 

--- a/tests/test_session_eviction.py
+++ b/tests/test_session_eviction.py
@@ -2,22 +2,23 @@
 
 import asyncio
 import contextlib
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from src.main import ServerState
 from src.session import SessionData
+from src.utils import utc_now
 
 
 class TestSessionDataActivity:
     """Tests for SessionData activity tracking."""
 
     def test_created_with_timestamps(self):
-        before = datetime.now()
+        before = utc_now()
         session = SessionData()
-        after = datetime.now()
+        after = utc_now()
 
         assert before <= session.created_at <= after
         assert before <= session.last_activity <= after
@@ -33,7 +34,7 @@ class TestSessionDataActivity:
     def test_touch_does_not_change_created_at(self):
         session = SessionData()
         created = session.created_at
-        session.last_activity = datetime.now() - timedelta(seconds=10)
+        session.last_activity = utc_now() - timedelta(seconds=10)
         session.touch()
         assert session.created_at == created
 
@@ -51,7 +52,7 @@ class TestServerStateEviction:
         state = self._make_state()
         session = state.get_session("s1")
         # Backdate and access again
-        session.last_activity = datetime.now() - timedelta(minutes=5)
+        session.last_activity = utc_now() - timedelta(minutes=5)
         before_touch = session.last_activity
         state.get_session("s1")
         assert session.last_activity > before_touch
@@ -61,7 +62,7 @@ class TestServerStateEviction:
         state.get_session("active")
         stale = state.get_session("stale")
         # Backdate the stale session
-        stale.last_activity = datetime.now() - timedelta(minutes=45)
+        stale.last_activity = utc_now() - timedelta(minutes=45)
 
         state._evict_idle_sessions(idle_timeout=1800)  # 30 min
 
@@ -81,7 +82,7 @@ class TestServerStateEviction:
         state = self._make_state()
         for name in ["a", "b", "c"]:
             s = state.get_session(name)
-            s.last_activity = datetime.now() - timedelta(hours=2)
+            s.last_activity = utc_now() - timedelta(hours=2)
 
         state._evict_idle_sessions(idle_timeout=1800)
 
@@ -174,7 +175,7 @@ class TestEvictionLoop:
         state = ServerState()
         state._ensure_eviction_task = lambda: None
         session = state.get_session("stale")
-        session.last_activity = datetime.now() - timedelta(hours=1)
+        session.last_activity = utc_now() - timedelta(hours=1)
 
         mock_config = MagicMock()
         mock_config.session_idle_timeout = 60

--- a/tests/test_session_eviction.py
+++ b/tests/test_session_eviction.py
@@ -1,6 +1,7 @@
 """Tests for session idle timeout and eviction."""
 
 import asyncio
+import contextlib
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
@@ -185,10 +186,8 @@ class TestEvictionLoop:
                 task = asyncio.create_task(state._eviction_loop())
                 await asyncio.sleep(0.3)  # Let it run a couple cycles
                 task.cancel()
-                try:
+                with contextlib.suppress(asyncio.CancelledError):
                     await task
-                except asyncio.CancelledError:
-                    pass
 
         await run_loop()
         assert "stale" not in state._sessions

--- a/tests/test_session_eviction.py
+++ b/tests/test_session_eviction.py
@@ -57,34 +57,34 @@ class TestServerStateEviction:
         state.get_session("s1")
         assert session.last_activity > before_touch
 
-    def test_evict_idle_sessions_removes_stale(self):
+    async def test_evict_idle_sessions_removes_stale(self):
         state = self._make_state()
         state.get_session("active")
         stale = state.get_session("stale")
         # Backdate the stale session
         stale.last_activity = utc_now() - timedelta(minutes=45)
 
-        state._evict_idle_sessions(idle_timeout=1800)  # 30 min
+        await state._evict_idle_sessions(idle_timeout=1800)  # 30 min
 
         assert "active" in state._sessions
         assert "stale" not in state._sessions
 
-    def test_evict_idle_sessions_keeps_all_when_fresh(self):
+    async def test_evict_idle_sessions_keeps_all_when_fresh(self):
         state = self._make_state()
         state.get_session("s1")
         state.get_session("s2")
 
-        state._evict_idle_sessions(idle_timeout=1800)
+        await state._evict_idle_sessions(idle_timeout=1800)
 
         assert state.session_count == 2
 
-    def test_evict_idle_sessions_removes_all_stale(self):
+    async def test_evict_idle_sessions_removes_all_stale(self):
         state = self._make_state()
         for name in ["a", "b", "c"]:
             s = state.get_session(name)
             s.last_activity = utc_now() - timedelta(hours=2)
 
-        state._evict_idle_sessions(idle_timeout=1800)
+        await state._evict_idle_sessions(idle_timeout=1800)
 
         assert state.session_count == 0
 
@@ -202,3 +202,95 @@ class TestEvictionLoop:
         state.cleanup()
 
         mock_task.cancel.assert_called_once()
+
+
+class TestBackgroundTaskTeardown:
+    """Every in-flight init task must be stopped before the session is released.
+
+    Two defects this pins:
+      * a single `_init_task` slot lost earlier tasks whenever discover_schema
+        overlapped, leaving them running against a released session;
+      * teardown only *scheduled* cancellation, then closed the Oxigraph store
+        and dropped the session in the same synchronous block -- so a cancelled
+        task could still be mid save_state when its store closed.
+    """
+
+    async def test_all_init_tasks_are_tracked_not_just_the_newest(self):
+        """Overlapping background inits must all be retained."""
+        state = ServerState()
+        session = state.get_session("s1")
+
+        async def noop() -> None:
+            await asyncio.sleep(3600)
+
+        tasks = [asyncio.create_task(noop()) for _ in range(3)]
+        for task in tasks:
+            session.graphrag.track_init_task(task)
+
+        assert len(session.graphrag.init_tasks) == 3, "earlier tasks were dropped"
+
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def test_finished_tasks_stop_being_tracked(self):
+        """The set must not grow without bound over a long-lived session."""
+        state = ServerState()
+        session = state.get_session("s1")
+
+        async def quick() -> None:
+            return None
+
+        task = asyncio.create_task(quick())
+        session.graphrag.track_init_task(task)
+        await task
+        await asyncio.sleep(0)  # let the done-callback run
+
+        assert session.graphrag.init_tasks == set()
+
+    async def test_aclose_waits_for_tasks_before_releasing_resources(self):
+        """The store must not close while a background task is still running."""
+        state = ServerState()
+        session = state.get_session("s1")
+
+        store_closed = False
+        still_running_at_close = False
+
+        class FakeStore:
+            def close(self) -> None:
+                nonlocal store_closed
+                store_closed = True
+
+        session.rdf_store.oxigraph_store = FakeStore()
+
+        started = asyncio.Event()
+
+        async def slow_init() -> None:
+            started.set()
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                nonlocal still_running_at_close
+                # If teardown did not await us, the store is already closed by
+                # the time this cleanup runs.
+                still_running_at_close = store_closed
+                raise
+
+        task = asyncio.create_task(slow_init())
+        session.graphrag.track_init_task(task)
+        await started.wait()
+
+        await state.aclose_session("s1")
+
+        assert task.done(), "teardown returned with the task still running"
+        assert store_closed, "store was never closed"
+        assert (
+            not still_running_at_close
+        ), "Oxigraph store closed while a background task was still running"
+        assert state.session_count == 0
+
+    async def test_aclose_is_safe_for_an_unknown_session(self):
+        """Closing twice, or closing something evicted already, must not raise."""
+        state = ServerState()
+        await state.aclose_session("never-existed")
+        assert state.session_count == 0

--- a/tests/test_startup_cleanup.py
+++ b/tests/test_startup_cleanup.py
@@ -138,6 +138,77 @@ def test_workspace_without_updated_at_is_kept(tmp_path, monkeypatch):
     assert ws.exists(), "workspace with no updated_at must not be deleted"
 
 
+async def _run_cleanup_workspace(tmp_path, monkeypatch, connection_id="conncleanup"):
+    """Drive the real cleanup_workspace tool against a temp output dir."""
+    from unittest.mock import AsyncMock, Mock
+
+    from src.handler_context import HandlerContext
+    from src.handlers import workspace as workspace_handler
+
+    monkeypatch.setattr("src.paths.OUTPUT_DIR", tmp_path)
+    monkeypatch.setattr(workspace_handler, "OUTPUT_DIR", tmp_path)
+
+    session = Mock()
+    session.connection_id = connection_id
+    session.oxigraph_store = None
+    ctx = Mock()
+    ctx.info = AsyncMock()
+
+    services = HandlerContext(get_session_data=lambda _ctx: session)
+    return await workspace_handler.cleanup_workspace(ctx, services)
+
+
+async def test_cleanup_workspace_removes_workspace_and_satellite_stores(
+    tmp_path, monkeypatch
+):
+    """The tool must delete all three directories, not just the workspace.
+
+    Behavioural: the earlier version of this test only asserted that the
+    source mentioned get_connection_store_dirs, which passed even when the
+    Oxigraph cleanup was deleted outright.
+    """
+    cid = "conncleanup"
+    (tmp_path / cid).mkdir(parents=True)
+    (tmp_path / cid / "metadata.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "chromadb" / cid).mkdir(parents=True)
+    (tmp_path / "oxigraph" / cid / "store").mkdir(parents=True)
+
+    result = await _run_cleanup_workspace(tmp_path, monkeypatch, cid)
+
+    assert not (tmp_path / cid).exists()
+    assert not (tmp_path / "chromadb" / cid).exists(), "ChromaDB store survived"
+    assert not (tmp_path / "oxigraph" / cid).exists(), "Oxigraph store survived"
+    assert "ChromaDB vector store" in str(result)
+    assert "Oxigraph RDF store" in str(result)
+
+
+async def test_cleanup_workspace_does_not_report_deletions_that_failed(
+    tmp_path, monkeypatch
+):
+    """Reporting must reflect what is actually gone.
+
+    rmtree(ignore_errors=True) never raises, so "it did not throw" proves
+    nothing -- a locked or read-only tree survives silently. Stubbing rmtree to
+    a no-op simulates exactly that: nothing is deleted, so nothing may be
+    reported as removed.
+    """
+    import shutil
+
+    cid = "conncleanup"
+    (tmp_path / cid).mkdir(parents=True)
+    (tmp_path / "chromadb" / cid).mkdir(parents=True)
+    (tmp_path / "oxigraph" / cid / "store").mkdir(parents=True)
+
+    monkeypatch.setattr(shutil, "rmtree", lambda *a, **k: None)
+
+    result = await _run_cleanup_workspace(tmp_path, monkeypatch, cid)
+
+    assert (tmp_path / cid).exists(), "precondition: rmtree was stubbed out"
+    assert "## Removed" not in str(
+        result
+    ), "cleanup_workspace claimed deletions that never happened"
+
+
 def test_cleanup_workspace_tool_covers_the_same_directories_as_startup():
     """The runtime cleanup tool and startup cleanup must delete the same set.
 
@@ -153,22 +224,4 @@ def test_cleanup_workspace_tool_covers_the_same_directories_as_startup():
     assert "get_connection_store_dirs" in source, (
         "cleanup_workspace must derive satellite store paths from "
         "get_connection_store_dirs() rather than hardcoding them"
-    )
-
-
-def test_cleanup_workspace_does_not_claim_failed_deletions(tmp_path, monkeypatch):
-    """rmtree(ignore_errors=True) never raises, so success must be verified.
-
-    A locked or read-only tree survives the call silently; reporting it as
-    removed tells the user their data is gone when it is not.
-    """
-    import inspect
-
-    from src.handlers import workspace as workspace_handler
-
-    source = inspect.getsource(workspace_handler.cleanup_workspace)
-    # The existence re-check is what makes the report truthful.
-    assert "if dir_path.exists():" in source, (
-        "cleanup_workspace must re-check existence after rmtree before "
-        "reporting a directory as removed"
     )

--- a/tests/test_startup_cleanup.py
+++ b/tests/test_startup_cleanup.py
@@ -1,0 +1,138 @@
+"""Tests for AUTO_CLEANUP_ON_STARTUP workspace cleanup.
+
+The output directory holds two different kinds of child directory:
+
+    OUTPUT_DIR/{connection_id}/          <- a workspace (has metadata.json)
+    OUTPUT_DIR/chromadb/{connection_id}/ <- satellite store, keyed one level down
+    OUTPUT_DIR/oxigraph/{connection_id}/ <- satellite store, keyed one level down
+
+Conflating them caused two bugs these tests pin:
+
+  * ``chromadb`` and ``oxigraph`` have no metadata.json, so scanning
+    OUTPUT_DIR for workspaces classified them as orphaned and deleted every
+    connection's vectors and triples on the first retention run.
+  * deleting a workspace left its satellite stores behind forever, which is
+    exactly the disk growth the retention mode exists to prevent.
+"""
+
+import json
+
+import pytest
+
+from src.paths import NON_WORKSPACE_DIRS
+from src.utils import utc_now
+
+FRESH = "connfresh"
+STALE = "connstale"
+ORPHAN = "connorphan"
+
+
+def _build_output_tree(root):
+    """Lay out a realistic OUTPUT_DIR with workspaces and satellite stores."""
+    stale_ts = utc_now().replace(year=utc_now().year - 5).isoformat()
+
+    for cid, updated_at in ((FRESH, utc_now().isoformat()), (STALE, stale_ts)):
+        ws = root / cid
+        ws.mkdir(parents=True)
+        (ws / "metadata.json").write_text(
+            json.dumps({"workspace": {"updated_at": updated_at, "schemas": {}}}),
+            encoding="utf-8",
+        )
+
+    (root / ORPHAN).mkdir(parents=True)  # no metadata.json
+
+    for cid in (FRESH, STALE, ORPHAN):
+        (root / "chromadb" / cid).mkdir(parents=True)
+        (root / "oxigraph" / cid / "store").mkdir(parents=True)
+
+    (root / "stale_top_level.png").write_text("x", encoding="utf-8")
+    (root / FRESH / "charts").mkdir()
+
+
+def _run_cleanup(monkeypatch, root, mode):
+    """Invoke the real cleanup_tmp_folder against a temp OUTPUT_DIR."""
+    import server
+
+    monkeypatch.setattr("src.paths.OUTPUT_DIR", root)
+    monkeypatch.setenv("AUTO_CLEANUP_ON_STARTUP", mode)
+    monkeypatch.setenv("WORKSPACE_MAX_AGE_DAYS", "30")
+    server.cleanup_tmp_folder()
+
+
+def test_non_workspace_dirs_covers_the_real_store_locations():
+    """The skip-list must match where the stores are actually written."""
+    assert {"chromadb", "oxigraph"} <= set(NON_WORKSPACE_DIRS)
+
+
+def test_disabled_mode_keeps_workspaces_but_clears_ephemera(tmp_path, monkeypatch):
+    """With cleanup off, only loose files and chart dirs go."""
+    _build_output_tree(tmp_path)
+    _run_cleanup(monkeypatch, tmp_path, "false")
+
+    assert (tmp_path / FRESH).exists()
+    assert (tmp_path / STALE).exists(), "disabled mode must not delete workspaces"
+    assert (tmp_path / ORPHAN).exists()
+    assert not (tmp_path / "stale_top_level.png").exists()
+    assert not (tmp_path / FRESH / "charts").exists()
+
+
+def test_retention_mode_preserves_satellite_store_roots(tmp_path, monkeypatch):
+    """chromadb/ and oxigraph/ must never be treated as orphaned workspaces.
+
+    This is the data-loss regression: they carry no metadata.json, so a naive
+    scan deleted both wholesale -- every connection's vectors and triples.
+    """
+    _build_output_tree(tmp_path)
+    _run_cleanup(monkeypatch, tmp_path, "true")
+
+    assert (tmp_path / "chromadb").exists(), "chromadb root was deleted"
+    assert (tmp_path / "oxigraph").exists(), "oxigraph root was deleted"
+    assert (tmp_path / "chromadb" / FRESH).exists()
+    assert (tmp_path / "oxigraph" / FRESH / "store").exists()
+
+
+def test_retention_mode_removes_stale_workspace_and_its_stores(tmp_path, monkeypatch):
+    """A deleted workspace must not strand its satellite stores."""
+    _build_output_tree(tmp_path)
+    _run_cleanup(monkeypatch, tmp_path, "true")
+
+    assert not (tmp_path / STALE).exists()
+    assert not (tmp_path / "chromadb" / STALE).exists(), "stranded ChromaDB store"
+    assert not (tmp_path / "oxigraph" / STALE).exists(), "stranded Oxigraph store"
+
+    assert (tmp_path / FRESH).exists(), "workspace within retention was deleted"
+
+
+def test_retention_mode_removes_orphaned_workspace_and_its_stores(
+    tmp_path, monkeypatch
+):
+    """A directory with no metadata.json is orphaned and goes, stores included."""
+    _build_output_tree(tmp_path)
+    _run_cleanup(monkeypatch, tmp_path, "true")
+
+    assert not (tmp_path / ORPHAN).exists()
+    assert not (tmp_path / "chromadb" / ORPHAN).exists()
+    assert not (tmp_path / "oxigraph" / ORPHAN).exists()
+
+
+@pytest.mark.parametrize("cid", [FRESH, STALE, ORPHAN])
+def test_all_mode_removes_every_workspace_and_store(tmp_path, monkeypatch, cid):
+    """`all` is a full reset -- no workspace or satellite store survives."""
+    _build_output_tree(tmp_path)
+    _run_cleanup(monkeypatch, tmp_path, "all")
+
+    assert not (tmp_path / cid).exists()
+    assert not (tmp_path / "chromadb" / cid).exists()
+    assert not (tmp_path / "oxigraph" / cid).exists()
+
+
+def test_workspace_without_updated_at_is_kept(tmp_path, monkeypatch):
+    """Metadata lacking updated_at is not evidence of staleness."""
+    ws = tmp_path / "connnodate"
+    ws.mkdir(parents=True)
+    (ws / "metadata.json").write_text(
+        json.dumps({"workspace": {"schemas": {}}}), encoding="utf-8"
+    )
+    _run_cleanup(monkeypatch, tmp_path, "true")
+
+    assert ws.exists(), "workspace with no updated_at must not be deleted"

--- a/tests/test_startup_cleanup.py
+++ b/tests/test_startup_cleanup.py
@@ -136,3 +136,39 @@ def test_workspace_without_updated_at_is_kept(tmp_path, monkeypatch):
     _run_cleanup(monkeypatch, tmp_path, "true")
 
     assert ws.exists(), "workspace with no updated_at must not be deleted"
+
+
+def test_cleanup_workspace_tool_covers_the_same_directories_as_startup():
+    """The runtime cleanup tool and startup cleanup must delete the same set.
+
+    Both remove a connection's workspace plus its satellite stores. They used to
+    hardcode the store paths independently, so adding a third store location
+    would have been fixed in one place and silently missed in the other.
+    """
+    import inspect
+
+    from src.handlers import workspace as workspace_handler
+
+    source = inspect.getsource(workspace_handler.cleanup_workspace)
+    assert "get_connection_store_dirs" in source, (
+        "cleanup_workspace must derive satellite store paths from "
+        "get_connection_store_dirs() rather than hardcoding them"
+    )
+
+
+def test_cleanup_workspace_does_not_claim_failed_deletions(tmp_path, monkeypatch):
+    """rmtree(ignore_errors=True) never raises, so success must be verified.
+
+    A locked or read-only tree survives the call silently; reporting it as
+    removed tells the user their data is gone when it is not.
+    """
+    import inspect
+
+    from src.handlers import workspace as workspace_handler
+
+    source = inspect.getsource(workspace_handler.cleanup_workspace)
+    # The existence re-check is what makes the report truthful.
+    assert "if dir_path.exists():" in source, (
+        "cleanup_workspace must re-check existence after rmtree before "
+        "reporting a directory as removed"
+    )

--- a/tests/test_timestamps.py
+++ b/tests/test_timestamps.py
@@ -1,0 +1,72 @@
+"""Tests for timezone-aware timestamp handling (DTZ005/DTZ006 migration).
+
+Workspace metadata persists timestamps as ISO strings and later compares them
+against the current time to decide retention. Once the writer switched to
+timezone-aware UTC, any workspace already on disk still held *naive* strings --
+and comparing naive against aware raises TypeError. These tests pin the
+backward-compatible read path that prevents that regression.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from src.utils import parse_timestamp, utc_now
+
+# A timestamp as written by the pre-migration code: no offset.
+LEGACY_NAIVE_ISO = "2020-01-01T12:00:00"
+
+
+def test_utc_now_is_timezone_aware():
+    """Everything written from now on must carry tzinfo."""
+    now = utc_now()
+    assert now.tzinfo is not None
+    assert now.utcoffset() == timedelta(0)
+
+
+def test_parse_timestamp_coerces_naive_to_utc():
+    """Legacy naive workspace values are read as UTC rather than rejected."""
+    parsed = parse_timestamp(LEGACY_NAIVE_ISO)
+    assert parsed.tzinfo is not None
+    assert parsed == datetime(2020, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def test_parse_timestamp_preserves_existing_offset():
+    """An already-aware value must survive untouched."""
+    aware = "2020-01-01T12:00:00+02:00"
+    assert parse_timestamp(aware) == datetime.fromisoformat(aware)
+
+
+def test_parse_timestamp_round_trips_what_utc_now_writes():
+    """The write path and read path agree."""
+    written = utc_now().isoformat()
+    assert parse_timestamp(written) == datetime.fromisoformat(written)
+
+
+def test_legacy_naive_timestamp_is_comparable_after_migration():
+    """The actual regression: retention cleanup on a pre-existing workspace.
+
+    Reading a legacy naive value with a bare ``datetime.fromisoformat`` and
+    comparing it to an aware "now" raises TypeError, which would break startup
+    cleanup for every workspace written before the migration. ``parse_timestamp``
+    is what keeps that working.
+    """
+    # Bare parse is genuinely broken against an aware now -- this is the bug.
+    naive = datetime.fromisoformat(LEGACY_NAIVE_ISO)
+    try:
+        naive < utc_now()
+        raise AssertionError("expected TypeError from naive/aware comparison")
+    except TypeError:
+        pass
+
+    # The shim makes the same on-disk value usable.
+    coerced = parse_timestamp(LEGACY_NAIVE_ISO)
+    assert coerced < utc_now()
+    assert (utc_now() - coerced).days > 0
+
+
+def test_retention_math_works_on_legacy_values():
+    """Age computation over a legacy timestamp yields a sane positive age."""
+    cutoff = utc_now() - timedelta(days=30)
+    assert parse_timestamp(LEGACY_NAIVE_ISO) < cutoff
+
+    recent = (utc_now() - timedelta(days=1)).isoformat()
+    assert parse_timestamp(recent) > cutoff


### PR DESCRIPTION
Stacked on #66 — **base is `chore/adopt-ruff-modernization`.** Merge order: #65 → #66 → this.

The judgment-heavy half of the ruff adoption. Unlike #66 this **changes behavior**, so each group was audited rather than auto-fixed. Five commits, each independently reviewable.

## 1. `ASYNC230` — blocking file I/O on the event loop (11 sites)

The most consequential fix here. Eleven `async def` handlers called plain `open()/read()/write()`. The artifacts are ontology TTL and schema JSON — routinely megabytes on a large schema — so every one stalled **all** concurrent MCP sessions for the duration.

Four helpers in `src/utils.py` push the whole operation into a worker thread via `asyncio.to_thread`, including the JSON encode/decode (itself CPU-bound at that size — doing it on the loop would have left half the problem). Behavior deliberately unchanged: same encoding, same `indent=2`/`ensure_ascii=False` on-disk format, identical exception propagation.

New `tests/test_async_file_io.py` (7 tests). The key one asserts a concurrent task still gets scheduled during a large write — **verified non-vacuous**: it reports 0 ticks and fails against a blocking implementation.

## 2. `S110`/`SIM105` — swallowed exceptions (19 sites)

The ones #66 deliberately refused to launder into `contextlib.suppress`. They split two ways:

- **14 driver cursor-cleanup sites** (`result.close()` in an error path / `finally`). The swallow is *correct* — a close failure must not mask the real error — but the failure vanished entirely. Now logged at debug with a comment recording why it isn't propagated. `contextlib.suppress`, the "obvious" fix, would have kept them equally silent while making the finding disappear.
- **5 narrow named catches** (`nx.NetworkXNoPath`, `ValueError/TypeError`, `AttributeError`) where "nothing to do" is correct. `S110` doesn't flag these precisely because they aren't broad, so `contextlib.suppress` is right and erases no signal.

## 3. `DTZ005/006` — naive timestamps (43 sites) ⚠️ migration hazard

Workspace metadata persists timestamps and later compares them against "now" for retention. The write side is easy; **the read side is the hazard.** Workspaces already on disk hold naive ISO strings, and comparing one against an aware `now` raises `TypeError`. Three sites do exactly that arithmetic — and the `server.py` one runs at **startup** under `AUTO_CLEANUP_ON_STARTUP`.

A write-only migration would have crashed startup for every existing user with a workspace on disk. This was not theoretical: migrating writes first made **6 existing tests fail with exactly that TypeError** before the read path was added.

`utc_now()` for writes, `parse_timestamp()` for reads (assumes UTC when no offset present). New `tests/test_timestamps.py` includes a test asserting the bare `fromisoformat` comparison *still* raises, so the shim can't be quietly removed later without the suite noticing.

## 4. `G201` — `logger.error(exc_info=True)` → `logger.exception` (24 sites)

Mechanical. AST-verified that all 24 sit inside an `except` handler — outside one, `logger.exception` logs a useless `NoneType: None`.

## 5. `BLE001` — 167 blind excepts, audited not waved through

An AST audit classified every one:

| | count |
|---|---|
| logs the exception | 153 |
| re-raises | 23 |
| folds message into returned error payload | 23 |
| **discards entirely** | **4** |

The breadth is *required* at the MCP tool boundary — a handler must turn failures into an error response, not leak arbitrary exceptions into the protocol layer. The 4 that threw information away are the real defect and are fixed:

- `shacl_validator.py` ×2 — a broken `pyshacl` install **silently disabled SHACL validation**. Still degrades gracefully, now says why.
- `vector_store_chromadb.py` — a failed type-distribution query silently reported **zeros for every element type**, indistinguishable from an empty store. Now warns the numbers are a fallback.
- `utils.py` — narrowed to `ValueError`, what `urlparse` actually raises. Anything else is a caller bug that should surface, not be flattened to `False`.

**`BLE001` stays unselected**, documented in `pyproject.toml` with the audit result: enabling it means 167 `noqa` comments and no added safety. Instead `tests/test_no_silent_exceptions.py` enforces the invariant that actually matters — *a broad handler may not discard what it caught* — by walking the AST. That's **stricter and more precise** than the lint rule: it permits the boundary pattern while failing on real information loss. It ships with a planted-violation test so it can't pass vacuously.

## Now permanently enabled

`ASYNC`, `S110`, `DTZ`, `G201` added to the ruff selection; the `SIM105` ignore from #66 is **removed** (genuinely resolved, not deferred). Enabling `ASYNC` repo-wide also surfaced `ASYNC250` in the three `integrations/` agent examples (blocking `input()`); fixed with `asyncio.to_thread` so the examples model the right pattern.

## Verification

`ruff check` clean **repo-wide** under 0.15.10 and 0.16.0 · `black` · `isort` · `mypy --strict` · **394 tests** (378 → 394; +16 new).

## Not included

`G004` (502 f-strings in logging) and `TRY400` (130) are outside the 0.16 default set — a further expansion, not part of the findings flagged in #65. `G004` in particular trades eager formatting for lazy `%`-args across the whole codebase and deserves its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)