### PR TITLE
chore(deps-dev): bump black from 23.12 to 26.5 and reformat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 repos:
   # Code formatting
   - repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 26.5.1
     hooks:
       - id: black
         language_version: python3.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ dev = [
     "pytest-mock>=3.15.0,<4.0.0",
     "pytest-benchmark>=5.1.0,<6.0.0",
     # Code formatting and linting
-    "black>=23.12.0,<24.0.0",
+    "black>=26.5.0,<27.0.0",
     "isort>=5.13.0,<6.0.0",
     "flake8>=7.0.0,<8.0.0",
     "mypy>=1.8.0,<2.0.0",
@@ -162,10 +162,8 @@ select = [
 
 [tool.black]
 line-length = 88
-# Highest syntax level the pinned black (>=23.12,<24) understands. The runtime
-# target is still Python 3.13 (see requires-python); this only bounds the syntax
-# black may emit. Bump to py313 when black is upgraded to >=24.10.
-target-version = ['py312']
+# Matches requires-python (>=3.13); bounds the syntax black may emit.
+target-version = ['py313']
 include = '\.pyi?$'
 extend-exclude = '''
 /(

--- a/src/database_manager.py
+++ b/src/database_manager.py
@@ -1034,9 +1034,9 @@ class DatabaseManager:
         }
 
         if not security_validation.get("is_safe", False):
-            validation_result[
-                "error"
-            ] = f"Security validation failed: {'; '.join(security_validation['issues'])}"
+            validation_result["error"] = (
+                f"Security validation failed: {'; '.join(security_validation['issues'])}"
+            )
             validation_result["error_type"] = "security_error"
             audit_log_security_event(
                 "sql_injection_attempt",
@@ -1045,9 +1045,11 @@ class DatabaseManager:
                     "issues": security_validation["issues"],
                     "risk_level": security_validation["risk_level"],
                 },
-                SecurityLevel.CRITICAL
-                if security_validation["risk_level"] == "critical"
-                else SecurityLevel.HIGH,
+                (
+                    SecurityLevel.CRITICAL
+                    if security_validation["risk_level"] == "critical"
+                    else SecurityLevel.HIGH
+                ),
             )
             return validation_result
 
@@ -1070,27 +1072,27 @@ class DatabaseManager:
 
             if parsed["parsed"]:
                 if not parsed["single_statement"]:
-                    validation_result[
-                        "error"
-                    ] = "Multiple SQL statements not allowed for security"
+                    validation_result["error"] = (
+                        "Multiple SQL statements not allowed for security"
+                    )
                     validation_result["error_type"] = "security_error"
                     validation_result["suggestions"].append(
                         "Split multiple statements into separate requests"
                     )
                     return validation_result
                 if parsed["query_type"] == "WRITE":
-                    validation_result[
-                        "error"
-                    ] = f"Destructive operations not allowed: {', '.join(parsed['write_operations'])}"
+                    validation_result["error"] = (
+                        f"Destructive operations not allowed: {', '.join(parsed['write_operations'])}"
+                    )
                     validation_result["error_type"] = "forbidden_operation"
                     validation_result["suggestions"].append(
                         "Use SELECT queries for data retrieval only"
                     )
                     return validation_result
                 if parsed["query_type"] == "UNKNOWN":
-                    validation_result[
-                        "error"
-                    ] = "Only SELECT, CTE, and metadata queries are allowed"
+                    validation_result["error"] = (
+                        "Only SELECT, CTE, and metadata queries are allowed"
+                    )
                     validation_result["error_type"] = "query_type_error"
                     validation_result["suggestions"].append(
                         "Start your query with SELECT, WITH, EXPLAIN, or SHOW"
@@ -1106,9 +1108,9 @@ class DatabaseManager:
                 query_upper = query_without_comments.upper()
 
                 if ";" in query_stripped[:-1]:
-                    validation_result[
-                        "error"
-                    ] = "Multiple SQL statements not allowed for security"
+                    validation_result["error"] = (
+                        "Multiple SQL statements not allowed for security"
+                    )
                     validation_result["error_type"] = "security_error"
                     validation_result["suggestions"].append(
                         "Split multiple statements into separate requests"
@@ -1140,18 +1142,18 @@ class DatabaseManager:
                         op for op in dangerous_ops if query_upper.startswith(op)
                     ]
                     if detected_ops:
-                        validation_result[
-                            "error"
-                        ] = f"Destructive operations not allowed: {', '.join(detected_ops)}"
+                        validation_result["error"] = (
+                            f"Destructive operations not allowed: {', '.join(detected_ops)}"
+                        )
                         validation_result["error_type"] = "forbidden_operation"
                         validation_result["suggestions"].append(
                             "Use SELECT queries for data retrieval only"
                         )
                         return validation_result
                     else:
-                        validation_result[
-                            "error"
-                        ] = "Only SELECT, CTE, and metadata queries are allowed"
+                        validation_result["error"] = (
+                            "Only SELECT, CTE, and metadata queries are allowed"
+                        )
                         validation_result["error_type"] = "query_type_error"
                         validation_result["suggestions"].append(
                             "Start your query with SELECT, WITH, EXPLAIN, or SHOW"

--- a/src/dremio_client.py
+++ b/src/dremio_client.py
@@ -112,9 +112,9 @@ class DremioClient:
             raise DremioAuthError("Client session is not initialized")
 
         headers = {
-            "Authorization": f"Bearer {self.token}"
-            if self.pat
-            else f"_dremio{self.token}",
+            "Authorization": (
+                f"Bearer {self.token}" if self.pat else f"_dremio{self.token}"
+            ),
             "Content-Type": "application/json",
         }
         if "headers" in kwargs:

--- a/src/drivers/bigquery.py
+++ b/src/drivers/bigquery.py
@@ -151,14 +151,12 @@ class BigQueryDriver(DatabaseDriver):
         """
         try:
             # Query INFORMATION_SCHEMA to get datasets
-            query = text(
-                f"""
+            query = text(f"""
                 SELECT schema_name
                 FROM `{self._project_id}`.INFORMATION_SCHEMA.SCHEMATA
                 WHERE schema_name NOT IN UNNEST({BIGQUERY_SYSTEM_SCHEMAS})
                 ORDER BY schema_name
-            """
-            )
+            """)
             assert self.engine is not None
             with self.engine.connect() as conn:
                 result = conn.execute(query)
@@ -181,14 +179,12 @@ class BigQueryDriver(DatabaseDriver):
 
             assert self.engine is not None
             with self.engine.connect() as conn:
-                query = text(
-                    f"""
+                query = text(f"""
                     SELECT table_name
                     FROM `{self._project_id}.{dataset}`.INFORMATION_SCHEMA.TABLES
                     WHERE table_type = 'BASE TABLE'
                     ORDER BY table_name
-                """
-                )
+                """)
                 result = conn.execute(query)
                 return [row[0] for row in result.fetchall()]
         except SQLAlchemyError as e:
@@ -300,9 +296,9 @@ class BigQueryDriver(DatabaseDriver):
                             "Insufficient permissions to access the specified tables/datasets"
                         )
         except Exception as conn_error:
-            validation_result[
-                "error"
-            ] = f"Database connection error during validation: {conn_error}"
+            validation_result["error"] = (
+                f"Database connection error during validation: {conn_error}"
+            )
             validation_result["error_type"] = "connection_error"
 
         return validation_result

--- a/src/drivers/clickhouse.py
+++ b/src/drivers/clickhouse.py
@@ -117,14 +117,12 @@ class ClickHouseDriver(DatabaseDriver):
 
     def get_schemas(self) -> list[str]:
         excluded_schemas = "', '".join(CLICKHOUSE_SYSTEM_SCHEMAS)
-        query = text(
-            f"""
+        query = text(f"""
             SELECT name
             FROM system.databases
             WHERE name NOT IN ('{excluded_schemas}')
             ORDER BY name
-        """
-        )
+        """)
         try:
             assert self.engine is not None
             with self.engine.connect() as conn:
@@ -139,28 +137,24 @@ class ClickHouseDriver(DatabaseDriver):
             assert self.engine is not None
             with self.engine.connect() as conn:
                 if schema_name:
-                    query = text(
-                        """
+                    query = text("""
                         SELECT name
                         FROM system.tables
                         WHERE database = :schema_name
                           AND engine NOT IN ('View', 'MaterializedView')
                         ORDER BY name
-                    """
-                    )
+                    """)
                     result = conn.execute(query, {"schema_name": schema_name})
                 else:
                     # Use the connected database name
                     db_name = self._current_database or "default"
-                    query = text(
-                        """
+                    query = text("""
                         SELECT name
                         FROM system.tables
                         WHERE database = :db_name
                           AND engine NOT IN ('View', 'MaterializedView')
                         ORDER BY name
-                    """
-                    )
+                    """)
                     result = conn.execute(query, {"db_name": db_name})
                 return [row[0] for row in result.fetchall()]
         except SQLAlchemyError as e:
@@ -274,13 +268,11 @@ class ClickHouseDriver(DatabaseDriver):
                 table_comment = None
                 if schema_name:
                     try:
-                        ch_meta_query = text(
-                            """
+                        ch_meta_query = text("""
                             SELECT engine, sorting_key, total_rows
                             FROM system.tables
                             WHERE database = :db AND name = :tbl
-                        """
-                        )
+                        """)
                         ch_result = conn.execute(
                             ch_meta_query,
                             {"db": schema_name, "tbl": table_name},
@@ -367,9 +359,9 @@ class ClickHouseDriver(DatabaseDriver):
                             "(ClickHouse is case-sensitive)"
                         )
         except Exception as conn_error:
-            validation_result[
-                "error"
-            ] = f"Database connection error during validation: {conn_error}"
+            validation_result["error"] = (
+                f"Database connection error during validation: {conn_error}"
+            )
             validation_result["error_type"] = "connection_error"
 
         return validation_result

--- a/src/drivers/databricks.py
+++ b/src/drivers/databricks.py
@@ -173,14 +173,12 @@ class DatabricksDriver(DatabaseDriver):
         """
         try:
             # Query to get schemas in the current catalog
-            query = text(
-                """
+            query = text("""
                 SELECT schema_name
                 FROM information_schema.schemata
                 WHERE catalog_name = :catalog
                 ORDER BY schema_name
-            """
-            )
+            """)
             assert self.engine is not None
             with self.engine.connect() as conn:
                 result = conn.execute(query, {"catalog": self._catalog})
@@ -214,16 +212,14 @@ class DatabricksDriver(DatabaseDriver):
 
             assert self.engine is not None
             with self.engine.connect() as conn:
-                query = text(
-                    """
+                query = text("""
                     SELECT table_name
                     FROM information_schema.tables
                     WHERE table_catalog = :catalog
                     AND table_schema = :schema
                     AND table_type = 'BASE TABLE'
                     ORDER BY table_name
-                """
-                )
+                """)
                 result = conn.execute(
                     query, {"catalog": self._catalog, "schema": schema}
                 )
@@ -388,9 +384,9 @@ class DatabricksDriver(DatabaseDriver):
                             "Insufficient permissions to access the specified tables/catalogs"
                         )
         except Exception as conn_error:
-            validation_result[
-                "error"
-            ] = f"Database connection error during validation: {conn_error}"
+            validation_result["error"] = (
+                f"Database connection error during validation: {conn_error}"
+            )
             validation_result["error_type"] = "connection_error"
 
         return validation_result

--- a/src/drivers/duckdb.py
+++ b/src/drivers/duckdb.py
@@ -161,14 +161,12 @@ class DuckDBDriver(DatabaseDriver):
         """
         try:
             excluded_schemas = "', '".join(DUCKDB_SYSTEM_SCHEMAS)
-            query = text(
-                f"""
+            query = text(f"""
                 SELECT schema_name
                 FROM information_schema.schemata
                 WHERE schema_name NOT IN ('{excluded_schemas}')
                 ORDER BY schema_name
-            """
-            )
+            """)
             assert self.engine is not None
             with self.engine.connect() as conn:
                 result = conn.execute(query)
@@ -188,15 +186,13 @@ class DuckDBDriver(DatabaseDriver):
 
             assert self.engine is not None
             with self.engine.connect() as conn:
-                query = text(
-                    """
+                query = text("""
                     SELECT table_name
                     FROM information_schema.tables
                     WHERE table_schema = :schema_name
                     AND table_type = 'BASE TABLE'
                     ORDER BY table_name
-                """
-                )
+                """)
                 result = conn.execute(query, {"schema_name": schema})
                 return [row[0] for row in result.fetchall()]
         except SQLAlchemyError as e:
@@ -327,9 +323,9 @@ class DuckDBDriver(DatabaseDriver):
                             "Review DuckDB SQL syntax - check for missing commas, parentheses, or keywords"
                         )
         except Exception as conn_error:
-            validation_result[
-                "error"
-            ] = f"Database connection error during validation: {conn_error}"
+            validation_result["error"] = (
+                f"Database connection error during validation: {conn_error}"
+            )
             validation_result["error_type"] = "connection_error"
 
         return validation_result

--- a/src/drivers/mysql.py
+++ b/src/drivers/mysql.py
@@ -135,14 +135,12 @@ class MySQLDriver(DatabaseDriver):
 
     def get_schemas(self) -> list[str]:
         excluded_schemas = "', '".join(MYSQL_SYSTEM_SCHEMAS)
-        query = text(
-            f"""
+        query = text(f"""
             SELECT SCHEMA_NAME
             FROM information_schema.SCHEMATA
             WHERE SCHEMA_NAME NOT IN ('{excluded_schemas}')
             ORDER BY SCHEMA_NAME
-        """
-        )
+        """)
         try:
             assert self.engine is not None
             with self.engine.connect() as conn:
@@ -157,25 +155,21 @@ class MySQLDriver(DatabaseDriver):
             assert self.engine is not None
             with self.engine.connect() as conn:
                 if schema_name:
-                    query = text(
-                        """
+                    query = text("""
                         SELECT TABLE_NAME
                         FROM information_schema.TABLES
                         WHERE TABLE_SCHEMA = :schema_name
                         AND TABLE_TYPE = 'BASE TABLE'
                         ORDER BY TABLE_NAME
-                    """
-                    )
+                    """)
                     result = conn.execute(query, {"schema_name": schema_name})
                 else:
-                    query = text(
-                        """
+                    query = text("""
                         SELECT TABLE_NAME
                         FROM information_schema.TABLES
                         WHERE TABLE_TYPE = 'BASE TABLE'
                         ORDER BY TABLE_NAME
-                    """
-                    )
+                    """)
                     result = conn.execute(query)
                 return [row[0] for row in result.fetchall()]
         except SQLAlchemyError as e:
@@ -328,9 +322,9 @@ class MySQLDriver(DatabaseDriver):
                             "Insufficient permissions to access the specified tables"
                         )
         except Exception as conn_error:
-            validation_result[
-                "error"
-            ] = f"Database connection error during validation: {conn_error}"
+            validation_result["error"] = (
+                f"Database connection error during validation: {conn_error}"
+            )
             validation_result["error_type"] = "connection_error"
 
         return validation_result

--- a/src/drivers/postgresql.py
+++ b/src/drivers/postgresql.py
@@ -133,16 +133,14 @@ class PostgreSQLDriver(DatabaseDriver):
 
     def get_schemas(self) -> list[str]:
         excluded_schemas = "', '".join(POSTGRES_SYSTEM_SCHEMAS)
-        query = text(
-            f"""
+        query = text(f"""
             SELECT schema_name
             FROM information_schema.schemata
             WHERE schema_name NOT IN ('{excluded_schemas}')
               AND schema_name NOT LIKE 'pg_temp_%'
               AND schema_name NOT LIKE 'pg_toast_temp_%'
             ORDER BY schema_name
-        """
-        )
+        """)
         try:
             assert self.engine is not None
             with self.engine.connect() as conn:
@@ -157,25 +155,21 @@ class PostgreSQLDriver(DatabaseDriver):
             assert self.engine is not None
             with self.engine.connect() as conn:
                 if schema_name:
-                    query = text(
-                        """
+                    query = text("""
                         SELECT table_name
                         FROM information_schema.tables
                         WHERE table_schema = :schema_name
                         AND table_type = 'BASE TABLE'
                         ORDER BY table_name
-                    """
-                    )
+                    """)
                     result = conn.execute(query, {"schema_name": schema_name})
                 else:
-                    query = text(
-                        """
+                    query = text("""
                         SELECT table_name
                         FROM information_schema.tables
                         WHERE table_type = 'BASE TABLE'
                         ORDER BY table_name
-                    """
-                    )
+                    """)
                     result = conn.execute(query)
                 return [row[0] for row in result.fetchall()]
         except SQLAlchemyError as e:
@@ -330,9 +324,9 @@ class PostgreSQLDriver(DatabaseDriver):
                             "Insufficient permissions to access the specified tables"
                         )
         except Exception as conn_error:
-            validation_result[
-                "error"
-            ] = f"Database connection error during validation: {conn_error}"
+            validation_result["error"] = (
+                f"Database connection error during validation: {conn_error}"
+            )
             validation_result["error_type"] = "connection_error"
 
         return validation_result

--- a/src/drivers/snowflake.py
+++ b/src/drivers/snowflake.py
@@ -115,14 +115,12 @@ class SnowflakeDriver(DatabaseDriver):
 
     def get_schemas(self) -> list[str]:
         excluded_schemas = "', '".join(SNOWFLAKE_SYSTEM_SCHEMAS)
-        query = text(
-            f"""
+        query = text(f"""
             SELECT schema_name
             FROM information_schema.schemata
             WHERE schema_name NOT IN ('{excluded_schemas}')
             ORDER BY schema_name
-        """
-        )
+        """)
         try:
             assert self.engine is not None
             with self.engine.connect() as conn:
@@ -137,25 +135,21 @@ class SnowflakeDriver(DatabaseDriver):
             assert self.engine is not None
             with self.engine.connect() as conn:
                 if schema_name:
-                    query = text(
-                        """
+                    query = text("""
                         SELECT table_name
                         FROM information_schema.tables
                         WHERE table_schema = :schema_name
                         AND table_type = 'BASE TABLE'
                         ORDER BY table_name
-                    """
-                    )
+                    """)
                     result = conn.execute(query, {"schema_name": schema_name})
                 else:
-                    query = text(
-                        """
+                    query = text("""
                         SELECT table_name
                         FROM information_schema.tables
                         WHERE table_type = 'BASE TABLE'
                         ORDER BY table_name
-                    """
-                    )
+                    """)
                     result = conn.execute(query)
                 return [row[0] for row in result.fetchall()]
         except SQLAlchemyError as e:
@@ -273,8 +267,7 @@ class SnowflakeDriver(DatabaseDriver):
                 cols_by_table: dict[str, list[dict]] = {}
                 cols_success = False
                 try:
-                    cols_query = text(
-                        """
+                    cols_query = text("""
                         SELECT table_name, column_name, data_type,
                                character_maximum_length, numeric_precision,
                                numeric_scale, is_nullable, column_default,
@@ -282,8 +275,7 @@ class SnowflakeDriver(DatabaseDriver):
                         FROM information_schema.columns
                         WHERE table_schema = :schema_name
                         ORDER BY table_name, ordinal_position
-                    """
-                    )
+                    """)
                     log_sql(str(cols_query))
                     result = conn.execute(cols_query, {"schema_name": schema_name})
                     for row in result.fetchall():
@@ -423,16 +415,14 @@ class SnowflakeDriver(DatabaseDriver):
                 # Fallback: if columns not from cache, fetch with query
                 if table_columns is None and schema_name:
                     try:
-                        cols_query = text(
-                            """
+                        cols_query = text("""
                             SELECT column_name, data_type, is_nullable,
                                    column_default, comment
                             FROM information_schema.columns
                             WHERE table_schema = :schema_name
                               AND table_name = :table_name
                             ORDER BY ordinal_position
-                        """
-                        )
+                        """)
                         if log_sql:
                             log_sql(str(cols_query))
                         result = conn.execute(
@@ -607,9 +597,9 @@ class SnowflakeDriver(DatabaseDriver):
                             "double quotes for case-sensitive names"
                         )
         except Exception as conn_error:
-            validation_result[
-                "error"
-            ] = f"Database connection error during validation: {conn_error}"
+            validation_result["error"] = (
+                f"Database connection error during validation: {conn_error}"
+            )
             validation_result["error_type"] = "connection_error"
 
         return validation_result

--- a/src/graphrag/manager.py
+++ b/src/graphrag/manager.py
@@ -393,9 +393,9 @@ class GraphRAGManager:
 
         if self.community_detector:
             overview["communities"] = self.community_detector.get_all_summaries()
-            overview[
-                "domain_suggestions"
-            ] = self.community_detector.suggest_domain_names()
+            overview["domain_suggestions"] = (
+                self.community_detector.suggest_domain_names()
+            )
 
         return overview
 

--- a/src/graphrag/vector_store_chromadb.py
+++ b/src/graphrag/vector_store_chromadb.py
@@ -477,9 +477,11 @@ class ChromaDBVectorStore:
                     "name": metadata.get("name", ""),
                     "description": metadata.get("description", ""),
                     "metadata": elem_metadata,
-                    "embedding": embedding.tolist()
-                    if hasattr(embedding, "tolist")
-                    else embedding,
+                    "embedding": (
+                        embedding.tolist()
+                        if hasattr(embedding, "tolist")
+                        else embedding
+                    ),
                 }
                 elements.append(element_dict)
 

--- a/src/handlers/ontology_io.py
+++ b/src/handlers/ontology_io.py
@@ -285,9 +285,9 @@ async def load_my_ontology(
             "properties_count": datatype_props,
             "relationships_count": object_props,
             "total_files_found": len(ttl_files),
-            "other_files": [f.name for f in ttl_files[1:5]]
-            if len(ttl_files) > 1
-            else [],
+            "other_files": (
+                [f.name for f in ttl_files[1:5]] if len(ttl_files) > 1 else []
+            ),
             "stored_in_rdf": stored_in_rdf,
         }
 
@@ -321,9 +321,9 @@ async def load_my_ontology(
                     "3. execute_sql_query (use ontology context for accurate SQL)",
                 ],
             }
-            response[
-                "note"
-            ] = "This ontology is now active and will be used instead of auto-generated ontologies"
+            response["note"] = (
+                "This ontology is now active and will be used instead of auto-generated ontologies"
+            )
 
         if compatibility:
             response["compatibility"] = compatibility

--- a/src/handlers/query.py
+++ b/src/handlers/query.py
@@ -131,9 +131,9 @@ async def validate_sql_syntax(
             if not obqc_result.is_valid:
                 validation_result["is_valid"] = False
                 if not validation_result.get("error"):
-                    validation_result[
-                        "error"
-                    ] = "OBQC validation failed - see obqc_issues for details"
+                    validation_result["error"] = (
+                        "OBQC validation failed - see obqc_issues for details"
+                    )
                 validation_result["error_type"] = (
                     validation_result.get("error_type") or "obqc_error"
                 )

--- a/src/ontology_generator.py
+++ b/src/ontology_generator.py
@@ -1632,9 +1632,9 @@ class OntologyGenerator:
 
             class_info: dict[str, Any] = {
                 "uri": str(subject),
-                "local_name": str(subject).split("/")[-1]
-                if "/" in str(subject)
-                else str(subject),
+                "local_name": (
+                    str(subject).split("/")[-1] if "/" in str(subject) else str(subject)
+                ),
                 "current_label": None,
                 "table_name": None,
                 "schema_name": None,
@@ -1666,9 +1666,9 @@ class OntologyGenerator:
         for subject in self.graph.subjects(RDF.type, OWL.DatatypeProperty):
             prop_info: dict[str, Any] = {
                 "uri": str(subject),
-                "local_name": str(subject).split("/")[-1]
-                if "/" in str(subject)
-                else str(subject),
+                "local_name": (
+                    str(subject).split("/")[-1] if "/" in str(subject) else str(subject)
+                ),
                 "current_label": None,
                 "column_name": None,
                 "table_name": None,
@@ -1706,9 +1706,9 @@ class OntologyGenerator:
         for subject in self.graph.subjects(RDF.type, OWL.ObjectProperty):
             rel_info: dict[str, Any] = {
                 "uri": str(subject),
-                "local_name": str(subject).split("/")[-1]
-                if "/" in str(subject)
-                else str(subject),
+                "local_name": (
+                    str(subject).split("/")[-1] if "/" in str(subject) else str(subject)
+                ),
                 "current_label": None,
                 "foreign_key_column": None,
                 "referenced_table": None,
@@ -1902,11 +1902,11 @@ class OntologyGenerator:
         return {
             "is_cryptic": is_cryptic,
             "reasons": reasons,
-            "confidence": "high"
-            if len(reasons) >= 2
-            else "medium"
-            if len(reasons) == 1
-            else "low",
+            "confidence": (
+                "high"
+                if len(reasons) >= 2
+                else "medium" if len(reasons) == 1 else "low"
+            ),
         }
 
     def apply_semantic_names(self, name_suggestions: dict[str, Any]) -> str:
@@ -2030,9 +2030,9 @@ class OntologyGenerator:
                                     class_label = str(label)
                                     break
                                 qualifier = class_label or change["table_name"]
-                                change[
-                                    "suggested"
-                                ] = f"{change['suggested']} ({qualifier})"
+                                change["suggested"] = (
+                                    f"{change['suggested']} ({qualifier})"
+                                )
 
             # Second pass: apply all changes
             for change in proposed_changes:

--- a/src/security.py
+++ b/src/security.py
@@ -135,9 +135,11 @@ class SecureCredentialManager:
         }
         # Check if key contains any sensitive substrings
         return {
-            k: "***REDACTED***"
-            if any(sens in k.lower() for sens in sensitive_keys) and v
-            else v
+            k: (
+                "***REDACTED***"
+                if any(sens in k.lower() for sens in sensitive_keys) and v
+                else v
+            )
             for k, v in credentials.items()
         }
 

--- a/src/session.py
+++ b/src/session.py
@@ -43,9 +43,9 @@ class SchemaCache:
     """Cached schema analysis results (multi-schema capable)."""
 
     def __init__(self) -> None:
-        self._cached_schema: dict[
-            str, list[Any]
-        ] | None = None  # schema_name -> List[TableInfo]
+        self._cached_schema: dict[str, list[Any]] | None = (
+            None  # schema_name -> List[TableInfo]
+        )
         self._last_analyzed_schema: str | None = None
 
     def cache_schema_analysis(self, schema_name: str, tables_info: list[Any]) -> None:

--- a/tests/test_no_blocking_io_in_async.py
+++ b/tests/test_no_blocking_io_in_async.py
@@ -224,9 +224,7 @@ def test_async_callers_do_not_invoke_blocking_sync_helpers():
             name = (
                 func.id
                 if isinstance(func, ast.Name)
-                else func.attr
-                if isinstance(func, ast.Attribute)
-                else None
+                else func.attr if isinstance(func, ast.Attribute) else None
             )
             if name not in blocking_helpers:
                 continue

--- a/tests/test_ontology_workflow_fix.py
+++ b/tests/test_ontology_workflow_fix.py
@@ -139,12 +139,13 @@ def mock_context():
 async def test_lightweight_caches_for_ontology(mock_context, mock_db_manager, tmp_path):
     """Test that lightweight mode caches full TableInfo for generate_ontology()."""
 
-    with patch("src.main.get_session_db_manager", return_value=mock_db_manager), patch(
-        "src.main.get_session_data"
-    ) as mock_session_data, patch(
-        "src.handlers.ontology_generation.ensure_output_dir", return_value=tmp_path
-    ), patch(
-        "src.main.get_session_safe_filename", return_value="test"
+    with (
+        patch("src.main.get_session_db_manager", return_value=mock_db_manager),
+        patch("src.main.get_session_data") as mock_session_data,
+        patch(
+            "src.handlers.ontology_generation.ensure_output_dir", return_value=tmp_path
+        ),
+        patch("src.main.get_session_safe_filename", return_value="test"),
     ):
         # Mock session data
         session = Mock()
@@ -193,15 +194,15 @@ async def test_lightweight_caches_for_ontology(mock_context, mock_db_manager, tm
 async def test_ontology_uses_lightweight_cache(mock_context, mock_db_manager, tmp_path):
     """Test that generate_ontology() works with data cached by lightweight mode."""
 
-    with patch("src.main.get_session_db_manager", return_value=mock_db_manager), patch(
-        "src.main.get_session_data"
-    ) as mock_session_data, patch(
-        "src.handlers.ontology_generation.ensure_output_dir", return_value=tmp_path
-    ), patch(
-        "src.main.get_session_safe_filename", return_value="test"
-    ), patch(
-        "src.main._server_state"
-    ) as mock_server_state:
+    with (
+        patch("src.main.get_session_db_manager", return_value=mock_db_manager),
+        patch("src.main.get_session_data") as mock_session_data,
+        patch(
+            "src.handlers.ontology_generation.ensure_output_dir", return_value=tmp_path
+        ),
+        patch("src.main.get_session_safe_filename", return_value="test"),
+        patch("src.main._server_state") as mock_server_state,
+    ):
         # Prepare cached tables (simulating what lightweight mode would cache)
         cached_tables = [
             TableInfo(
@@ -300,15 +301,15 @@ async def test_full_workflow_lightweight_to_ontology(
 ):
     """Integration test: lightweight analyze -> generate ontology."""
 
-    with patch("src.main.get_session_db_manager", return_value=mock_db_manager), patch(
-        "src.main.get_session_data"
-    ) as mock_session_data, patch(
-        "src.handlers.ontology_generation.ensure_output_dir", return_value=tmp_path
-    ), patch(
-        "src.main.get_session_safe_filename", return_value="test"
-    ), patch(
-        "src.main._server_state"
-    ) as mock_server_state:
+    with (
+        patch("src.main.get_session_db_manager", return_value=mock_db_manager),
+        patch("src.main.get_session_data") as mock_session_data,
+        patch(
+            "src.handlers.ontology_generation.ensure_output_dir", return_value=tmp_path
+        ),
+        patch("src.main.get_session_safe_filename", return_value="test"),
+        patch("src.main._server_state") as mock_server_state,
+    ):
         # Real session-like behavior
         cached_data = {}
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -228,8 +228,9 @@ class TestSecureCredentialManager(unittest.TestCase):
     def test_encryption_without_master_password(self) -> None:
         """Test that encryption fails without master password."""
         # Patch load_dotenv and os.getenv to prevent loading from .env file
-        with patch("src.security.load_dotenv"), patch(
-            "src.security.os.getenv", return_value=None
+        with (
+            patch("src.security.load_dotenv"),
+            patch("src.security.os.getenv", return_value=None),
         ):
             manager = SecureCredentialManager()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -231,19 +231,20 @@ class TestMCPToolsAsync:
         mock_session_data.db_manager = mock_db_manager
 
         # The function raises exception (no internal error handling)
-        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
-            "src.main.get_session_db_manager", return_value=mock_db_manager
-        ), patch(
-            "src.main._get_connection_fingerprint", return_value="test1234abcd"
-        ), patch.dict(
-            "os.environ",
-            {
-                "POSTGRES_HOST": "localhost",
-                "POSTGRES_PORT": "5432",
-                "POSTGRES_DATABASE": "testdb",
-                "POSTGRES_USERNAME": "testuser",
-                "POSTGRES_PASSWORD": "testpass",
-            },
+        with (
+            patch("src.main.get_session_data", return_value=mock_session_data),
+            patch("src.main.get_session_db_manager", return_value=mock_db_manager),
+            patch("src.main._get_connection_fingerprint", return_value="test1234abcd"),
+            patch.dict(
+                "os.environ",
+                {
+                    "POSTGRES_HOST": "localhost",
+                    "POSTGRES_PORT": "5432",
+                    "POSTGRES_DATABASE": "testdb",
+                    "POSTGRES_USERNAME": "testuser",
+                    "POSTGRES_PASSWORD": "testpass",
+                },
+            ),
         ):
             result = await main_module.connect_database(mock_ctx, db_type="postgresql")
 
@@ -266,17 +267,19 @@ class TestMCPToolsAsync:
         mock_db_manager.connect_postgresql.return_value = False
         mock_session_data.db_manager = mock_db_manager
 
-        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
-            "src.main.get_session_db_manager", return_value=mock_db_manager
-        ), patch.dict(
-            "os.environ",
-            {
-                "POSTGRES_HOST": "localhost",
-                "POSTGRES_PORT": "5432",
-                "POSTGRES_DATABASE": "testdb",
-                "POSTGRES_USERNAME": "testuser",
-                "POSTGRES_PASSWORD": "wrongpass",
-            },
+        with (
+            patch("src.main.get_session_data", return_value=mock_session_data),
+            patch("src.main.get_session_db_manager", return_value=mock_db_manager),
+            patch.dict(
+                "os.environ",
+                {
+                    "POSTGRES_HOST": "localhost",
+                    "POSTGRES_PORT": "5432",
+                    "POSTGRES_DATABASE": "testdb",
+                    "POSTGRES_USERNAME": "testuser",
+                    "POSTGRES_PASSWORD": "wrongpass",
+                },
+            ),
         ):
             result = await main_module.connect_database(mock_ctx, db_type="postgresql")
 
@@ -293,20 +296,21 @@ class TestMCPToolsAsync:
         mock_db_manager.connect_snowflake.return_value = True
         mock_session_data.db_manager = mock_db_manager
 
-        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
-            "src.main.get_session_db_manager", return_value=mock_db_manager
-        ), patch(
-            "src.main._get_connection_fingerprint", return_value="test5678efgh"
-        ), patch.dict(
-            "os.environ",
-            {
-                "SNOWFLAKE_ACCOUNT": "test-account",
-                "SNOWFLAKE_USERNAME": "testuser",
-                "SNOWFLAKE_PASSWORD": "testpass",
-                "SNOWFLAKE_WAREHOUSE": "COMPUTE_WH",
-                "SNOWFLAKE_DATABASE": "TESTDB",
-                "SNOWFLAKE_SCHEMA": "PUBLIC",
-            },
+        with (
+            patch("src.main.get_session_data", return_value=mock_session_data),
+            patch("src.main.get_session_db_manager", return_value=mock_db_manager),
+            patch("src.main._get_connection_fingerprint", return_value="test5678efgh"),
+            patch.dict(
+                "os.environ",
+                {
+                    "SNOWFLAKE_ACCOUNT": "test-account",
+                    "SNOWFLAKE_USERNAME": "testuser",
+                    "SNOWFLAKE_PASSWORD": "testpass",
+                    "SNOWFLAKE_WAREHOUSE": "COMPUTE_WH",
+                    "SNOWFLAKE_DATABASE": "TESTDB",
+                    "SNOWFLAKE_SCHEMA": "PUBLIC",
+                },
+            ),
         ):
             result = await main_module.connect_database(mock_ctx, db_type="snowflake")
 
@@ -327,9 +331,10 @@ class TestMCPToolsAsync:
     ):
         """Test connection with missing required environment variables."""
         # Use os.environ.get patching to simulate missing env vars
-        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
-            "os.getenv"
-        ) as mock_getenv:
+        with (
+            patch("src.main.get_session_data", return_value=mock_session_data),
+            patch("os.getenv") as mock_getenv,
+        ):
             # Only return value for POSTGRES_HOST, return None for others
             def getenv_side_effect(key, default=None):
                 env_map = {
@@ -355,19 +360,20 @@ class TestMCPToolsAsync:
         mock_db_manager.connect_postgresql.side_effect = Exception("Connection error")
         mock_session_data.db_manager = mock_db_manager
 
-        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
-            "src.main.get_session_db_manager", return_value=mock_db_manager
-        ), patch.dict(
-            "os.environ",
-            {
-                "POSTGRES_HOST": "localhost",
-                "POSTGRES_PORT": "5432",
-                "POSTGRES_DATABASE": "testdb",
-                "POSTGRES_USERNAME": "testuser",
-                "POSTGRES_PASSWORD": "testpass",
-            },
-        ), pytest.raises(
-            Exception, match="Connection error"
+        with (
+            patch("src.main.get_session_data", return_value=mock_session_data),
+            patch("src.main.get_session_db_manager", return_value=mock_db_manager),
+            patch.dict(
+                "os.environ",
+                {
+                    "POSTGRES_HOST": "localhost",
+                    "POSTGRES_PORT": "5432",
+                    "POSTGRES_DATABASE": "testdb",
+                    "POSTGRES_USERNAME": "testuser",
+                    "POSTGRES_PASSWORD": "testpass",
+                },
+            ),
+            pytest.raises(Exception, match="Connection error"),
         ):
             await main_module.connect_database(mock_ctx, db_type="postgresql")
 
@@ -378,8 +384,9 @@ class TestMCPToolsAsync:
         mock_session_data.db_manager = mock_db_manager
 
         # The function raises exception (no internal error handling)
-        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
-            "src.main.get_session_db_manager", return_value=mock_db_manager
+        with (
+            patch("src.main.get_session_data", return_value=mock_session_data),
+            patch("src.main.get_session_db_manager", return_value=mock_db_manager),
         ):
             result = await main_module.list_schemas(mock_ctx)
 
@@ -395,9 +402,11 @@ class TestMCPToolsAsync:
         mock_db_manager.get_schemas.side_effect = RuntimeError("No database connection")
         mock_session_data.db_manager = mock_db_manager
 
-        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
-            "src.main.get_session_db_manager", return_value=mock_db_manager
-        ), pytest.raises(RuntimeError, match="No database connection"):
+        with (
+            patch("src.main.get_session_data", return_value=mock_session_data),
+            patch("src.main.get_session_db_manager", return_value=mock_db_manager),
+            pytest.raises(RuntimeError, match="No database connection"),
+        ):
             await main_module.list_schemas(mock_ctx)
 
     async def test_discover_schema_success(
@@ -413,14 +422,15 @@ class TestMCPToolsAsync:
         mock_session_data.db_manager = mock_db_manager
 
         # The function raises exception (no internal error handling)
-        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
-            "src.main.get_session_db_manager", return_value=mock_db_manager
-        ), patch("src.server_state.get_session_id", return_value="test-session"), patch(
-            "src.main.get_session_safe_filename", return_value="test_schema.json"
-        ), patch(
-            "builtins.open", MagicMock()
-        ), patch(
-            "json.dump"
+        with (
+            patch("src.main.get_session_data", return_value=mock_session_data),
+            patch("src.main.get_session_db_manager", return_value=mock_db_manager),
+            patch("src.server_state.get_session_id", return_value="test-session"),
+            patch(
+                "src.main.get_session_safe_filename", return_value="test_schema.json"
+            ),
+            patch("builtins.open", MagicMock()),
+            patch("json.dump"),
         ):
             result = await main_module.discover_schema(
                 mock_ctx, "public", lightweight=False
@@ -455,9 +465,11 @@ class TestMCPToolsAsync:
         mock_db_manager.get_tables.side_effect = RuntimeError("No database connection")
         mock_session_data.db_manager = mock_db_manager
 
-        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
-            "src.main.get_session_db_manager", return_value=mock_db_manager
-        ), pytest.raises(RuntimeError, match="No database connection"):
+        with (
+            patch("src.main.get_session_data", return_value=mock_session_data),
+            patch("src.main.get_session_db_manager", return_value=mock_db_manager),
+            pytest.raises(RuntimeError, match="No database connection"),
+        ):
             await main_module.discover_schema(mock_ctx, "public")
 
     async def test_generate_ontology_success(
@@ -480,14 +492,14 @@ class TestMCPToolsAsync:
         )
 
         # The function raises exception (no internal error handling)
-        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
-            "src.main.get_session_db_manager", return_value=mock_db_manager
-        ), patch(
-            "src.main.get_session_safe_filename", return_value="test_ontology.ttl"
-        ), patch(
-            "src.server_state.OntologyGenerator", return_value=mock_generator
-        ), patch(
-            "builtins.open", MagicMock()
+        with (
+            patch("src.main.get_session_data", return_value=mock_session_data),
+            patch("src.main.get_session_db_manager", return_value=mock_db_manager),
+            patch(
+                "src.main.get_session_safe_filename", return_value="test_ontology.ttl"
+            ),
+            patch("src.server_state.OntologyGenerator", return_value=mock_generator),
+            patch("builtins.open", MagicMock()),
         ):
             result = await main_module.generate_ontology(
                 mock_ctx, schema_name="public", base_uri="http://example.com/ontology/"
@@ -507,8 +519,9 @@ class TestMCPToolsAsync:
         mock_db_manager.get_tables.return_value = []
         mock_session_data.db_manager = mock_db_manager
 
-        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
-            "src.main.get_session_db_manager", return_value=mock_db_manager
+        with (
+            patch("src.main.get_session_data", return_value=mock_session_data),
+            patch("src.main.get_session_db_manager", return_value=mock_db_manager),
         ):
             result = await main_module.generate_ontology(mock_ctx, schema_name="public")
 
@@ -527,8 +540,9 @@ class TestMCPToolsAsync:
         mock_db_manager.sample_table_data.return_value = sample_data
         mock_session_data.db_manager = mock_db_manager
 
-        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
-            "src.main.get_session_db_manager", return_value=mock_db_manager
+        with (
+            patch("src.main.get_session_data", return_value=mock_session_data),
+            patch("src.main.get_session_db_manager", return_value=mock_db_manager),
         ):
             result = await main_module.sample_table_data(
                 mock_ctx, "users", "public", 10
@@ -563,9 +577,11 @@ class TestMCPToolsAsync:
         )
         mock_session_data.db_manager = mock_db_manager
 
-        with patch("src.main.get_session_data", return_value=mock_session_data), patch(
-            "src.main.get_session_db_manager", return_value=mock_db_manager
-        ), pytest.raises(ValueError, match="Invalid table name format"):
+        with (
+            patch("src.main.get_session_data", return_value=mock_session_data),
+            patch("src.main.get_session_db_manager", return_value=mock_db_manager),
+            pytest.raises(ValueError, match="Invalid table name format"),
+        ):
             await main_module.sample_table_data(mock_ctx, "invalid-table", "public", 10)
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -224,8 +224,9 @@ class TestWorkspaceDetection:
         conn_dir.mkdir(parents=True, exist_ok=True)
         (conn_dir / "schema_test.json").write_text('{"tables": []}')
 
-        with patch("src.workspace.OUTPUT_DIR", self.output_dir), patch(
-            "src.workspace.get_connection_dir", return_value=conn_dir
+        with (
+            patch("src.workspace.OUTPUT_DIR", self.output_dir),
+            patch("src.workspace.get_connection_dir", return_value=conn_dir),
         ):
             result = detect_workspace(self.connection_id)
 

--- a/tests/test_workspace_restore.py
+++ b/tests/test_workspace_restore.py
@@ -28,8 +28,9 @@ class TestWorkspaceRdfRestore(unittest.IsolatedAsyncioTestCase):
         session = SessionData()
         ctx = MagicMock()
 
-        with patch("src.handlers.workspace.VersionMetadataManager") as MgrCls, patch(
-            "src.handlers.workspace.OXIGRAPH_AVAILABLE", True
+        with (
+            patch("src.handlers.workspace.VersionMetadataManager") as MgrCls,
+            patch("src.handlers.workspace.OXIGRAPH_AVAILABLE", True),
         ):
             MgrCls.return_value.get_workspace.return_value = workspace
             result = await _restore_workspace_core(
@@ -57,8 +58,9 @@ class TestWorkspaceRdfRestore(unittest.IsolatedAsyncioTestCase):
         del bare_function.get_oxigraph_store  # force AttributeError on attr access
         session = SessionData()
 
-        with patch("src.handlers.workspace.VersionMetadataManager") as MgrCls, patch(
-            "src.handlers.workspace.OXIGRAPH_AVAILABLE", True
+        with (
+            patch("src.handlers.workspace.VersionMetadataManager") as MgrCls,
+            patch("src.handlers.workspace.OXIGRAPH_AVAILABLE", True),
         ):
             MgrCls.return_value.get_workspace.return_value = workspace
             result = await _restore_workspace_core(

--- a/uv.lock
+++ b/uv.lock
@@ -295,7 +295,7 @@ wheels = [
 
 [[package]]
 name = "black"
-version = "23.12.1"
+version = "26.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -303,10 +303,21 @@ dependencies = [
     { name = "packaging" },
     { name = "pathspec" },
     { name = "platformdirs" },
+    { name = "pytokens" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/f4/a57cde4b60da0e249073009f4a9087e9e0a955deae78d3c2a493208d0c5c/black-23.12.1.tar.gz", hash = "sha256:4ce3ef14ebe8d9509188014d96af1c456a910d5b5cbf434a09fef7e024b3d0d5", size = 620809, upload-time = "2023-12-22T23:06:17.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/14/4da7b12a9abc43a601c215cb5a3d176734578da109f0dbf0a832ed78be09/black-23.12.1-py3-none-any.whl", hash = "sha256:78baad24af0f033958cad29731e27363183e140962595def56423e626f4bee3e", size = 194363, upload-time = "2023-12-22T23:06:14.278Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
+    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
 ]
 
 [[package]]
@@ -2485,7 +2496,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "bandit", specifier = ">=1.7.5,<2.0.0" },
-    { name = "black", specifier = ">=23.12.0,<24.0.0" },
+    { name = "black", specifier = ">=26.5.0,<27.0.0" },
     { name = "flake8", specifier = ">=7.0.0,<8.0.0" },
     { name = "isort", specifier = ">=5.13.0,<6.0.0" },
     { name = "locust", specifier = ">=2.20.0,<3.0.0" },
@@ -2617,11 +2628,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "0.12.1"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -3392,6 +3403,30 @@ wheels = [
 client = [
     { name = "requests" },
     { name = "websocket-client" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Supersedes #62.

Dependabot's standalone bump (#62) failed the quality job: black 26 reformats 21 files that black 23 left alone (mostly the *hug parens around multiline conditional expressions* rule from the 24.x stable style). The reformat has to land in the same commit as the version bump.

This PR:
- bumps `black` to `>=26.5.0,<27.0.0` and applies the resulting reformat (22 files, formatting only)
- bumps the `psf/black` pre-commit `rev` 23.12.1 → 26.5.1, so local hooks don't revert the formatting on the next commit
- moves `[tool.black] target-version` py312 → py313, which the existing comment in `pyproject.toml` explicitly flagged as blocked on a black >= 24.10 upgrade

Verified locally: 482 tests pass; `ruff`, `isort --check-only`, and `mypy src/` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)