### PR TITLE
feat(lifecycle): build the recording half of per-version retention

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -26,12 +26,26 @@ AUTO_ONTOLOGY=false
 # -- the file currently referenced is never a deletion candidate.
 ARTIFACT_KEEP_VERSIONS=3
 
+# Per-version retention
+# ---------------------
+# Every discover_schema opens a version for that schema, which generate_ontology
+# and GraphRAG initialization then fill in. Opening a new one archives the
+# previous. The cleanup_old_versions tool deletes ARCHIVED versions that exceed
+# BOTH the keep-count and the age threshold below; the current generation is
+# never a candidate, and at least 2 versions are always kept.
+#
+# Read at cleanup time and override the copy recorded in each workspace's
+# metadata.json, so changes apply to workspaces that already exist. Cleanup is
+# manual -- cleanup_old_versions defaults to dry_run=true.
+GRAPHRAG_KEEP_VERSIONS=3
+GRAPHRAG_MAX_AGE_DAYS=30
+ONTOLOGY_KEEP_VERSIONS=5
+ONTOLOGY_MAX_AGE_DAYS=60
+
 # Startup Workspace Cleanup
 # -------------------------
-# NOTE: per-version retention (keeping the last N GraphRAG/ontology versions)
-# is designed but NOT wired up, so GRAPHRAG_KEEP_VERSIONS, GRAPHRAG_MAX_AGE_DAYS,
-# ONTOLOGY_KEEP_VERSIONS and ONTOLOGY_MAX_AGE_DAYS are deliberately absent here:
-# nothing reads them. Cleanup operates on whole workspace directories only.
+# Distinct from the per-version retention above: this deletes whole workspace
+# directories, not individual versions inside a workspace still in use.
 #
 # Runs on every startup regardless of the setting below:
 #   - stale loose files directly under the output dir are deleted

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -211,6 +211,10 @@ DATABRICKS_SCHEMA=default
 | `ARTIFACT_KEEP_VERSIONS` | `3` | Generations of each ontology / schema / R2RML file to keep per schema. Older ones are pruned when a new one is written. Minimum 1 |
 | `AUTO_CLEANUP_ON_STARTUP` | `false` | Delete whole workspaces at startup: `false` (keep all), `true` (orphaned, or older than `WORKSPACE_MAX_AGE_DAYS`), `all` (delete every workspace). See [Startup workspace cleanup](#startup-workspace-cleanup) |
 | `WORKSPACE_MAX_AGE_DAYS` | `30` | Age threshold for `AUTO_CLEANUP_ON_STARTUP=true`, measured from the workspace's last update. Ignored in the other modes |
+| `GRAPHRAG_KEEP_VERSIONS` | `3` | Archived GraphRAG snapshots kept per schema. See [Per-version retention](#per-version-retention) |
+| `GRAPHRAG_MAX_AGE_DAYS` | `30` | Age past which an archived GraphRAG snapshot may be deleted |
+| `ONTOLOGY_KEEP_VERSIONS` | `5` | Archived ontology versions kept per schema |
+| `ONTOLOGY_MAX_AGE_DAYS` | `60` | Age past which an archived ontology version may be deleted |
 | `ONTOLOGY_BASE_URI` | `http://example.com/ontology/` | Base URI for generated RDF ontologies |
 | `R2RML_BASE_IRI` | `http://mycompany.com/` | Base IRI for R2RML subject templates |
 | `OUTPUT_DIR` | `tmp` | Directory for generated files (relative to project root) |
@@ -251,7 +255,31 @@ There is no partial or per-artifact cleanup. The `chromadb/` and `oxigraph/` par
 
 **Age comes from metadata, not the filesystem.** The `true` mode reads `workspace.updated_at` out of `metadata.json` rather than looking at file modification times, so touching files on disk does not keep a workspace alive.
 
-> **Note on per-version retention.** An earlier design kept the last *N* versions of GraphRAG and ontology data per schema, configured by `GRAPHRAG_KEEP_VERSIONS`, `GRAPHRAG_MAX_AGE_DAYS`, `ONTOLOGY_KEEP_VERSIONS` and `ONTOLOGY_MAX_AGE_DAYS`. That mechanism is **not wired up** -- those four variables are read nowhere in the code and setting them has no effect, so they are intentionally absent from `.env.template`. The retention policy defaults are still recorded in each workspace's `metadata.json`, and `DataCleanupManager` still implements the logic, but nothing invokes it. Only the whole-workspace cleanup described above actually runs.
+### Per-version retention
+
+Startup cleanup deletes whole workspaces; this deletes individual **versions** inside a workspace that is still in use.
+
+Every `discover_schema` call opens a version for that schema, and `generate_ontology` and GraphRAG initialization fill in their halves as they complete. The result is a history under `schemas.{name}.versions` in `metadata.json` recording, per generation: the schema fingerprint and table/column counts, the ontology TTL file, its named graph and triple count, and the GraphRAG vector count and snapshot files. Opening a new version archives the one before it -- only the newest is `active`.
+
+Retention applies to **archived** versions only, so the current generation is never a candidate:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GRAPHRAG_KEEP_VERSIONS` | `3` | Archived GraphRAG snapshots to keep per schema |
+| `GRAPHRAG_MAX_AGE_DAYS` | `30` | Age past which an archived GraphRAG snapshot is eligible for deletion |
+| `ONTOLOGY_KEEP_VERSIONS` | `5` | Archived ontology versions to keep per schema |
+| `ONTOLOGY_MAX_AGE_DAYS` | `60` | Age past which an archived ontology version is eligible for deletion |
+
+A version must exceed **both** the count and the age threshold to be deleted, and at least `min_versions` (2) are always kept regardless. These are read at cleanup time and override the copy recorded in `metadata.json`, so changing them takes effect on workspaces that already exist. Invalid or sub-1 values are logged and ignored rather than failing startup.
+
+Cleanup is **manual**: call the `cleanup_old_versions` tool, which defaults to `dry_run=true` so you can see what would go before anything does. It reports the effective policy, what was (or would be) deleted, and the schema's remaining history.
+
+Two deletions are deliberately guarded rather than unconditional:
+
+- **Named graphs.** Successive generations of a schema reuse the same graph URI, so the graph is only dropped from Oxigraph when no surviving version still references it.
+- **ChromaDB collections.** GraphRAG is connection-scoped and accumulative by design -- one collection holds every schema's vectors so cross-schema search and join discovery work -- so versions share a collection rather than each owning one. The collection is deleted only when no surviving version references it, which in practice means it stays as long as the schema has a live version. Per-version GraphRAG *files* are pruned normally.
+
+Ontology, schema and R2RML **files** are additionally pruned by count as they are written, independently of this, via `ARTIFACT_KEEP_VERSIONS`.
 
 ### Security Notes
 

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -621,6 +621,29 @@ Add a custom triple (subject-predicate-object) to the RDF store to enrich the on
 - Useful for layering business annotations onto a generated ontology
 - Added triples are queryable via `query_sparql`
 
+---
+
+### 24. cleanup_old_versions
+
+Prune old ontology and GraphRAG versions for one schema according to the retention policy. Unlike `cleanup_workspace`, this keeps the current generation and recent history -- it deletes only *archived* versions that have aged out.
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `schema_name` | string | No | Last analyzed | Schema whose version history to prune |
+| `dry_run` | boolean | No | `true` | Report what would be deleted without deleting it |
+
+**Returns:** Dictionary with `schema`, `dry_run`, `retention_policy`, per-area `graphrag` and `ontology` reports, and `versions` -- the schema's remaining history.
+
+**Key Features:**
+- Defaults to a dry run, so the first call is always safe to make
+- A version must exceed both the keep-count and the age threshold; at least 2 are always kept
+- Retention comes from `GRAPHRAG_KEEP_VERSIONS`, `GRAPHRAG_MAX_AGE_DAYS`, `ONTOLOGY_KEEP_VERSIONS`, `ONTOLOGY_MAX_AGE_DAYS` -- see [Configuration](configuration.md#per-version-retention)
+- Named graphs and ChromaDB collections are only deleted when no surviving version still references them, since generations share both
+
+---
+
 > **Note:** Server metadata (name, version, supported databases, capabilities) is provided
 > automatically via the MCP `initialize` handshake and the server `instructions`, and the live
 > tool list via `tools/list` -- so no dedicated `get_server_info` tool is needed.

--- a/src/graphrag/manager.py
+++ b/src/graphrag/manager.py
@@ -7,6 +7,7 @@ to provide intelligent schema navigation and context-aware query generation.
 
 import json
 import logging
+import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -399,17 +400,50 @@ class GraphRAGManager:
 
         return overview
 
-    def save_state(self, output_dir: Path) -> None:
+    @property
+    def vector_collection_name(self) -> str:
+        """Name of the backing ChromaDB collection, or "" when not using one.
+
+        Recorded on each version so retention can tell whether a collection is
+        still referenced by a live version before deleting it. Empty for the
+        JSON fallback store, which has no collections.
+        """
+        collection = getattr(self.vector_store, "collection", None)
+        return str(getattr(collection, "name", "") or "")
+
+    @property
+    def vector_count(self) -> int:
+        """Number of elements currently in the vector store, 0 if unavailable."""
+        try:
+            stats = self.vector_store.get_statistics()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(f"Failed to read vector store statistics: {e}")
+            return 0
+        return int(stats.get("total_elements", 0) or 0)
+
+    def save_state(self, output_dir: Path, version: int | None = None) -> list[str]:
         """
         Save GraphRAG state to disk.
 
         Saves combined state (all accumulated schemas) plus per-schema files
         for backward compatibility with workspace metadata.
 
+        When *version* is given, each per-schema file is also written under a
+        ``_v{version}`` name. Those copies are the per-version history that
+        retention prunes; the unversioned files stay the current-generation
+        pointer that :meth:`load_state` reads, so they are never deletion
+        candidates and restore cannot be broken by cleanup.
+
         Args:
             output_dir: Output directory
+            version: Version number to snapshot under, or None for no snapshot.
+
+        Returns:
+            Names of the versioned snapshot files written, relative to the
+            connection directory. Empty when *version* is None.
         """
         output_dir = Path(output_dir)
+        snapshot_files: list[str] = []
 
         # Create connection-specific subdirectory to prevent collisions
         connection_dir = output_dir / self._connection_id
@@ -439,6 +473,7 @@ class GraphRAGManager:
                 json.dump(communities_data, f, indent=2)
 
         # Also save per-schema files (backward compat with workspace metadata)
+        suffix = f"_v{version}" if version is not None else ""
         for schema_name in self._schema_names:
             vector_store_path = connection_dir / f"vector_store_{schema_name}.json"
             self.vector_store.save(vector_store_path)
@@ -457,19 +492,46 @@ class GraphRAGManager:
             with open(per_schema_graph_path, "w") as f:
                 json.dump(per_schema_data, f, indent=2)
 
+            schema_communities_path: Path | None = None
             if self.community_detector:
-                communities_path = connection_dir / f"communities_{schema_name}.json"
+                schema_communities_path = (
+                    connection_dir / f"communities_{schema_name}.json"
+                )
                 communities_data = {
                     "summaries": self.community_detector.get_all_summaries(),
                     "domain_names": self.community_detector.suggest_domain_names(),
                 }
-                with open(communities_path, "w") as f:
+                with open(schema_communities_path, "w") as f:
                     json.dump(communities_data, f, indent=2)
+
+            if not suffix:
+                continue
+
+            # Snapshot this generation. Copied from the files just written
+            # rather than re-serialized, so the snapshot is byte-identical to
+            # the state restore would load.
+            for current in (
+                vector_store_path,
+                per_schema_graph_path,
+                schema_communities_path,
+            ):
+                if current is None or not current.exists():
+                    continue
+                snapshot = current.with_name(f"{current.stem}{suffix}{current.suffix}")
+                try:
+                    shutil.copy2(current, snapshot)
+                except OSError as e:
+                    # A missing snapshot costs history for this generation, not
+                    # correctness of the live state -- do not fail the save.
+                    logger.warning(f"Failed to snapshot {current.name}: {e}")
+                    continue
+                snapshot_files.append(snapshot.name)
 
         logger.info(
             f"Saved GraphRAG state to {connection_dir} "
             f"(schemas: {self._schema_names})"
         )
+        return snapshot_files
 
     def load_state(self, output_dir: Path) -> bool:
         """Restore GraphRAG state from disk.

--- a/src/graphrag/manager.py
+++ b/src/graphrag/manager.py
@@ -421,26 +421,41 @@ class GraphRAGManager:
             return 0
         return int(stats.get("total_elements", 0) or 0)
 
-    def save_state(self, output_dir: Path, version: int | None = None) -> list[str]:
+    def save_state(
+        self,
+        output_dir: Path,
+        version: int | None = None,
+        snapshot_schema: str | None = None,
+    ) -> list[str]:
         """
         Save GraphRAG state to disk.
 
         Saves combined state (all accumulated schemas) plus per-schema files
         for backward compatibility with workspace metadata.
 
-        When *version* is given, each per-schema file is also written under a
-        ``_v{version}`` name. Those copies are the per-version history that
-        retention prunes; the unversioned files stay the current-generation
-        pointer that :meth:`load_state` reads, so they are never deletion
-        candidates and restore cannot be broken by cleanup.
+        When *version* and *snapshot_schema* are both given, that one schema's
+        files are also written under a ``_v{version}`` name. Those copies are
+        the per-version history that retention prunes; the unversioned files
+        stay the current-generation pointer that :meth:`load_state` reads, so
+        they are never deletion candidates and restore cannot be broken by
+        cleanup.
+
+        Snapshotting is deliberately restricted to a single schema. Version
+        numbers are per schema, and this manager holds every accumulated schema
+        on the connection -- so applying one schema's version number across all
+        of them would overwrite ``vector_store_public_v1.json`` when *analytics*
+        v1 is saved, and hand ownership of public's snapshot to analytics's
+        version record. Cleanup would then delete another schema's history.
 
         Args:
             output_dir: Output directory
             version: Version number to snapshot under, or None for no snapshot.
+            snapshot_schema: The one schema to snapshot; required for a snapshot
+                to be taken, and must be the schema *version* belongs to.
 
         Returns:
             Names of the versioned snapshot files written, relative to the
-            connection directory. Empty when *version* is None.
+            connection directory. Empty when no snapshot was taken.
         """
         output_dir = Path(output_dir)
         snapshot_files: list[str] = []
@@ -473,7 +488,6 @@ class GraphRAGManager:
                 json.dump(communities_data, f, indent=2)
 
         # Also save per-schema files (backward compat with workspace metadata)
-        suffix = f"_v{version}" if version is not None else ""
         for schema_name in self._schema_names:
             vector_store_path = connection_dir / f"vector_store_{schema_name}.json"
             self.vector_store.save(vector_store_path)
@@ -504,12 +518,12 @@ class GraphRAGManager:
                 with open(schema_communities_path, "w") as f:
                     json.dump(communities_data, f, indent=2)
 
-            if not suffix:
+            # Snapshot only the schema whose version number this is.
+            if version is None or schema_name != snapshot_schema:
                 continue
 
-            # Snapshot this generation. Copied from the files just written
-            # rather than re-serialized, so the snapshot is byte-identical to
-            # the state restore would load.
+            # Copied from the files just written rather than re-serialized, so
+            # the snapshot is byte-identical to the state restore would load.
             for current in (
                 vector_store_path,
                 per_schema_graph_path,
@@ -517,7 +531,9 @@ class GraphRAGManager:
             ):
                 if current is None or not current.exists():
                     continue
-                snapshot = current.with_name(f"{current.stem}{suffix}{current.suffix}")
+                snapshot = current.with_name(
+                    f"{current.stem}_v{version}{current.suffix}"
+                )
                 try:
                     shutil.copy2(current, snapshot)
                 except OSError as e:

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -25,30 +25,29 @@ from ..utils import utc_now, write_text_file
 logger = logging.getLogger(__name__)
 
 
-async def _save_graphrag_state(session: Any, schema_name: str) -> None:
-    """Persist GraphRAG state and record its half of the schema's open version.
+async def _save_graphrag_state(
+    session: Any, schema_name: str, version: int | None
+) -> None:
+    """Persist GraphRAG state and record its half of a specific version.
 
-    The snapshot is taken under the version ``discover_schema`` opened, which
-    gives retention per-version files to prune. A missing version -- no
-    connection, or a schema discovered before version recording existed --
-    just means no snapshot; the unversioned current-state files that restore
-    reads are written either way.
+    *version* is the generation this work was started for, resolved by the
+    caller before the task was scheduled -- not looked up here. Initialization
+    can run for a long time, and a second ``discover_schema`` for the same
+    schema during that window opens a newer version; resolving on completion
+    would stamp this run's snapshots and vector counts onto a generation they
+    do not belong to.
+
+    A missing version -- no connection, or a schema discovered before version
+    recording existed -- just means no snapshot; the unversioned current-state
+    files that restore reads are written either way.
 
     Args:
         session: Session data holding the GraphRAG manager and connection id.
         schema_name: Schema whose version to record against.
+        version: The version number this work belongs to, if known.
     """
     manager = session.graphrag_manager
     output_dir = ensure_output_dir()
-
-    version: int | None = None
-    if session.connection_id:
-        try:
-            version = await get_active_version_number(
-                session.connection_id, OUTPUT_DIR, schema_name
-            )
-        except Exception as e:
-            logger.warning(f"Failed to read active version: {e}")
 
     snapshot_files = await asyncio.to_thread(
         manager.save_state, output_dir, version, schema_name
@@ -67,6 +66,7 @@ async def _save_graphrag_state(session: Any, schema_name: str) -> None:
                 "graphrag_collection": manager.vector_collection_name,
                 "graphrag_files": snapshot_files,
             },
+            version=version,
         )
     except Exception as e:
         logger.warning(f"Failed to record GraphRAG version state: {e}")
@@ -109,11 +109,16 @@ async def _auto_generate_ontology_background(
     tables_info: list[Any],
     session: Any,
     ctx: Context,
+    version: int | None = None,
 ) -> None:
     """Background task: Auto-generate ontology after GraphRAG completes.
 
     Uses direct schema state access (not convenience properties) to avoid
     race conditions when the user switches schemas during background work.
+
+    *version* is the generation this work was started for. It is recorded
+    against explicitly, because a second discover_schema for the same schema
+    can open a newer version while this task is still running.
     """
     from ..config import config_manager
 
@@ -196,6 +201,7 @@ async def _auto_generate_ontology_background(
                             "ontology_graph_uri": graph_uri,
                             "ontology_triple_count": triple_count,
                         },
+                        version=version,
                     )
                 except Exception as e:
                     logger.warning(f"Failed to write workspace metadata: {e}")
@@ -217,11 +223,16 @@ async def _auto_initialize_graphrag_background(
     tables_info: list[Any],
     session: Any,
     ctx: Context,
+    version: int | None = None,
 ) -> None:
     """Background task: Auto-initialize or accumulate GraphRAG after schema analysis.
 
     GraphRAG is connection-scoped and accumulative. If already initialized,
     new schema tables are added to the existing graph and vector store.
+
+    *version* is the generation discover_schema opened before scheduling this
+    task. It is threaded through rather than resolved on completion so a
+    rediscovery of the same schema mid-run cannot capture this run's output.
     """
     try:
         start_time = time.time()
@@ -247,7 +258,7 @@ async def _auto_initialize_graphrag_background(
                 tables_info=tables_dict, schema_name=schema_name
             )
 
-        await _save_graphrag_state(session, schema_name)
+        await _save_graphrag_state(session, schema_name, version)
 
         elapsed = time.time() - start_time
         session.graphrag_initialized = True
@@ -288,6 +299,7 @@ async def _auto_initialize_graphrag_background(
                 tables_info=tables_info,
                 session=session,
                 ctx=ctx,
+                version=version,
             )
 
     except Exception as e:
@@ -369,6 +381,17 @@ async def initialize_graphrag(
 
     eff_schema = effective_schema or "default"
 
+    # Bound to the generation current when this call started; embedding a large
+    # schema is slow enough for a rediscovery to land before it finishes.
+    target_version: int | None = None
+    if session.connection_id:
+        try:
+            target_version = await get_active_version_number(
+                session.connection_id, OUTPUT_DIR, eff_schema
+            )
+        except Exception as e:
+            logger.warning(f"Failed to read active version: {e}")
+
     try:
         if session.graphrag_manager is None:
             session.graphrag_manager = GraphRAGManager(
@@ -388,7 +411,7 @@ async def initialize_graphrag(
 
         session.graphrag_initialized = True
 
-        await _save_graphrag_state(session, eff_schema)
+        await _save_graphrag_state(session, eff_schema, target_version)
 
         total_tables = session.graphrag_manager.graph_retriever.graph.number_of_nodes()
         schemas = session.graphrag_manager._schema_names

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -50,7 +50,9 @@ async def _save_graphrag_state(session: Any, schema_name: str) -> None:
         except Exception as e:
             logger.warning(f"Failed to read active version: {e}")
 
-    snapshot_files = await asyncio.to_thread(manager.save_state, output_dir, version)
+    snapshot_files = await asyncio.to_thread(
+        manager.save_state, output_dir, version, schema_name
+    )
 
     if version is None or not session.connection_id:
         return
@@ -145,6 +147,8 @@ async def _auto_generate_ontology_background(
             previous_ontology_file = schema_state.ontology.ontology_file
             schema_state.ontology.ontology_file = ontology_file.name
 
+            graph_uri = ""
+            triple_count = 0
             if OXIGRAPH_AVAILABLE:
                 try:
                     # Direct store access for background task (connection-scoped)
@@ -163,9 +167,41 @@ async def _auto_generate_ontology_background(
             logger.info(f"Ontology auto-generated successfully ({elapsed:.2f}s)")
             logger.info(f"Saved to: {ontology_file.name}")
 
-            # Pruned last, and never touching what the session previously
-            # pointed at: this path writes no persisted metadata, so the
-            # in-memory reference is the only record the older file is in use.
+            # Record the same way the foreground handler does. discover_schema
+            # opened a version before this task was scheduled, so without this
+            # an auto-generated ontology leaves that version with no TTL file,
+            # no graph URI and a zero triple count -- and retention could never
+            # clean up the graph it loaded.
+            if session.connection_id:
+                try:
+                    await update_workspace_section(
+                        connection_id=session.connection_id,
+                        output_dir=OUTPUT_DIR,
+                        schema_name=schema_name,
+                        section="ontology",
+                        data={
+                            "ontology_file": ontology_file.name,
+                            "enriched": False,
+                            "graph_uri": graph_uri,
+                            "persisted_to_rdf": bool(graph_uri),
+                            "generated_at": utc_now().isoformat(),
+                        },
+                    )
+                    await update_schema_version(
+                        connection_id=session.connection_id,
+                        output_dir=OUTPUT_DIR,
+                        schema_name=schema_name,
+                        updates={
+                            "ontology_ttl_file": ontology_file.name,
+                            "ontology_graph_uri": graph_uri,
+                            "ontology_triple_count": triple_count,
+                        },
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to write workspace metadata: {e}")
+
+            # Pruned last, once metadata durably names the new file, and never
+            # touching what the session previously pointed at.
             await prune_superseded_artifacts(
                 ontology_file,
                 protect=[previous_ontology_file] if previous_ontology_file else [],

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -12,13 +12,62 @@ from ..exceptions import ConnectionError
 from ..graphrag import GraphRAGManager
 from ..handler_context import HandlerContext
 from ..lifecycle.artifacts import artifact_family_lock, prune_superseded_artifacts
-from ..lifecycle.metadata import update_workspace_section
+from ..lifecycle.metadata import (
+    get_active_version_number,
+    update_schema_version,
+    update_workspace_section,
+)
 from ..ontology_generator import OntologyGenerator
 from ..oxigraph_store import OXIGRAPH_AVAILABLE
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
 from ..utils import utc_now, write_text_file
 
 logger = logging.getLogger(__name__)
+
+
+async def _save_graphrag_state(session: Any, schema_name: str) -> None:
+    """Persist GraphRAG state and record its half of the schema's open version.
+
+    The snapshot is taken under the version ``discover_schema`` opened, which
+    gives retention per-version files to prune. A missing version -- no
+    connection, or a schema discovered before version recording existed --
+    just means no snapshot; the unversioned current-state files that restore
+    reads are written either way.
+
+    Args:
+        session: Session data holding the GraphRAG manager and connection id.
+        schema_name: Schema whose version to record against.
+    """
+    manager = session.graphrag_manager
+    output_dir = ensure_output_dir()
+
+    version: int | None = None
+    if session.connection_id:
+        try:
+            version = await get_active_version_number(
+                session.connection_id, OUTPUT_DIR, schema_name
+            )
+        except Exception as e:
+            logger.warning(f"Failed to read active version: {e}")
+
+    snapshot_files = await asyncio.to_thread(manager.save_state, output_dir, version)
+
+    if version is None or not session.connection_id:
+        return
+
+    try:
+        await update_schema_version(
+            connection_id=session.connection_id,
+            output_dir=OUTPUT_DIR,
+            schema_name=schema_name,
+            updates={
+                "graphrag_vector_count": manager.vector_count,
+                "graphrag_collection": manager.vector_collection_name,
+                "graphrag_files": snapshot_files,
+            },
+        )
+    except Exception as e:
+        logger.warning(f"Failed to record GraphRAG version state: {e}")
 
 
 def _table_info_to_dict(table_info: Any) -> dict[str, Any]:
@@ -162,8 +211,7 @@ async def _auto_initialize_graphrag_background(
                 tables_info=tables_dict, schema_name=schema_name
             )
 
-        output_dir = ensure_output_dir()
-        await asyncio.to_thread(session.graphrag_manager.save_state, output_dir)
+        await _save_graphrag_state(session, schema_name)
 
         elapsed = time.time() - start_time
         session.graphrag_initialized = True
@@ -304,8 +352,7 @@ async def initialize_graphrag(
 
         session.graphrag_initialized = True
 
-        output_dir = ensure_output_dir()
-        await asyncio.to_thread(session.graphrag_manager.save_state, output_dir)
+        await _save_graphrag_state(session, eff_schema)
 
         total_tables = session.graphrag_manager.graph_retriever.graph.number_of_nodes()
         schemas = session.graphrag_manager._schema_names

--- a/src/handlers/ontology_generation.py
+++ b/src/handlers/ontology_generation.py
@@ -12,6 +12,7 @@ from ..database_manager import ColumnInfo, TableInfo
 from ..handler_context import HandlerContext
 from ..lifecycle.artifacts import artifact_family_lock, prune_superseded_artifacts
 from ..lifecycle.metadata import (
+    get_active_version_number,
     mark_ontology_persisted,
     ontology_is_current,
     update_schema_version,
@@ -247,6 +248,20 @@ async def generate_ontology(
         )
         return err
 
+    # Bound before the slow work below, not after it. Generation plus SHACL
+    # validation are the long poles in this handler, and a discover_schema
+    # landing during them opens a newer version -- which would then be credited
+    # with this run's TTL file and treated as current for RDF auto-persist.
+    session = services.get_session_data(ctx)
+    target_version: int | None = None
+    if session.connection_id:
+        try:
+            target_version = await get_active_version_number(
+                session.connection_id, OUTPUT_DIR, schema_name or "default"
+            )
+        except Exception as e:
+            logger.warning(f"Failed to read active version: {e}")
+
     generator = services.server_state.get_ontology_generator(base_uri=base_uri)
     # rdflib work is CPU-bound (~876 ms per 2.65 MB of Turtle); off the loop
     # so it does not freeze every concurrent session.
@@ -311,7 +326,6 @@ async def generate_ontology(
             session.obqc_validator = None
 
             # Write workspace metadata for ontology section
-            target_version: int | None = None
             if session.connection_id:
                 try:
                     await update_workspace_section(
@@ -327,13 +341,11 @@ async def generate_ontology(
                             "generated_at": utc_now().isoformat(),
                         },
                     )
-                    # Record the ontology half of the version discovery opened,
-                    # and hold on to which version that was: the RDF load below
-                    # is slow, and a rediscovery during it would otherwise send
-                    # the triple count to a different generation than the file.
-                    # The count is not known until that load, so it is filled in
-                    # there rather than guessed here.
-                    target_version = await update_schema_version(
+                    # Recorded against the version captured before generation
+                    # started, so this TTL lands on the generation it was built
+                    # from. The triple count is not known until the RDF load
+                    # below, so it is filled in there against the same version.
+                    await update_schema_version(
                         connection_id=session.connection_id,
                         output_dir=OUTPUT_DIR,
                         schema_name=schema_name or "default",
@@ -341,6 +353,7 @@ async def generate_ontology(
                             "ontology_ttl_file": ontology_filename,
                             "ontology_graph_uri": graph_uri or "",
                         },
+                        version=target_version,
                     )
                 except Exception as e:
                     logger.warning(f"Failed to write workspace metadata: {e}")

--- a/src/handlers/ontology_generation.py
+++ b/src/handlers/ontology_generation.py
@@ -14,6 +14,7 @@ from ..lifecycle.artifacts import artifact_family_lock, prune_superseded_artifac
 from ..lifecycle.metadata import (
     mark_ontology_persisted,
     ontology_is_current,
+    update_schema_version,
     update_workspace_rdf,
     update_workspace_section,
 )
@@ -325,6 +326,18 @@ async def generate_ontology(
                             "generated_at": utc_now().isoformat(),
                         },
                     )
+                    # Record the ontology half of the version discovery opened.
+                    # The triple count is not known until the RDF load below,
+                    # so it is filled in there rather than guessed here.
+                    await update_schema_version(
+                        connection_id=session.connection_id,
+                        output_dir=OUTPUT_DIR,
+                        schema_name=schema_name or "default",
+                        updates={
+                            "ontology_ttl_file": ontology_filename,
+                            "ontology_graph_uri": graph_uri or "",
+                        },
+                    )
                 except Exception as e:
                     logger.warning(f"Failed to write workspace metadata: {e}")
 
@@ -432,6 +445,20 @@ async def generate_ontology(
                                     "initialized_at": utc_now().isoformat(),
                                 },
                             )
+                            # Only now is the triple count known. Gated on
+                            # `marked` for the same reason that flag is: if a
+                            # newer generation superseded this one, its counts
+                            # are the ones the version should carry.
+                            if marked:
+                                await update_schema_version(
+                                    connection_id=session.connection_id,
+                                    output_dir=OUTPUT_DIR,
+                                    schema_name=schema_name or "default",
+                                    updates={
+                                        "ontology_triple_count": triple_count,
+                                        "ontology_graph_uri": graph_uri,
+                                    },
+                                )
                         except Exception as e:
                             logger.warning(f"Failed to write workspace metadata: {e}")
 

--- a/src/handlers/ontology_generation.py
+++ b/src/handlers/ontology_generation.py
@@ -311,6 +311,7 @@ async def generate_ontology(
             session.obqc_validator = None
 
             # Write workspace metadata for ontology section
+            target_version: int | None = None
             if session.connection_id:
                 try:
                     await update_workspace_section(
@@ -326,10 +327,13 @@ async def generate_ontology(
                             "generated_at": utc_now().isoformat(),
                         },
                     )
-                    # Record the ontology half of the version discovery opened.
-                    # The triple count is not known until the RDF load below,
-                    # so it is filled in there rather than guessed here.
-                    await update_schema_version(
+                    # Record the ontology half of the version discovery opened,
+                    # and hold on to which version that was: the RDF load below
+                    # is slow, and a rediscovery during it would otherwise send
+                    # the triple count to a different generation than the file.
+                    # The count is not known until that load, so it is filled in
+                    # there rather than guessed here.
+                    target_version = await update_schema_version(
                         connection_id=session.connection_id,
                         output_dir=OUTPUT_DIR,
                         schema_name=schema_name or "default",
@@ -458,6 +462,7 @@ async def generate_ontology(
                                         "ontology_triple_count": triple_count,
                                         "ontology_graph_uri": graph_uri,
                                     },
+                                    version=target_version,
                                 )
                         except Exception as e:
                             logger.warning(f"Failed to write workspace metadata: {e}")

--- a/src/handlers/rdf.py
+++ b/src/handlers/rdf.py
@@ -13,7 +13,11 @@ from ..exceptions import (
     ValidationError,
 )
 from ..handler_context import HandlerContext
-from ..lifecycle.metadata import update_workspace_rdf, update_workspace_section
+from ..lifecycle.metadata import (
+    update_schema_version,
+    update_workspace_rdf,
+    update_workspace_section,
+)
 from ..oxigraph_store import OXIGRAPH_AVAILABLE, schema_graph_uri
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
 from ..utils import read_text_file, utc_now
@@ -96,6 +100,21 @@ async def store_ontology_in_rdf(
                         "initialized": True,
                         "graph_uris": [graph_uri],
                         "initialized_at": utc_now().isoformat(),
+                    },
+                )
+                # This is the documented path for generate_ontology(
+                # auto_persist=False), which leaves the version with no graph
+                # URI and a zero triple count. Without recording them here the
+                # version never learns which graph it loaded, and retention
+                # could not delete that graph when the version aged out.
+                await update_schema_version(
+                    connection_id=session.connection_id,
+                    output_dir=OUTPUT_DIR,
+                    schema_name=effective_schema,
+                    updates={
+                        "ontology_ttl_file": session.ontology_file,
+                        "ontology_graph_uri": graph_uri,
+                        "ontology_triple_count": triple_count,
                     },
                 )
             except Exception as e:

--- a/src/handlers/rdf.py
+++ b/src/handlers/rdf.py
@@ -14,6 +14,7 @@ from ..exceptions import (
 )
 from ..handler_context import HandlerContext
 from ..lifecycle.metadata import (
+    get_active_version_number,
     update_schema_version,
     update_workspace_rdf,
     update_workspace_section,
@@ -69,6 +70,18 @@ async def store_ontology_in_rdf(
         if not graph_uri:
             graph_uri = schema_graph_uri(effective_schema)
 
+        # Resolved before the load, which can take a while on a large ontology:
+        # a discover_schema landing meanwhile would otherwise send this graph
+        # URI and triple count to a generation that never loaded them.
+        target_version: int | None = None
+        if session.connection_id:
+            try:
+                target_version = await get_active_version_number(
+                    session.connection_id, OUTPUT_DIR, effective_schema
+                )
+            except Exception as e:
+                logger.warning(f"Failed to read active version: {e}")
+
         triple_count = store.load_ontology(
             ontology_ttl=ontology_ttl, graph_uri=graph_uri, schema_name=effective_schema
         )
@@ -116,6 +129,7 @@ async def store_ontology_in_rdf(
                         "ontology_graph_uri": graph_uri,
                         "ontology_triple_count": triple_count,
                     },
+                    version=target_version,
                 )
             except Exception as e:
                 logger.warning(f"Failed to write workspace metadata: {e}")

--- a/src/handlers/schema.py
+++ b/src/handlers/schema.py
@@ -10,7 +10,11 @@ from fastmcp import Context
 
 from ..handler_context import HandlerContext
 from ..lifecycle.artifacts import artifact_family_lock, prune_superseded_artifacts
-from ..lifecycle.metadata import open_schema_version, update_workspace_section
+from ..lifecycle.metadata import (
+    get_active_version_number,
+    open_schema_version,
+    update_workspace_section,
+)
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
 from ..r2rml_generator import R2RMLGenerator
 from ..utils import utc_now, write_json_file, write_text_file
@@ -20,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 async def _open_schema_version(
     session: Any, schema_name: str | None, tables: list[Any]
-) -> None:
+) -> int | None:
     """Record a new version for a schema that was just discovered.
 
     Never fatal: version history is bookkeeping alongside the discovery, and a
@@ -30,9 +34,14 @@ async def _open_schema_version(
         session: Session data holding the connection fingerprint.
         schema_name: Schema that was discovered.
         tables: The discovered table objects.
+
+    Returns:
+        The version number opened, or None if it could not be recorded. Pass it
+        to the background producers so their output lands on the generation they
+        were started for, not on whichever is active when they finish.
     """
     if not session.connection_id or not tables:
-        return
+        return None
     try:
         version = await open_schema_version(
             connection_id=session.connection_id,
@@ -43,8 +52,31 @@ async def _open_schema_version(
         logger.debug(
             f"Opened version {version} for schema '{schema_name or 'default'}'"
         )
+        return version
     except Exception as e:
         logger.warning(f"Failed to record schema version: {e}")
+        return None
+
+
+async def _active_schema_version(session: Any, schema_name: str) -> int | None:
+    """The schema's current version number, or None if it has no history.
+
+    Args:
+        session: Session data holding the connection fingerprint.
+        schema_name: Schema to look up.
+
+    Returns:
+        The active version number, if any.
+    """
+    if not session.connection_id:
+        return None
+    try:
+        return await get_active_version_number(
+            session.connection_id, OUTPUT_DIR, schema_name
+        )
+    except Exception as e:
+        logger.warning(f"Failed to read active schema version: {e}")
+        return None
 
 
 async def reset_cache(
@@ -164,12 +196,20 @@ async def discover_schema(
             logger.info(
                 f"GraphRAG auto-init triggered for cached schema: {effective_schema or 'default'}"
             )
+            # No new version: nothing was rediscovered. Bind to the generation
+            # current *now* rather than letting the task resolve it on
+            # completion, so a discover_schema that lands meanwhile does not
+            # capture this task's output.
+            cached_version = await _active_schema_version(
+                session, effective_schema or "default"
+            )
             task = asyncio.create_task(
                 services.auto_initialize_graphrag_background(
                     schema_name=effective_schema or "default",
                     tables_info=cached_tables,
                     session=session,
                     ctx=ctx,
+                    version=cached_version,
                 )
             )
             session.graphrag.track_init_task(task)
@@ -258,7 +298,9 @@ async def discover_schema(
 
         # Open the version before GraphRAG is kicked off below: the background
         # task looks up the active version to snapshot its state under.
-        await _open_schema_version(session, schema_name, table_info_objects)
+        schema_version = await _open_schema_version(
+            session, schema_name, table_info_objects
+        )
 
         lightweight_result = {
             "schema": schema_name or "default",
@@ -296,6 +338,7 @@ async def discover_schema(
                     tables_info=table_info_objects,
                     session=session,
                     ctx=ctx,
+                    version=schema_version,
                 )
             )
             session.graphrag.track_init_task(task)
@@ -349,7 +392,9 @@ async def discover_schema(
 
     # Open the version before GraphRAG is kicked off further down: the
     # background task looks up the active version to snapshot its state under.
-    await _open_schema_version(session, schema_name, table_info_objects)
+    schema_version = await _open_schema_version(
+        session, schema_name, table_info_objects
+    )
 
     # Both artifact families and the metadata naming them are produced under
     # one lock. Two overlapping discover_schema calls for the same schema
@@ -529,6 +574,7 @@ async def discover_schema(
                     tables_info=table_info_objects,
                     session=services.get_session_data(ctx),
                     ctx=ctx,
+                    version=schema_version,
                 )
             )
             session = services.get_session_data(ctx)

--- a/src/handlers/schema.py
+++ b/src/handlers/schema.py
@@ -10,12 +10,41 @@ from fastmcp import Context
 
 from ..handler_context import HandlerContext
 from ..lifecycle.artifacts import artifact_family_lock, prune_superseded_artifacts
-from ..lifecycle.metadata import update_workspace_section
+from ..lifecycle.metadata import open_schema_version, update_workspace_section
 from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
 from ..r2rml_generator import R2RMLGenerator
 from ..utils import utc_now, write_json_file, write_text_file
 
 logger = logging.getLogger(__name__)
+
+
+async def _open_schema_version(
+    session: Any, schema_name: str | None, tables: list[Any]
+) -> None:
+    """Record a new version for a schema that was just discovered.
+
+    Never fatal: version history is bookkeeping alongside the discovery, and a
+    metadata failure must not cost the caller the schema they asked for.
+
+    Args:
+        session: Session data holding the connection fingerprint.
+        schema_name: Schema that was discovered.
+        tables: The discovered table objects.
+    """
+    if not session.connection_id or not tables:
+        return
+    try:
+        version = await open_schema_version(
+            connection_id=session.connection_id,
+            output_dir=OUTPUT_DIR,
+            schema_name=schema_name or "default",
+            tables=tables,
+        )
+        logger.debug(
+            f"Opened version {version} for schema '{schema_name or 'default'}'"
+        )
+    except Exception as e:
+        logger.warning(f"Failed to record schema version: {e}")
 
 
 async def reset_cache(
@@ -227,6 +256,10 @@ async def discover_schema(
             f"Cached {len(table_info_objects)} tables for generate_ontology() reuse"
         )
 
+        # Open the version before GraphRAG is kicked off below: the background
+        # task looks up the active version to snapshot its state under.
+        await _open_schema_version(session, schema_name, table_info_objects)
+
         lightweight_result = {
             "schema": schema_name or "default",
             "table_count": len(tables),
@@ -313,6 +346,10 @@ async def discover_schema(
 
     session = services.get_session_data(ctx)
     session.cache_schema_analysis(schema_name or "", table_info_objects)
+
+    # Open the version before GraphRAG is kicked off further down: the
+    # background task looks up the active version to snapshot its state under.
+    await _open_schema_version(session, schema_name, table_info_objects)
 
     # Both artifact families and the metadata naming them are produced under
     # one lock. Two overlapping discover_schema calls for the same schema

--- a/src/handlers/workspace.py
+++ b/src/handlers/workspace.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import shutil
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,7 @@ from fastmcp import Context
 from ..database_manager import TableInfo
 from ..graphrag import GraphRAGManager
 from ..handler_context import HandlerContext
+from ..lifecycle.cleanup import DataCleanupManager
 from ..lifecycle.metadata import VersionMetadataManager, mutate_workspace_metadata
 from ..oxigraph_store import OXIGRAPH_AVAILABLE
 from ..paths import (
@@ -362,6 +364,85 @@ async def cleanup_workspace(
     result += "Call discover_schema() to start building a new workspace.\n"
 
     return result
+
+
+async def cleanup_old_versions(
+    ctx: Context,
+    schema_name: str | None,
+    dry_run: bool,
+    services: "HandlerContext",
+) -> dict[str, Any]:
+    """Apply the per-version retention policy to a schema's history.
+
+    Unlike ``cleanup_workspace``, which removes everything for the connection,
+    this deletes only the artifacts of *archived* versions that have aged past
+    the retention policy, leaving the current generation and recent history
+    intact.
+
+    Args:
+        ctx: FastMCP context
+        schema_name: Schema whose history to prune; the last analyzed one if omitted
+        dry_run: Report what would be deleted without deleting it
+        services: Handler service bundle
+
+    Returns:
+        Per-schema report of the versions removed or eligible for removal
+    """
+    session = services.get_session_data(ctx)
+
+    if not session.connection_id:
+        err: dict[str, Any] = services.create_error_response(
+            "No database connection. Call connect_database first.",
+            "connection_error",
+        )
+        return err
+
+    target = schema_name or session.get_last_analyzed_schema() or "default"
+
+    manager = DataCleanupManager(session.connection_id, OUTPUT_DIR)
+    policy = manager.metadata_mgr.get_retention_policy()
+
+    graphrag_report = await manager.cleanup_graphrag(target, dry_run=dry_run)
+    ontology_report = await manager.cleanup_ontology(
+        target,
+        dry_run=dry_run,
+        oxigraph_store=session.oxigraph_store,
+    )
+
+    # Read history *after* cleanup so the listing reflects the result the caller
+    # is being told about, not the state before it.
+    history = [
+        {
+            "version": v.version,
+            "created_at": v.created_at,
+            "status": v.status,
+            "table_count": v.table_count,
+            "column_count": v.column_count,
+            "ontology_file": v.ontology_ttl_file,
+            "ontology_triples": v.ontology_triple_count,
+            "graphrag_vectors": v.graphrag_vector_count,
+        }
+        for v in manager.metadata_mgr.get_versions(target)
+    ]
+
+    deleted_count = len(graphrag_report.get("deleted", [])) + len(
+        ontology_report.get("deleted", [])
+    )
+    verb = "would be removed" if dry_run else "removed"
+    await ctx.info(
+        f"Retention for schema '{target}': {deleted_count} version artifact "
+        f"group(s) {verb}"
+    )
+
+    return {
+        "success": True,
+        "schema": target,
+        "dry_run": dry_run,
+        "retention_policy": asdict(policy),
+        "graphrag": graphrag_report,
+        "ontology": ontology_report,
+        "versions": history,
+    }
 
 
 async def save_semantic_model(

--- a/src/lifecycle/cleanup.py
+++ b/src/lifecycle/cleanup.py
@@ -196,16 +196,35 @@ class DataCleanupManager:
 
         await mutate_workspace_metadata(self.connection_id, self.output_dir, _mutate)
 
+    def _all_versions(self) -> list[tuple[str, VersionInfo]]:
+        """Every recorded version on this connection, paired with its schema.
+
+        Both ownership guards need connection-wide scope: a ChromaDB collection
+        is shared across schemas by design, and a named graph URI can be shared
+        whenever a caller passes an explicit ``graph_uri``. Scoping either check
+        to the schema being cleaned would let it delete a resource another
+        schema is still using.
+
+        Returns:
+            (schema name, version) for every schema in the workspace.
+        """
+        return [
+            (schema_name, version)
+            for schema_name in self.metadata_mgr.metadata.get("schemas", {})
+            for version in self.metadata_mgr.get_versions(schema_name)
+        ]
+
     def _graph_uris_still_in_use(self, schema_name: str) -> set[str]:
         """Named graphs referenced by versions that are not being deleted.
 
         Successive generations of one schema reuse the same named graph URI
         (``schema_graph_uri`` is derived from the schema name), so deleting the
         graph because an *old* version referenced it would take the current
-        ontology's triples with it.
+        ontology's triples with it. Other schemas are included too, since an
+        explicit ``graph_uri`` argument can point two of them at one graph.
 
         Args:
-            schema_name: Schema whose versions to inspect.
+            schema_name: Schema being cleaned up.
 
         Returns:
             Graph URIs that must be preserved.
@@ -217,11 +236,11 @@ class DataCleanupManager:
             )
         }
         return {
-            v.ontology_graph_uri
-            for v in self.metadata_mgr.get_versions(schema_name)
-            if v.ontology_graph_uri
-            and v.ontology_status != "deleted"
-            and v.version not in doomed
+            version.ontology_graph_uri
+            for other_schema, version in self._all_versions()
+            if version.ontology_graph_uri
+            and version.ontology_status != "deleted"
+            and not (other_schema == schema_name and version.version in doomed)
         }
 
     def _delete_ontology_artifacts(
@@ -252,10 +271,12 @@ class DataCleanupManager:
                 "surviving version"
             )
             return
-        try:
-            oxigraph_store.delete_graph(graph_uri)
-        except Exception as e:
-            logger.warning(f"Failed to delete graph {graph_uri}: {e}")
+        # Deliberately unguarded. Swallowing a failure here left the triples in
+        # Oxigraph while the caller went on to mark the version deleted --
+        # destroying the only record of which graph to retry, so a transient
+        # store error orphaned the data permanently. Letting it propagate makes
+        # the caller record the failure and leave the version intact to retry.
+        oxigraph_store.delete_graph(graph_uri)
 
     def _delete_graphrag_files(self, schema_name: str, version: VersionInfo) -> None:
         """
@@ -306,11 +327,16 @@ class DataCleanupManager:
         if not collection:
             return
 
+        # Scanned across every schema on the connection, not just this one.
+        # The collection is connection-scoped by design, so analytics can be
+        # backed by the same collection public is being cleaned out of --
+        # checking only public's history would delete a store still serving
+        # analytics.
         still_referenced = any(
             other.graphrag_collection == collection
-            and other.version != version.version
+            and not (other_schema == schema_name and other.version == version.version)
             and other.graphrag_status != "deleted"
-            for other in self.metadata_mgr.get_versions(schema_name)
+            for other_schema, other in self._all_versions()
         )
         if still_referenced:
             logger.info(
@@ -329,11 +355,16 @@ class DataCleanupManager:
         if not db_path.exists():
             return
 
-        try:
-            client = chromadb.PersistentClient(path=str(db_path))
-            client.delete_collection(collection)
-            logger.info(f"Deleted ChromaDB collection '{collection}'")
-        except Exception as e:
-            # A collection that is already gone is the expected case when
-            # cleanup reruns; anything else is worth a line but not a failure.
-            logger.warning(f"Could not delete ChromaDB collection '{collection}': {e}")
+        # Absence is success, not failure: a rerun after a partial cleanup finds
+        # the collection already gone. Distinguishing that from a real error
+        # matters because errors propagate -- swallowing them would let the
+        # caller mark the version deleted and lose the record needed to retry,
+        # while propagating "already absent" would make every rerun fail.
+        client = chromadb.PersistentClient(path=str(db_path))
+        existing = {c.name for c in client.list_collections()}
+        if collection not in existing:
+            logger.info(f"ChromaDB collection '{collection}' already absent")
+            return
+
+        client.delete_collection(collection)
+        logger.info(f"Deleted ChromaDB collection '{collection}'")

--- a/src/lifecycle/cleanup.py
+++ b/src/lifecycle/cleanup.py
@@ -5,12 +5,15 @@ Implements automatic cleanup of old GraphRAG and RDF ontology versions
 based on retention policies.
 """
 
+import asyncio
 import logging
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
+from ..paths import OUTPUT_DIR
 from ..utils import parse_timestamp, utc_now
-from .metadata import VersionMetadataManager
+from .metadata import VersionInfo, VersionMetadataManager, mutate_workspace_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -18,25 +21,17 @@ logger = logging.getLogger(__name__)
 class DataCleanupManager:
     """Manages cleanup of old GraphRAG and RDF data based on retention policies.
 
-    Currently unwired. This is the per-version retention design from Phase 3B,
-    whose entry points (``cleanup_all``, ``cleanup_all_connections``) were
-    removed as dead code once ``AUTO_CLEANUP_ON_STARTUP`` shipped separately in
-    ``server.py`` as simpler whole-workspace-age retention. Nothing instantiates
-    this class today.
+    Retention is per *version*: each ``discover_schema`` opens a generation that
+    ontology generation and GraphRAG initialization then fill in, and this class
+    deletes the artifacts of generations that have aged out of the policy. It is
+    the counterpart to ``lifecycle/artifacts.py``, which prunes superseded files
+    eagerly by count -- this one prunes whole recorded versions by age, and
+    leaves a record of what it removed.
 
-    .. warning::
-       Reviving it requires a concurrency fix first. The methods below mutate
-       metadata.json through ``metadata_mgr.mark_version_deleted()``, which
-       bypasses the per-connection lock in ``lifecycle/metadata.py``. That is
-       only harmless while the API stays synchronous and uncalled -- and the
-       original design invoked it from async paths (startup, post-analysis, and
-       an MCP tool), which is exactly where it would race. An unserialized
-       read-modify-write of metadata.json reproducibly drops other writers'
-       sections and can leave the file unparseable.
-
-       Route the writes through ``mutate_workspace_metadata()`` before calling
-       any of this from async code, and drop the matching exemption in
-       ``tests/test_metadata_concurrency.py`` at the same time.
+    Every metadata write goes through ``mutate_workspace_metadata()``, so the
+    read-modify-write of metadata.json is serialized against the workspace
+    writers in the handlers. Deleting files and RDF graphs is offloaded with
+    ``asyncio.to_thread`` -- both touch disk and neither belongs on the loop.
     """
 
     def __init__(self, connection_id: str, output_dir: Path):
@@ -52,7 +47,7 @@ class DataCleanupManager:
         self.connection_dir = output_dir / connection_id
         self.metadata_mgr = VersionMetadataManager(connection_id, output_dir)
 
-    def cleanup_graphrag(
+    async def cleanup_graphrag(
         self, schema_name: str, dry_run: bool = True
     ) -> dict[str, Any]:
         """
@@ -76,17 +71,17 @@ class DataCleanupManager:
                 "reason": "All versions within retention policy",
             }
 
+        max_age = self.metadata_mgr.get_retention_policy().graphrag_max_age_days
         deleted = []
         errors = []
 
         for version in versions_to_delete:
             try:
                 if not dry_run:
-                    # Delete ChromaDB collection or JSON files
-                    self._delete_graphrag_files(schema_name, version.version)
-
-                    # Mark as deleted in metadata
-                    self.metadata_mgr.mark_version_deleted(
+                    await asyncio.to_thread(
+                        self._delete_graphrag_files, schema_name, version
+                    )
+                    await self._mark_version_deleted(
                         schema_name, version.version, "graphrag"
                     )
 
@@ -97,19 +92,20 @@ class DataCleanupManager:
                         "version": version.version,
                         "age_days": age_days,
                         "created_at": version.created_at,
-                        "reason": f"Age {age_days} days exceeds max {self.metadata_mgr.get_retention_policy().graphrag_max_age_days} days",
+                        "files": version.graphrag_files,
+                        "reason": (f"Age {age_days} days exceeds max {max_age} days"),
                     }
                 )
 
             except Exception as e:
-                logger.error(
+                logger.exception(
                     f"Failed to delete GraphRAG version {version.version}: {e}"
                 )
                 errors.append({"version": version.version, "error": str(e)})
 
         return {"deleted": deleted, "errors": errors, "dry_run": dry_run}
 
-    def cleanup_ontology(
+    async def cleanup_ontology(
         self,
         schema_name: str,
         dry_run: bool = True,
@@ -137,28 +133,21 @@ class DataCleanupManager:
                 "reason": "All versions within retention policy",
             }
 
+        max_age = self.metadata_mgr.get_retention_policy().ontology_max_age_days
+        live_graphs = self._graph_uris_still_in_use(schema_name)
         deleted = []
         errors = []
 
         for version in versions_to_delete:
             try:
                 if not dry_run:
-                    # Delete TTL file
-                    ttl_path = self.output_dir / version.ontology_ttl_file
-                    if ttl_path.exists():
-                        ttl_path.unlink()
-
-                    # Delete named graph from Oxigraph (if store provided)
-                    if oxigraph_store and version.ontology_graph_uri:
-                        try:
-                            oxigraph_store.delete_graph(version.ontology_graph_uri)
-                        except Exception as e:
-                            logger.warning(
-                                f"Failed to delete graph {version.ontology_graph_uri}: {e}"
-                            )
-
-                    # Mark as deleted in metadata
-                    self.metadata_mgr.mark_version_deleted(
+                    await asyncio.to_thread(
+                        self._delete_ontology_artifacts,
+                        version,
+                        oxigraph_store,
+                        live_graphs,
+                    )
+                    await self._mark_version_deleted(
                         schema_name, version.version, "ontology"
                     )
 
@@ -171,45 +160,180 @@ class DataCleanupManager:
                         "created_at": version.created_at,
                         "graph_uri": version.ontology_graph_uri,
                         "ttl_file": version.ontology_ttl_file,
-                        "reason": f"Age {age_days} days exceeds max {self.metadata_mgr.get_retention_policy().ontology_max_age_days} days",
+                        "reason": (f"Age {age_days} days exceeds max {max_age} days"),
                     }
                 )
 
             except Exception as e:
-                logger.error(
+                logger.exception(
                     f"Failed to delete Ontology version {version.version}: {e}"
                 )
                 errors.append({"version": version.version, "error": str(e)})
 
         return {"deleted": deleted, "errors": errors, "dry_run": dry_run}
 
-    def _delete_graphrag_files(self, schema_name: str, version: int) -> None:
+    async def _mark_version_deleted(
+        self, schema_name: str, version: int, data_type: str
+    ) -> None:
+        """Record a version as deleted, serialized against other metadata writers.
+
+        Args:
+            schema_name: Schema name.
+            version: Version number that was deleted.
+            data_type: "graphrag", "ontology" or "all".
+        """
+
+        def _mutate(mgr: VersionMetadataManager) -> None:
+            mgr.mark_version_deleted(schema_name, version, data_type)
+            # Adopt the state that was just persisted, inside the lock. This
+            # instance's view is read between calls -- _graph_uris_still_in_use
+            # and the ChromaDB ownership guard both consult it -- and a stale
+            # copy would let the second version in a run be judged against the
+            # history as it stood before the first. Re-running mark_version_
+            # deleted on our own manager instead would be a second, unserialized
+            # write of metadata.json: the exact race this lock exists to stop.
+            self.metadata_mgr.metadata = deepcopy(mgr.metadata)
+
+        await mutate_workspace_metadata(self.connection_id, self.output_dir, _mutate)
+
+    def _graph_uris_still_in_use(self, schema_name: str) -> set[str]:
+        """Named graphs referenced by versions that are not being deleted.
+
+        Successive generations of one schema reuse the same named graph URI
+        (``schema_graph_uri`` is derived from the schema name), so deleting the
+        graph because an *old* version referenced it would take the current
+        ontology's triples with it.
+
+        Args:
+            schema_name: Schema whose versions to inspect.
+
+        Returns:
+            Graph URIs that must be preserved.
+        """
+        doomed = {
+            v.version
+            for v in self.metadata_mgr.get_versions_to_cleanup(
+                schema_name, data_type="ontology"
+            )
+        }
+        return {
+            v.ontology_graph_uri
+            for v in self.metadata_mgr.get_versions(schema_name)
+            if v.ontology_graph_uri
+            and v.ontology_status != "deleted"
+            and v.version not in doomed
+        }
+
+    def _delete_ontology_artifacts(
+        self,
+        version: VersionInfo,
+        oxigraph_store: Any | None,
+        live_graphs: set[str],
+    ) -> None:
+        """Delete one version's TTL file and, if unreferenced, its named graph.
+
+        Args:
+            version: Version being cleaned up.
+            oxigraph_store: Store to delete the named graph from, if available.
+            live_graphs: Graph URIs still referenced by surviving versions.
+        """
+        if version.ontology_ttl_file:
+            ttl_path = self.connection_dir / version.ontology_ttl_file
+            if ttl_path.exists():
+                ttl_path.unlink()
+                logger.info(f"Deleted {ttl_path}")
+
+        graph_uri = version.ontology_graph_uri
+        if not (oxigraph_store and graph_uri):
+            return
+        if graph_uri in live_graphs:
+            logger.info(
+                f"Kept named graph <{graph_uri}>: still referenced by a "
+                "surviving version"
+            )
+            return
+        try:
+            oxigraph_store.delete_graph(graph_uri)
+        except Exception as e:
+            logger.warning(f"Failed to delete graph {graph_uri}: {e}")
+
+    def _delete_graphrag_files(self, schema_name: str, version: VersionInfo) -> None:
         """
         Delete GraphRAG files for a specific version.
 
         Args:
             schema_name: Schema name
-            version: Version number
+            version: Version being cleaned up
         """
-        # Check for ChromaDB collection
-        chromadb_dir = self.output_dir / "chromadb" / self.connection_id
-        if chromadb_dir.exists():
-            # ChromaDB collections are managed by ChromaDB itself
-            # We'll need to use the ChromaDB client to delete collections
-            # For now, just log
-            logger.info(
-                f"ChromaDB collection cleanup for version {version} (managed by ChromaDB)"
-            )
+        self._delete_chromadb_collection(schema_name, version)
 
-        # Check for JSON files (legacy or backup)
-        json_patterns = [
-            f"vector_store_{schema_name}_v{version}.json",
-            f"graph_{schema_name}_v{version}.json",
-            f"communities_{schema_name}_v{version}.json",
+        # Snapshot files recorded when the version was saved. Older workspaces
+        # predate the recording, so fall back to the conventional names.
+        names = version.graphrag_files or [
+            f"vector_store_{schema_name}_v{version.version}.json",
+            f"graph_{schema_name}_v{version.version}.json",
+            f"communities_{schema_name}_v{version.version}.json",
         ]
 
-        for pattern in json_patterns:
-            file_path = self.connection_dir / pattern
+        for name in names:
+            file_path = self.connection_dir / name
             if file_path.exists():
                 file_path.unlink()
                 logger.info(f"Deleted {file_path}")
+
+    def _delete_chromadb_collection(
+        self, schema_name: str, version: VersionInfo
+    ) -> None:
+        """Delete this version's ChromaDB collection, if it owns one outright.
+
+        GraphRAG is connection-scoped and accumulative by design: one collection
+        holds every schema's vectors so cross-schema search and join discovery
+        work. Successive versions therefore share a collection rather than each
+        getting their own, and dropping it because an archived version referenced
+        it would wipe the live vector store for every schema on the connection.
+
+        So the delete is guarded by ownership -- it runs only when no surviving
+        version references the same collection. Today that makes it a no-op
+        whenever the schema still has a live version, which is the correct
+        outcome and the reason this is a guard rather than an unconditional
+        delete.
+
+        Args:
+            schema_name: Schema name.
+            version: Version being cleaned up.
+        """
+        collection = version.graphrag_collection
+        if not collection:
+            return
+
+        still_referenced = any(
+            other.graphrag_collection == collection
+            and other.version != version.version
+            and other.graphrag_status != "deleted"
+            for other in self.metadata_mgr.get_versions(schema_name)
+        )
+        if still_referenced:
+            logger.info(
+                f"Kept ChromaDB collection '{collection}': still referenced by "
+                "a surviving version"
+            )
+            return
+
+        try:
+            import chromadb
+        except ImportError:
+            logger.info(f"ChromaDB not installed; skipping collection '{collection}'")
+            return
+
+        db_path = OUTPUT_DIR / "chromadb" / self.connection_id
+        if not db_path.exists():
+            return
+
+        try:
+            client = chromadb.PersistentClient(path=str(db_path))
+            client.delete_collection(collection)
+            logger.info(f"Deleted ChromaDB collection '{collection}'")
+        except Exception as e:
+            # A collection that is already gone is the expected case when
+            # cleanup reruns; anything else is worth a line but not a failure.
+            logger.warning(f"Could not delete ChromaDB collection '{collection}': {e}")

--- a/src/lifecycle/metadata.py
+++ b/src/lifecycle/metadata.py
@@ -8,14 +8,15 @@ Also manages workspace state for session restore across reconnections.
 
 import asyncio
 import contextlib
+import hashlib
 import json
 import logging
 import os
 import tempfile
 import threading
 import weakref
-from collections.abc import Callable
-from dataclasses import asdict, dataclass
+from collections.abc import Callable, Iterable
+from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
 from typing import Any
 
@@ -91,7 +92,13 @@ def _get_metadata_thread_lock(connection_id: str) -> threading.Lock:
 
 @dataclass
 class VersionInfo:
-    """Information about a specific version."""
+    """Information about a specific version.
+
+    A version is one *generation cycle* for a schema. ``discover_schema`` opens
+    it, and ``generate_ontology`` and GraphRAG initialization fill in their
+    halves as they complete -- so a version is partially populated for as long
+    as the workflow that produces it is still running.
+    """
 
     version: int
     created_at: str  # ISO format
@@ -101,19 +108,73 @@ class VersionInfo:
 
     # GraphRAG info
     graphrag_vector_count: int
-    graphrag_status: str  # "active" or "archived"
+    graphrag_status: str  # "active", "archived" or "deleted"
 
     # Ontology info
     ontology_graph_uri: str
     ontology_triple_count: int
     ontology_ttl_file: str
-    ontology_status: str  # "active" or "archived"
+    ontology_status: str  # "active", "archived" or "deleted"
 
     # Changes from previous version (if any)
     changes: dict[str, Any] | None = None
 
     # Overall status
-    status: str = "active"  # "active" or "archived"
+    status: str = "active"  # "active", "archived" or "deleted"
+
+    # ChromaDB collection backing this version's vectors. Recorded so cleanup
+    # can tell whether the collection is still referenced by a live version
+    # before deleting it -- see DataCleanupManager._delete_graphrag_files.
+    graphrag_collection: str = ""
+
+    # Per-version GraphRAG snapshot files, relative to the connection dir.
+    # These are what cleanup deletes; the unversioned files that load_state
+    # reads are the current-generation pointer and are never candidates.
+    graphrag_files: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "VersionInfo":
+        """Build a VersionInfo from a stored dict, tolerating schema drift.
+
+        metadata.json outlives any single release: a file written by a newer
+        build can carry fields this one does not know, and a workspace written
+        by an older build lacks fields added since. Unknown keys are dropped and
+        missing optional ones fall back to their defaults, so neither direction
+        raises TypeError while loading a workspace.
+
+        Args:
+            data: One entry of a schema's ``versions`` array.
+
+        Returns:
+            The parsed version record.
+        """
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+def _env_int(name: str) -> int | None:
+    """Read a positive integer environment variable.
+
+    Args:
+        name: Environment variable name.
+
+    Returns:
+        The parsed value, or None if unset, unparseable, or below 1. Invalid
+        values are logged and ignored rather than raising, so a typo in .env
+        degrades to the default instead of failing server startup.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(f"Invalid {name}={raw!r}; ignoring")
+        return None
+    if value < 1:
+        logger.warning(f"Invalid {name}={raw!r} (must be >= 1); ignoring")
+        return None
+    return value
 
 
 @dataclass
@@ -125,6 +186,40 @@ class RetentionPolicy:
     ontology_keep_versions: int = 5
     ontology_max_age_days: int = 60
     min_versions: int = 2  # Always keep at least this many
+
+    @classmethod
+    def from_metadata(cls, stored: dict[str, Any] | None) -> "RetentionPolicy":
+        """Build a policy from stored metadata, letting the environment win.
+
+        Precedence is environment > the workspace's recorded policy > the
+        dataclass default. The environment wins because it is how an operator
+        changes retention for a server that already has workspaces on disk --
+        the recorded copy is a snapshot of whatever was in force when the
+        workspace was created, and would otherwise pin it forever.
+
+        Unknown keys in *stored* are ignored: metadata.json is long-lived and a
+        policy field removed in a later release must not break loading.
+
+        Args:
+            stored: The ``retention_policy`` section of metadata.json, if any.
+
+        Returns:
+            The effective retention policy.
+        """
+        known = {f.name for f in fields(cls)}
+        values: dict[str, Any] = {k: v for k, v in (stored or {}).items() if k in known}
+
+        for field_name, env_name in (
+            ("graphrag_keep_versions", "GRAPHRAG_KEEP_VERSIONS"),
+            ("graphrag_max_age_days", "GRAPHRAG_MAX_AGE_DAYS"),
+            ("ontology_keep_versions", "ONTOLOGY_KEEP_VERSIONS"),
+            ("ontology_max_age_days", "ONTOLOGY_MAX_AGE_DAYS"),
+        ):
+            from_env = _env_int(env_name)
+            if from_env is not None:
+                values[field_name] = from_env
+
+        return cls(**values)
 
 
 class VersionMetadataManager:
@@ -226,10 +321,207 @@ class VersionMetadataManager:
         # Find active version
         for v_dict in reversed(versions):
             if v_dict.get("status") == "active":
-                return VersionInfo(**v_dict)
+                return VersionInfo.from_dict(v_dict)
 
         # Fallback to latest
-        return VersionInfo(**versions[-1])
+        return VersionInfo.from_dict(versions[-1])
+
+    def get_versions(self, schema_name: str) -> list[VersionInfo]:
+        """All recorded versions for a schema, oldest first.
+
+        Args:
+            schema_name: Schema name.
+
+        Returns:
+            The schema's version history, empty if it has none.
+        """
+        schema_meta = self.get_schema_metadata(schema_name)
+        if not schema_meta:
+            return []
+        return [VersionInfo.from_dict(v) for v in schema_meta.get("versions", [])]
+
+    def _version_entries(self, schema_name: str) -> list[dict[str, Any]]:
+        """The raw ``versions`` list for a schema, creating the path if absent.
+
+        Returns the live list so callers can mutate it in place; the caller is
+        responsible for persisting.
+
+        Args:
+            schema_name: Schema name.
+
+        Returns:
+            The mutable list of version dicts.
+        """
+        schemas = self.metadata.setdefault("schemas", {})
+        schema_meta = schemas.setdefault(schema_name, {})
+        entries: list[dict[str, Any]] = schema_meta.setdefault("versions", [])
+        return entries
+
+    def _migrate_legacy_versions(self, schema_name: str) -> bool:
+        """Seed a version 1 for a workspace that predates version recording.
+
+        Workspaces created before this feature have a populated ``workspace``
+        section but no ``versions`` array, so their current generation would be
+        invisible to history and -- worse -- the next ``open_version`` would
+        record version 1 as though nothing had come before. Seeding from what
+        the workspace already knows keeps the existing artifacts in the history
+        instead of orphaning them.
+
+        Only the fields the workspace actually recorded are carried over; the
+        rest keep their zero values, which is honest about what is unknown
+        rather than inventing counts.
+
+        Args:
+            schema_name: Schema name.
+
+        Returns:
+            True if a version was seeded, False if there was nothing to migrate.
+        """
+        if self._version_entries(schema_name):
+            return False
+
+        workspace_schema = self.get_workspace_schema(schema_name)
+        if not workspace_schema:
+            return False
+
+        schema_section = workspace_schema.get("schema") or {}
+        ontology_section = workspace_schema.get("ontology") or {}
+        graphrag_section = workspace_schema.get("graphrag") or {}
+
+        # Nothing worth recording -- an empty workspace shell is not a version.
+        if not (schema_section or ontology_section or graphrag_section):
+            return False
+
+        created_at = (
+            schema_section.get("analyzed_at")
+            or ontology_section.get("generated_at")
+            or (self.get_workspace() or {}).get("updated_at")
+            or utc_now().isoformat()
+        )
+
+        seeded = VersionInfo(
+            version=1,
+            created_at=created_at,
+            schema_hash=schema_section.get("schema_hash", ""),
+            table_count=int(schema_section.get("table_count", 0) or 0),
+            column_count=int(schema_section.get("column_count", 0) or 0),
+            graphrag_vector_count=int(graphrag_section.get("vector_count", 0) or 0),
+            graphrag_status="active" if graphrag_section else "archived",
+            ontology_graph_uri=ontology_section.get("graph_uri", "") or "",
+            ontology_triple_count=int(ontology_section.get("triple_count", 0) or 0),
+            ontology_ttl_file=ontology_section.get("ontology_file", "") or "",
+            ontology_status="active" if ontology_section else "archived",
+            changes={"migrated_from_workspace": True},
+            status="active",
+            graphrag_collection=graphrag_section.get("collection", "") or "",
+        )
+        self._version_entries(schema_name).append(asdict(seeded))
+        logger.info(
+            f"Seeded version 1 for schema '{schema_name}' from existing "
+            f"workspace state (connection {self.connection_id})"
+        )
+        return True
+
+    def open_version(
+        self,
+        schema_name: str,
+        schema_hash: str,
+        table_count: int,
+        column_count: int,
+    ) -> VersionInfo:
+        """Start a new version for a schema, archiving the one it supersedes.
+
+        Called from ``discover_schema``: discovery is what defines a generation,
+        and ontology generation plus GraphRAG initialization fill in their
+        halves afterwards via :meth:`update_active_version`.
+
+        Args:
+            schema_name: Schema name.
+            schema_hash: Fingerprint of the discovered structure.
+            table_count: Number of tables discovered.
+            column_count: Total number of columns across those tables.
+
+        Returns:
+            The newly opened version.
+        """
+        self._migrate_legacy_versions(schema_name)
+        entries = self._version_entries(schema_name)
+
+        previous = None
+        for entry in entries:
+            if entry.get("status") == "active":
+                previous = entry
+            # Archive every still-live record; only the new version is active.
+            for key in ("status", "graphrag_status", "ontology_status"):
+                if entry.get(key) == "active":
+                    entry[key] = "archived"
+
+        next_number = max((int(e.get("version", 0)) for e in entries), default=0) + 1
+
+        changes: dict[str, Any] | None = None
+        if previous is not None:
+            changes = {
+                "previous_version": int(previous.get("version", 0)),
+                "table_count_delta": table_count
+                - int(previous.get("table_count", 0) or 0),
+                "schema_changed": previous.get("schema_hash", "") != schema_hash,
+            }
+
+        opened = VersionInfo(
+            version=next_number,
+            created_at=utc_now().isoformat(),
+            schema_hash=schema_hash,
+            table_count=table_count,
+            column_count=column_count,
+            graphrag_vector_count=0,
+            graphrag_status="active",
+            ontology_graph_uri="",
+            ontology_triple_count=0,
+            ontology_ttl_file="",
+            ontology_status="active",
+            changes=changes,
+            status="active",
+        )
+        entries.append(asdict(opened))
+        self._save_metadata()
+        logger.debug(
+            f"Opened version {next_number} for schema '{schema_name}' "
+            f"(connection {self.connection_id})"
+        )
+        return opened
+
+    def update_active_version(
+        self, schema_name: str, updates: dict[str, Any]
+    ) -> VersionInfo | None:
+        """Merge *updates* into the schema's active version record.
+
+        Used by the producers that complete a generation after discovery opened
+        it -- ontology generation and GraphRAG initialization. If no version is
+        open the update is dropped rather than inventing one: those producers
+        can legitimately run against a schema discovered before this feature
+        existed, or with recording disabled.
+
+        Args:
+            schema_name: Schema name.
+            updates: VersionInfo field names to new values. Unknown keys are
+                ignored so a caller cannot silently corrupt the record shape.
+
+        Returns:
+            The updated version, or None if the schema has no active version.
+        """
+        known = {f.name for f in fields(VersionInfo)} - {"version", "created_at"}
+        applicable = {k: v for k, v in updates.items() if k in known}
+        if not applicable:
+            return None
+
+        for entry in reversed(self._version_entries(schema_name)):
+            if entry.get("status") != "active":
+                continue
+            entry.update(applicable)
+            self._save_metadata()
+            return VersionInfo.from_dict(entry)
+
+        return None
 
     def get_versions_to_cleanup(
         self,
@@ -250,11 +542,11 @@ class VersionMetadataManager:
         if not schema_meta:
             return []
 
-        versions = [VersionInfo(**v) for v in schema_meta.get("versions", [])]
+        versions = [VersionInfo.from_dict(v) for v in schema_meta.get("versions", [])]
         if not versions:
             return []
 
-        policy = RetentionPolicy(**self.metadata.get("retention_policy", {}))
+        policy = self.get_retention_policy()
 
         # Separate logic for GraphRAG vs Ontology
         if data_type == "graphrag":
@@ -345,12 +637,20 @@ class VersionMetadataManager:
             if age_days > max_age_days:
                 to_delete.append(version)
 
-        # Safety check: ensure we keep minimum versions
+        # Safety check: ensure we keep minimum versions.
+        #
+        # Unreachable while keep_count >= min_versions, since to_delete is drawn
+        # from sorted_versions[:-keep_count] and so always leaves keep_count
+        # behind. It becomes reachable now that keep_count is operator-settable
+        # (GRAPHRAG_KEEP_VERSIONS=1 with min_versions=2, say).
+        #
+        # Spare the *newest* candidates, not the oldest: to_delete is ordered
+        # oldest-first, so trimming from the front would keep the stalest
+        # versions and delete the ones most likely to be worth rolling back to.
         remaining = len(sorted_versions) - len(to_delete)
         if remaining < min_versions:
-            # Delete fewer to maintain minimum
             excess = min_versions - remaining
-            to_delete = to_delete[excess:]
+            to_delete = to_delete[:-excess] if excess < len(to_delete) else []
 
         return to_delete
 
@@ -382,8 +682,8 @@ class VersionMetadataManager:
         self._save_metadata()
 
     def get_retention_policy(self) -> RetentionPolicy:
-        """Get current retention policy."""
-        return RetentionPolicy(**self.metadata.get("retention_policy", {}))
+        """Get the effective retention policy (environment overrides stored)."""
+        return RetentionPolicy.from_metadata(self.metadata.get("retention_policy"))
 
     # --- Workspace State Management ---
 
@@ -638,6 +938,127 @@ async def mark_ontology_persisted(
 
     await mutate_workspace_metadata(connection_id, output_dir, _mutate)
     return applied
+
+
+def schema_fingerprint(tables: Iterable[Any]) -> tuple[str, int, int]:
+    """Summarize a discovered schema as (hash, table count, column count).
+
+    The hash covers table names and their column names, sorted, so it is stable
+    across the order the driver happens to return objects in and changes only
+    when the structure does. It is a change detector for version history, not a
+    security primitive.
+
+    Accepts anything table-shaped -- ``.name``, optional ``.schema``, and
+    ``.columns`` whose entries have ``.name`` -- rather than importing the
+    driver's TableInfo, which would point this module's dependencies the wrong
+    way.
+
+    Args:
+        tables: Discovered table objects.
+
+    Returns:
+        Tuple of (schema hash, table count, total column count).
+    """
+    entries: list[str] = []
+    column_count = 0
+    table_count = 0
+
+    for table in tables:
+        table_count += 1
+        columns = getattr(table, "columns", None) or []
+        names = sorted(str(getattr(c, "name", c)) for c in columns)
+        column_count += len(names)
+        qualified = f"{getattr(table, 'schema', '') or ''}.{getattr(table, 'name', '')}"
+        entries.append(f"{qualified}({','.join(names)})")
+
+    digest = hashlib.sha256("|".join(sorted(entries)).encode()).hexdigest()[:16]
+    return digest, table_count, column_count
+
+
+async def open_schema_version(
+    connection_id: str,
+    output_dir: Path,
+    schema_name: str,
+    tables: Iterable[Any],
+) -> int | None:
+    """Open a new version for a freshly discovered schema.
+
+    Args:
+        connection_id: Database connection fingerprint.
+        output_dir: Base output directory.
+        schema_name: Schema that was discovered.
+        tables: The discovered table objects (see :func:`schema_fingerprint`).
+
+    Returns:
+        The new version number, or None if it could not be recorded.
+    """
+    schema_hash, table_count, column_count = schema_fingerprint(tables)
+    opened: int | None = None
+
+    def _mutate(mgr: VersionMetadataManager) -> None:
+        nonlocal opened
+        opened = mgr.open_version(
+            schema_name,
+            schema_hash=schema_hash,
+            table_count=table_count,
+            column_count=column_count,
+        ).version
+
+    await mutate_workspace_metadata(connection_id, output_dir, _mutate)
+    return opened
+
+
+async def update_schema_version(
+    connection_id: str,
+    output_dir: Path,
+    schema_name: str,
+    updates: dict[str, Any],
+) -> int | None:
+    """Fill in part of a schema's open version.
+
+    Args:
+        connection_id: Database connection fingerprint.
+        output_dir: Base output directory.
+        schema_name: Schema whose active version to update.
+        updates: VersionInfo field names to new values.
+
+    Returns:
+        The version number updated, or None if no version was open.
+    """
+    updated: int | None = None
+
+    def _mutate(mgr: VersionMetadataManager) -> None:
+        nonlocal updated
+        version = mgr.update_active_version(schema_name, updates)
+        updated = version.version if version else None
+
+    await mutate_workspace_metadata(connection_id, output_dir, _mutate)
+    return updated
+
+
+async def get_active_version_number(
+    connection_id: str,
+    output_dir: Path,
+    schema_name: str,
+) -> int | None:
+    """The schema's open version number, or None if it has no history.
+
+    Args:
+        connection_id: Database connection fingerprint.
+        output_dir: Base output directory.
+        schema_name: Schema to look up.
+
+    Returns:
+        The active version number, if any.
+    """
+
+    def _read() -> int | None:
+        mgr = VersionMetadataManager(connection_id, output_dir)
+        current = mgr.get_current_version(schema_name)
+        return current.version if current else None
+
+    async with _get_metadata_lock(connection_id):
+        return await asyncio.to_thread(_read)
 
 
 async def update_workspace_rdf(

--- a/src/lifecycle/metadata.py
+++ b/src/lifecycle/metadata.py
@@ -433,7 +433,7 @@ class VersionMetadataManager:
 
         Called from ``discover_schema``: discovery is what defines a generation,
         and ontology generation plus GraphRAG initialization fill in their
-        halves afterwards via :meth:`update_active_version`.
+        halves afterwards via :meth:`update_version`.
 
         Args:
             schema_name: Schema name.
@@ -490,24 +490,36 @@ class VersionMetadataManager:
         )
         return opened
 
-    def update_active_version(
-        self, schema_name: str, updates: dict[str, Any]
+    def update_version(
+        self,
+        schema_name: str,
+        updates: dict[str, Any],
+        version: int | None = None,
     ) -> VersionInfo | None:
-        """Merge *updates* into the schema's active version record.
+        """Merge *updates* into one of a schema's version records.
 
         Used by the producers that complete a generation after discovery opened
-        it -- ontology generation and GraphRAG initialization. If no version is
-        open the update is dropped rather than inventing one: those producers
-        can legitimately run against a schema discovered before this feature
-        existed, or with recording disabled.
+        it -- ontology generation and GraphRAG initialization. If the target
+        version does not exist the update is dropped rather than inventing one:
+        those producers can legitimately run against a schema discovered before
+        this feature existed, or with recording disabled.
+
+        Pass *version* to address a specific generation. Producers must, because
+        several of them finish long after they started -- background GraphRAG
+        init, AUTO_ONTOLOGY generation, an Oxigraph load -- and a second
+        ``discover_schema`` for the same schema during that window opens a newer
+        version. Resolving "the active version" at completion time would then
+        stamp the first run's snapshots, TTL file and triple counts onto a
+        generation they have nothing to do with.
 
         Args:
             schema_name: Schema name.
             updates: VersionInfo field names to new values. Unknown keys are
                 ignored so a caller cannot silently corrupt the record shape.
+            version: Version number to update; the active one if omitted.
 
         Returns:
-            The updated version, or None if the schema has no active version.
+            The updated version, or None if no matching version exists.
         """
         known = {f.name for f in fields(VersionInfo)} - {"version", "created_at"}
         applicable = {k: v for k, v in updates.items() if k in known}
@@ -515,7 +527,12 @@ class VersionMetadataManager:
             return None
 
         for entry in reversed(self._version_entries(schema_name)):
-            if entry.get("status") != "active":
+            matches = (
+                entry.get("version") == version
+                if version is not None
+                else entry.get("status") == "active"
+            )
+            if not matches:
                 continue
             entry.update(applicable)
             self._save_metadata()
@@ -1013,24 +1030,30 @@ async def update_schema_version(
     output_dir: Path,
     schema_name: str,
     updates: dict[str, Any],
+    version: int | None = None,
 ) -> int | None:
-    """Fill in part of a schema's open version.
+    """Fill in part of one of a schema's versions.
+
+    Callers that started work against a known generation should pass *version*
+    -- see :meth:`VersionMetadataManager.update_version` for why resolving the
+    active version at completion time is unsafe.
 
     Args:
         connection_id: Database connection fingerprint.
         output_dir: Base output directory.
-        schema_name: Schema whose active version to update.
+        schema_name: Schema whose version to update.
         updates: VersionInfo field names to new values.
+        version: Version number to update; the active one if omitted.
 
     Returns:
-        The version number updated, or None if no version was open.
+        The version number updated, or None if no matching version exists.
     """
     updated: int | None = None
 
     def _mutate(mgr: VersionMetadataManager) -> None:
         nonlocal updated
-        version = mgr.update_active_version(schema_name, updates)
-        updated = version.version if version else None
+        target = mgr.update_version(schema_name, updates, version)
+        updated = target.version if target else None
 
     await mutate_workspace_metadata(connection_id, output_dir, _mutate)
     return updated

--- a/src/main.py
+++ b/src/main.py
@@ -572,6 +572,34 @@ async def cleanup_workspace(ctx: Context) -> str:
 
 
 @mcp.tool()
+async def cleanup_old_versions(
+    ctx: Context,
+    schema_name: _Identifier | None = None,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    """Prune old ontology and GraphRAG versions for a schema per the retention policy.
+
+    Unlike cleanup_workspace(), which removes everything for the connection, this
+    deletes only archived versions that have aged past the retention policy —
+    the current generation and recent history are kept. Also returns the schema's
+    remaining version history.
+
+    Retention is controlled by GRAPHRAG_KEEP_VERSIONS, GRAPHRAG_MAX_AGE_DAYS,
+    ONTOLOGY_KEEP_VERSIONS and ONTOLOGY_MAX_AGE_DAYS.
+
+    Args:
+        schema_name: Schema whose history to prune (last analyzed schema if omitted)
+        dry_run: Report what would be deleted without deleting it (default True)
+    """
+    return await _h_workspace.cleanup_old_versions(
+        ctx,
+        schema_name,
+        dry_run,
+        services=_services(),
+    )
+
+
+@mcp.tool()
 async def save_semantic_model(
     ctx: Context,
     model_yaml: _DocBody,

--- a/tests/test_metadata_concurrency.py
+++ b/tests/test_metadata_concurrency.py
@@ -35,17 +35,6 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 SRC = PROJECT_ROOT / "src"
 METADATA_MODULE = SRC / "lifecycle" / "metadata.py"
 
-# DataCleanupManager is the unwired remnant of the Phase 3B per-version
-# retention design -- its entry points were removed as dead code once
-# AUTO_CLEANUP_ON_STARTUP shipped separately in server.py. Its API is
-# synchronous and nothing instantiates it, so it cannot take the asyncio lock
-# and cannot presently race anything. Exempted deliberately and narrowly rather
-# than async-ifying dead code on speculation -- but note the original design
-# called it from async paths, which is precisely where it would race. cleanup.py
-# carries the matching warning; reviving it means routing through
-# mutate_workspace_metadata first, and deleting this exemption.
-UNWIRED_SYNC_MODULES = {SRC / "lifecycle" / "cleanup.py"}
-
 # Methods that mutate and persist metadata.json.
 MUTATORS = {
     "_save_metadata",
@@ -53,6 +42,8 @@ MUTATORS = {
     "update_workspace_connection",
     "update_workspace_rdf_store",
     "mark_version_deleted",
+    "open_version",
+    "update_active_version",
 }
 
 CONNECTION_ID = "concurrency-test-conn"
@@ -215,7 +206,7 @@ def _mutating_calls_outside_metadata_module():
     offenders = []
 
     for path in sorted(SRC.rglob("*.py")):
-        if path == METADATA_MODULE or path in UNWIRED_SYNC_MODULES:
+        if path == METADATA_MODULE:
             continue
         tree = ast.parse(path.read_text(encoding="utf-8"))
 

--- a/tests/test_metadata_concurrency.py
+++ b/tests/test_metadata_concurrency.py
@@ -43,7 +43,7 @@ MUTATORS = {
     "update_workspace_rdf_store",
     "mark_version_deleted",
     "open_version",
-    "update_active_version",
+    "update_version",
 }
 
 CONNECTION_ID = "concurrency-test-conn"

--- a/tests/test_version_retention.py
+++ b/tests/test_version_retention.py
@@ -15,6 +15,7 @@ seams between them:
 import json
 from datetime import timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -553,6 +554,160 @@ async def test_a_shared_chromadb_collection_survives(tmp_path, monkeypatch):
         await manager.cleanup_graphrag(SCHEMA, dry_run=False)
 
     client.assert_not_called()
+
+
+async def test_a_collection_shared_with_another_schema_survives(tmp_path, monkeypatch):
+    """The ownership guard must span the connection, not one schema's history.
+
+    The ChromaDB collection is connection-scoped by design -- analytics's
+    vectors live in the same collection as public's. Scoping the guard to the
+    schema being cleaned deleted a store still backing every other schema.
+    """
+    monkeypatch.setenv("GRAPHRAG_KEEP_VERSIONS", "1")
+    monkeypatch.setenv("GRAPHRAG_MAX_AGE_DAYS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=4, age_days=100)
+    # Only the doomed version carries the collection, so public's own history
+    # holds no other reference -- a schema-scoped guard would clear it to go.
+    versions = mgr.metadata["schemas"][SCHEMA]["versions"]
+    versions[0]["graphrag_collection"] = "schema_public"
+
+    # analytics accumulated into that same collection and is still live.
+    mgr.open_version("analytics", "h", 1, 1)
+    mgr.update_version("analytics", {"graphrag_collection": "schema_public"})
+
+    # The store must exist, or the delete short-circuits before the guard even
+    # matters and the test passes for the wrong reason.
+    (tmp_path / "chromadb" / CONN).mkdir(parents=True)
+
+    with (
+        mock.patch("src.lifecycle.cleanup.OUTPUT_DIR", tmp_path),
+        mock.patch("chromadb.PersistentClient") as client,
+    ):
+        await DataCleanupManager(CONN, tmp_path).cleanup_graphrag(SCHEMA, dry_run=False)
+
+    client.assert_not_called()
+
+
+def _collection(name: str):
+    """A ChromaDB collection stub. Mock(name=...) sets the repr, not .name."""
+    return SimpleNamespace(name=name)
+
+
+async def _cleanup_graphrag_with_chromadb(tmp_path, mgr, client):
+    """Run GraphRAG cleanup with a stubbed ChromaDB client and a real store dir."""
+    versions = mgr.metadata["schemas"][SCHEMA]["versions"]
+    versions[0]["graphrag_collection"] = "schema_public"
+    mgr._save_metadata()
+    (tmp_path / "chromadb" / CONN).mkdir(parents=True, exist_ok=True)
+
+    with (
+        mock.patch("src.lifecycle.cleanup.OUTPUT_DIR", tmp_path),
+        mock.patch("chromadb.PersistentClient", return_value=client),
+    ):
+        return await DataCleanupManager(CONN, tmp_path).cleanup_graphrag(
+            SCHEMA, dry_run=False
+        )
+
+
+async def test_an_unreferenced_collection_is_deleted(tmp_path, monkeypatch):
+    monkeypatch.setenv("GRAPHRAG_KEEP_VERSIONS", "1")
+    monkeypatch.setenv("GRAPHRAG_MAX_AGE_DAYS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=4, age_days=100)
+
+    client = mock.Mock()
+    client.list_collections.return_value = [_collection("schema_public")]
+
+    report = await _cleanup_graphrag_with_chromadb(tmp_path, mgr, client)
+
+    client.delete_collection.assert_called_once_with("schema_public")
+    assert not report["errors"]
+
+
+async def test_an_already_absent_collection_is_not_an_error(tmp_path, monkeypatch):
+    """A rerun after a partial cleanup must converge, not fail forever."""
+    monkeypatch.setenv("GRAPHRAG_KEEP_VERSIONS", "1")
+    monkeypatch.setenv("GRAPHRAG_MAX_AGE_DAYS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=4, age_days=100)
+
+    client = mock.Mock()
+    client.list_collections.return_value = []  # already gone
+
+    report = await _cleanup_graphrag_with_chromadb(tmp_path, mgr, client)
+
+    client.delete_collection.assert_not_called()
+    assert not report["errors"]
+    assert report["deleted"], "absence is success -- the version still gets cleaned"
+
+
+async def test_a_failed_collection_delete_keeps_the_version(tmp_path, monkeypatch):
+    """Same contract as the named graph: report the failure, allow a retry."""
+    monkeypatch.setenv("GRAPHRAG_KEEP_VERSIONS", "1")
+    monkeypatch.setenv("GRAPHRAG_MAX_AGE_DAYS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=4, age_days=100)
+
+    client = mock.Mock()
+    client.list_collections.return_value = [_collection("schema_public")]
+    client.delete_collection.side_effect = RuntimeError("chromadb unavailable")
+
+    report = await _cleanup_graphrag_with_chromadb(tmp_path, mgr, client)
+
+    assert report["errors"]
+    reloaded = {v.version: v for v in _mgr(tmp_path).get_versions(SCHEMA)}
+    assert reloaded[1].graphrag_status != "deleted"
+
+
+async def test_a_graph_shared_with_another_schema_survives(tmp_path, monkeypatch):
+    """An explicit graph_uri can point two schemas at one named graph."""
+    monkeypatch.setenv("ONTOLOGY_KEEP_VERSIONS", "1")
+    monkeypatch.setenv("ONTOLOGY_MAX_AGE_DAYS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=4, age_days=100)
+    # Only the doomed version references it within public's own history.
+    versions = mgr.metadata["schemas"][SCHEMA]["versions"]
+    versions[0]["ontology_graph_uri"] = "urn:graph:shared"
+
+    mgr.open_version("analytics", "h", 1, 1)
+    mgr.update_version("analytics", {"ontology_graph_uri": "urn:graph:shared"})
+
+    store = mock.Mock()
+    await DataCleanupManager(CONN, tmp_path).cleanup_ontology(
+        SCHEMA, dry_run=False, oxigraph_store=store
+    )
+
+    store.delete_graph.assert_not_called()
+
+
+async def test_a_failed_graph_delete_keeps_the_version(tmp_path, monkeypatch):
+    """A transient store error must leave the version around to retry.
+
+    Swallowing the failure left the triples in Oxigraph while the version was
+    marked deleted -- destroying the only record of which graph to retry, so
+    the data was orphaned permanently.
+    """
+    monkeypatch.setenv("ONTOLOGY_KEEP_VERSIONS", "1")
+    monkeypatch.setenv("ONTOLOGY_MAX_AGE_DAYS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=4, age_days=100)
+    versions = mgr.metadata["schemas"][SCHEMA]["versions"]
+    versions[0]["ontology_graph_uri"] = "urn:graph:retired"
+    mgr._save_metadata()
+
+    store = mock.Mock()
+    store.delete_graph.side_effect = RuntimeError("oxigraph unavailable")
+
+    report = await DataCleanupManager(CONN, tmp_path).cleanup_ontology(
+        SCHEMA, dry_run=False, oxigraph_store=store
+    )
+
+    assert report["errors"], "the failure must be reported, not swallowed"
+    reloaded = {v.version: v for v in _mgr(tmp_path).get_versions(SCHEMA)}
+    assert (
+        reloaded[1].ontology_status != "deleted"
+    ), "a version whose graph survived must stay eligible for retry"
 
 
 async def test_cleanup_reports_the_versions_it_removed(tmp_path, monkeypatch):

--- a/tests/test_version_retention.py
+++ b/tests/test_version_retention.py
@@ -149,11 +149,11 @@ def test_first_version_has_no_delta(tmp_path):
     assert _mgr(tmp_path).open_version(SCHEMA, "h", 1, 1).changes is None
 
 
-def test_update_active_version_fills_the_ontology_half(tmp_path):
+def test_update_version_fills_the_ontology_half(tmp_path):
     mgr = _mgr(tmp_path)
     mgr.open_version(SCHEMA, "h", 2, 6)
 
-    updated = mgr.update_active_version(
+    updated = mgr.update_version(
         SCHEMA,
         {"ontology_ttl_file": "ontology_x.ttl", "ontology_triple_count": 412},
     )
@@ -163,17 +163,17 @@ def test_update_active_version_fills_the_ontology_half(tmp_path):
     assert mgr.get_current_version(SCHEMA).ontology_triple_count == 412
 
 
-def test_update_active_version_ignores_unknown_fields(tmp_path):
+def test_update_version_ignores_unknown_fields(tmp_path):
     mgr = _mgr(tmp_path)
     mgr.open_version(SCHEMA, "h", 2, 6)
-    assert mgr.update_active_version(SCHEMA, {"not_a_field": 1}) is None
+    assert mgr.update_version(SCHEMA, {"not_a_field": 1}) is None
 
 
-def test_update_active_version_cannot_rewrite_identity(tmp_path):
+def test_update_version_cannot_rewrite_identity(tmp_path):
     """version and created_at define the record; a producer must not move them."""
     mgr = _mgr(tmp_path)
     opened = mgr.open_version(SCHEMA, "h", 2, 6)
-    mgr.update_active_version(SCHEMA, {"version": 99, "created_at": "1999-01-01"})
+    mgr.update_version(SCHEMA, {"version": 99, "created_at": "1999-01-01"})
 
     current = mgr.get_current_version(SCHEMA)
     assert current.version == opened.version
@@ -181,16 +181,63 @@ def test_update_active_version_cannot_rewrite_identity(tmp_path):
 
 
 def test_update_without_an_open_version_is_a_no_op(tmp_path):
-    assert (
-        _mgr(tmp_path).update_active_version(SCHEMA, {"ontology_triple_count": 1})
-        is None
+    assert _mgr(tmp_path).update_version(SCHEMA, {"ontology_triple_count": 1}) is None
+
+
+def test_update_targets_a_specific_version(tmp_path):
+    """A producer must be able to write to the generation it was started for."""
+    mgr = _mgr(tmp_path)
+    mgr.open_version(SCHEMA, "h1", 1, 1)
+    mgr.open_version(SCHEMA, "h2", 2, 2)  # v1 is now archived
+
+    updated = mgr.update_version(SCHEMA, {"ontology_triple_count": 99}, version=1)
+
+    by_number = {v.version: v for v in mgr.get_versions(SCHEMA)}
+    assert updated.version == 1
+    assert by_number[1].ontology_triple_count == 99
+    assert by_number[2].ontology_triple_count == 0, "the newer version is untouched"
+
+
+def test_update_of_an_unknown_version_is_a_no_op(tmp_path):
+    mgr = _mgr(tmp_path)
+    mgr.open_version(SCHEMA, "h", 1, 1)
+    assert mgr.update_version(SCHEMA, {"ontology_triple_count": 5}, version=42) is None
+
+
+async def test_a_slow_producer_cannot_capture_a_newer_version(tmp_path):
+    """The seam the race lived in: resolve the version early, write to it late.
+
+    GraphRAG init and AUTO_ONTOLOGY generation run in the background and can
+    still be going when a second discover_schema for the same schema opens a
+    newer version. Resolving "the active version" at completion time stamped
+    the first run's snapshots, TTL file and triple counts onto a generation
+    they had nothing to do with.
+    """
+    started_for = await open_schema_version(CONN, tmp_path, SCHEMA, _tables(2))
+
+    # A rediscovery lands while the slow producer is still working.
+    await open_schema_version(CONN, tmp_path, SCHEMA, _tables(5))
+
+    await update_schema_version(
+        CONN,
+        tmp_path,
+        SCHEMA,
+        {"graphrag_vector_count": 500, "ontology_triple_count": 900},
+        version=started_for,
     )
+
+    by_number = {v.version: v for v in _mgr(tmp_path).get_versions(SCHEMA)}
+    assert by_number[1].graphrag_vector_count == 500
+    assert (
+        by_number[2].graphrag_vector_count == 0
+    ), "the newer generation must not inherit the older run's output"
+    assert by_number[2].ontology_triple_count == 0
 
 
 def test_versions_survive_a_reload(tmp_path):
     mgr = _mgr(tmp_path)
     mgr.open_version(SCHEMA, "h", 2, 6)
-    mgr.update_active_version(SCHEMA, {"graphrag_vector_count": 77})
+    mgr.update_version(SCHEMA, {"graphrag_vector_count": 77})
 
     assert _mgr(tmp_path).get_current_version(SCHEMA).graphrag_vector_count == 77
 
@@ -317,7 +364,7 @@ def _history(mgr: VersionMetadataManager, count: int, age_days: int) -> None:
     """Record *count* versions, all archived and aged, plus a live one on top."""
     for i in range(count):
         mgr.open_version(SCHEMA, f"h{i}", 1, 1)
-        mgr.update_active_version(
+        mgr.update_version(
             SCHEMA,
             {
                 "ontology_ttl_file": f"ontology_v{i + 1}.ttl",

--- a/tests/test_version_retention.py
+++ b/tests/test_version_retention.py
@@ -583,40 +583,70 @@ async def test_active_version_of_an_unknown_schema_is_none(tmp_path):
 # --- versioned GraphRAG snapshots -------------------------------------------
 
 
-def test_save_state_without_a_version_writes_no_snapshots(tmp_path):
+def _fake_manager(schemas: list[str], payload: str = "{}"):
+    """A GraphRAGManager with just enough wired up to exercise save_state."""
     from src.graphrag.manager import GraphRAGManager
 
     manager = GraphRAGManager.__new__(GraphRAGManager)
     manager._connection_id = CONN
-    manager._schema_names = []
-    manager.graph_retriever = mock.Mock()
-    manager.graph_retriever._tables_info = {}
-    manager.graph_retriever.export_graph_for_visualization.return_value = {}
-    manager.community_detector = None
-
-    assert manager.save_state(tmp_path) == []
-
-
-def test_save_state_snapshots_each_per_schema_file(tmp_path):
-    from src.graphrag.manager import GraphRAGManager
-
-    manager = GraphRAGManager.__new__(GraphRAGManager)
-    manager._connection_id = CONN
-    manager._schema_names = [SCHEMA]
+    manager._schema_names = schemas
     manager.graph_retriever = mock.Mock()
     manager.graph_retriever._tables_info = {}
     manager.graph_retriever.export_graph_for_visualization.return_value = {}
     manager.community_detector = None
     manager.vector_store = mock.Mock()
-    manager.vector_store.save.side_effect = lambda p: Path(p).write_text("{}")
+    manager.vector_store.save.side_effect = lambda p: Path(p).write_text(payload)
+    return manager
 
-    written = manager.save_state(tmp_path, version=3)
+
+def test_save_state_without_a_version_writes_no_snapshots(tmp_path):
+    assert _fake_manager([]).save_state(tmp_path) == []
+
+
+def test_save_state_snapshots_each_per_schema_file(tmp_path):
+    manager = _fake_manager([SCHEMA])
+
+    written = manager.save_state(tmp_path, version=3, snapshot_schema=SCHEMA)
 
     assert f"vector_store_{SCHEMA}_v3.json" in written
     assert f"graph_{SCHEMA}_v3.json" in written
     assert (
         tmp_path / CONN / f"vector_store_{SCHEMA}.json"
     ).exists(), "the unversioned current-state file must still be written"
+
+
+def test_snapshot_is_confined_to_the_schema_being_recorded(tmp_path):
+    """One schema's version number must not snapshot every accumulated schema.
+
+    GraphRAG is connection-scoped, so this manager holds every schema on the
+    connection, but version numbers are per schema. Snapshotting all of them
+    under the version being recorded overwrote public's v1 when analytics v1
+    was saved, and handed public's snapshot to analytics's version record --
+    so cleaning up analytics v1 would have deleted public's history.
+    """
+    manager = _fake_manager(["public", "analytics"], payload='{"state": "first"}')
+    manager.save_state(tmp_path, version=1, snapshot_schema="public")
+    public_v1 = tmp_path / CONN / "vector_store_public_v1.json"
+    original = public_v1.read_text(encoding="utf-8")
+
+    # analytics is discovered next and accumulates; its own v1 is recorded.
+    manager.vector_store.save.side_effect = lambda p: Path(p).write_text(
+        '{"state": "after-analytics"}'
+    )
+    written = manager.save_state(tmp_path, version=1, snapshot_schema="analytics")
+
+    assert (
+        public_v1.read_text(encoding="utf-8") == original
+    ), "another schema's save must not rewrite public's snapshot"
+    assert not any(
+        "public" in name for name in written
+    ), "analytics's version must not claim ownership of public's files"
+    assert (tmp_path / CONN / "vector_store_analytics_v1.json").exists()
+
+
+def test_no_snapshot_without_a_named_schema(tmp_path):
+    """A version number alone is ambiguous on a multi-schema connection."""
+    assert _fake_manager(["public", "analytics"]).save_state(tmp_path, version=1) == []
 
 
 # --- end to end through the handler -----------------------------------------
@@ -685,6 +715,114 @@ async def test_discover_schema_records_a_version(tmp_path, monkeypatch):
     assert recorded.table_count == 2
     assert recorded.column_count == 2
     assert recorded.schema_hash
+
+
+async def test_auto_generated_ontology_reaches_the_version(tmp_path, monkeypatch):
+    """AUTO_ONTOLOGY=true must fill in the version discovery opened.
+
+    This background path wrote no persisted metadata at all, so an
+    auto-generated ontology left the version with no TTL file, no graph URI and
+    a zero triple count -- and retention could never clean up the graph it had
+    loaded into Oxigraph.
+    """
+    import types
+    from unittest.mock import Mock, patch
+
+    from src.database_manager import ColumnInfo, TableInfo
+    from src.handlers import graphrag as graphrag_handler
+
+    await open_schema_version(CONN, tmp_path, SCHEMA, _tables(1))
+
+    tables = [
+        TableInfo(
+            name="customers",
+            schema=SCHEMA,
+            columns=[
+                ColumnInfo(
+                    name="id",
+                    data_type="INTEGER",
+                    is_nullable=False,
+                    is_primary_key=True,
+                    is_foreign_key=False,
+                )
+            ],
+            primary_keys=["id"],
+            foreign_keys=[],
+            row_count=1,
+        )
+    ]
+
+    store = Mock()
+    store.load_ontology.return_value = 314
+
+    session = Mock()
+    session.connection_id = CONN
+    session.oxigraph_store = store
+    session.get_or_create_schema_state.return_value = types.SimpleNamespace(
+        ontology=types.SimpleNamespace(ontology_file=None)
+    )
+
+    conn_dir = tmp_path / CONN
+    conn_dir.mkdir(parents=True, exist_ok=True)
+    with (
+        patch("src.handlers.graphrag.OUTPUT_DIR", tmp_path),
+        patch("src.handlers.graphrag.get_connection_dir", return_value=conn_dir),
+        patch("src.handlers.graphrag.OXIGRAPH_AVAILABLE", True),
+    ):
+        await graphrag_handler._auto_generate_ontology_background(
+            schema_name=SCHEMA, tables_info=tables, session=session, ctx=None
+        )
+
+    recorded = _mgr(tmp_path).get_current_version(SCHEMA)
+    assert recorded.ontology_ttl_file.endswith(".ttl")
+    assert recorded.ontology_triple_count == 314
+    assert recorded.ontology_graph_uri
+
+
+async def test_manual_rdf_store_records_the_graph(tmp_path, monkeypatch):
+    """store_ontology_in_rdf is the documented auto_persist=False follow-up.
+
+    Without recording here the version never learns which graph was loaded, so
+    retention cannot delete that graph when the version ages out.
+    """
+    from unittest.mock import AsyncMock, Mock, patch
+
+    from src.handlers import rdf as rdf_handler
+
+    await open_schema_version(CONN, tmp_path, SCHEMA, _tables(1))
+
+    conn_dir = tmp_path / CONN
+    conn_dir.mkdir(parents=True, exist_ok=True)
+    (conn_dir / "ontology_public.ttl").write_text("@prefix x: <urn:x> .")
+
+    store = Mock()
+    store.load_ontology.return_value = 271
+
+    ctx = Mock()
+    ctx.info = AsyncMock()
+
+    session = Mock()
+    session.connection_id = CONN
+    session.ontology_file = "ontology_public.ttl"
+    session.get_last_analyzed_schema.return_value = SCHEMA
+
+    services = Mock()
+    services.get_session_data.return_value = session
+    services.get_oxigraph_store.return_value = store
+
+    with (
+        patch("src.handlers.rdf.OUTPUT_DIR", tmp_path),
+        patch("src.handlers.rdf.get_connection_dir", return_value=conn_dir),
+        patch("src.handlers.rdf.OXIGRAPH_AVAILABLE", True),
+    ):
+        await rdf_handler.store_ontology_in_rdf(
+            ctx, schema_name=SCHEMA, graph_uri=None, services=services
+        )
+
+    recorded = _mgr(tmp_path).get_current_version(SCHEMA)
+    assert recorded.ontology_triple_count == 271
+    assert recorded.ontology_graph_uri, "the loaded graph URI must be recorded"
+    assert recorded.ontology_ttl_file == "ontology_public.ttl"
 
 
 async def test_a_second_discovery_archives_the_first(tmp_path, monkeypatch):

--- a/tests/test_version_retention.py
+++ b/tests/test_version_retention.py
@@ -1,0 +1,719 @@
+"""Per-version retention: recording, policy, and cleanup.
+
+The cleanup half of this design shipped long before the recording half, which
+meant ``get_versions_to_cleanup`` returned ``[]`` unconditionally and the whole
+mechanism provably did nothing (issue #68). These tests pin both halves and the
+seams between them:
+
+  * ``discover_schema`` opens a version; ontology and GraphRAG fill it in
+  * opening a version archives its predecessor, so only the newest is active
+  * retention deletes archived versions only, honouring env-driven policy
+  * shared resources -- named graphs, ChromaDB collections -- survive cleanup of
+    a version while another version still references them
+"""
+
+import json
+from datetime import timedelta
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from src.lifecycle.cleanup import DataCleanupManager
+from src.lifecycle.metadata import (
+    RetentionPolicy,
+    VersionInfo,
+    VersionMetadataManager,
+    get_active_version_number,
+    open_schema_version,
+    schema_fingerprint,
+    update_schema_version,
+)
+from src.utils import utc_now
+
+CONN = "retention-test-conn"
+SCHEMA = "public"
+
+
+class _Column:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _Table:
+    """Minimal stand-in for the driver's TableInfo (duck-typed by fingerprint)."""
+
+    def __init__(self, name: str, columns: list[str], schema: str = SCHEMA) -> None:
+        self.name = name
+        self.schema = schema
+        self.columns = [_Column(c) for c in columns]
+
+
+def _tables(n: int = 2, columns: int = 3) -> list[_Table]:
+    return [_Table(f"t{i}", [f"c{j}" for j in range(columns)]) for i in range(n)]
+
+
+def _mgr(tmp_path: Path) -> VersionMetadataManager:
+    return VersionMetadataManager(CONN, tmp_path)
+
+
+def _age(mgr: VersionMetadataManager, schema: str, version: int, days: int) -> None:
+    """Backdate a recorded version so age-based retention can select it."""
+    stamp = (utc_now() - timedelta(days=days)).isoformat()
+    for entry in mgr.metadata["schemas"][schema]["versions"]:
+        if entry["version"] == version:
+            entry["created_at"] = stamp
+    mgr._save_metadata()
+
+
+# --- fingerprinting ---------------------------------------------------------
+
+
+def test_fingerprint_counts_tables_and_columns():
+    digest, tables, columns = schema_fingerprint(_tables(3, 4))
+    assert tables == 3
+    assert columns == 12
+    assert digest
+
+
+def test_fingerprint_is_order_independent():
+    tables = _tables(3)
+    forward, _, _ = schema_fingerprint(tables)
+    backward, _, _ = schema_fingerprint(list(reversed(tables)))
+    assert forward == backward, "hash must not depend on driver ordering"
+
+
+def test_fingerprint_changes_when_structure_changes():
+    before, _, _ = schema_fingerprint([_Table("t", ["a", "b"])])
+    after, _, _ = schema_fingerprint([_Table("t", ["a", "b", "c"])])
+    assert before != after
+
+
+def test_fingerprint_of_nothing_is_stable():
+    digest, tables, columns = schema_fingerprint([])
+    assert (tables, columns) == (0, 0)
+    assert digest == schema_fingerprint([])[0]
+
+
+# --- recording --------------------------------------------------------------
+
+
+def test_open_version_numbers_from_one(tmp_path):
+    mgr = _mgr(tmp_path)
+    first = mgr.open_version(SCHEMA, "hash-a", 2, 6)
+    second = mgr.open_version(SCHEMA, "hash-b", 3, 9)
+    assert (first.version, second.version) == (1, 2)
+
+
+def test_opening_a_version_archives_the_previous(tmp_path):
+    mgr = _mgr(tmp_path)
+    mgr.open_version(SCHEMA, "hash-a", 2, 6)
+    mgr.open_version(SCHEMA, "hash-b", 3, 9)
+
+    versions = mgr.get_versions(SCHEMA)
+    assert [v.status for v in versions] == ["archived", "active"]
+    assert [v.graphrag_status for v in versions] == ["archived", "active"]
+    assert [v.ontology_status for v in versions] == ["archived", "active"]
+
+
+def test_only_one_version_is_ever_active(tmp_path):
+    mgr = _mgr(tmp_path)
+    for i in range(5):
+        mgr.open_version(SCHEMA, f"hash-{i}", i, i)
+    active = [v for v in mgr.get_versions(SCHEMA) if v.status == "active"]
+    assert len(active) == 1
+    assert active[0].version == 5
+
+
+def test_second_version_records_the_delta(tmp_path):
+    mgr = _mgr(tmp_path)
+    mgr.open_version(SCHEMA, "hash-a", 2, 6)
+    second = mgr.open_version(SCHEMA, "hash-b", 5, 20)
+
+    assert second.changes == {
+        "previous_version": 1,
+        "table_count_delta": 3,
+        "schema_changed": True,
+    }
+
+
+def test_unchanged_structure_is_reported_as_unchanged(tmp_path):
+    mgr = _mgr(tmp_path)
+    mgr.open_version(SCHEMA, "same", 2, 6)
+    second = mgr.open_version(SCHEMA, "same", 2, 6)
+    assert second.changes["schema_changed"] is False
+    assert second.changes["table_count_delta"] == 0
+
+
+def test_first_version_has_no_delta(tmp_path):
+    assert _mgr(tmp_path).open_version(SCHEMA, "h", 1, 1).changes is None
+
+
+def test_update_active_version_fills_the_ontology_half(tmp_path):
+    mgr = _mgr(tmp_path)
+    mgr.open_version(SCHEMA, "h", 2, 6)
+
+    updated = mgr.update_active_version(
+        SCHEMA,
+        {"ontology_ttl_file": "ontology_x.ttl", "ontology_triple_count": 412},
+    )
+
+    assert updated.ontology_ttl_file == "ontology_x.ttl"
+    assert updated.ontology_triple_count == 412
+    assert mgr.get_current_version(SCHEMA).ontology_triple_count == 412
+
+
+def test_update_active_version_ignores_unknown_fields(tmp_path):
+    mgr = _mgr(tmp_path)
+    mgr.open_version(SCHEMA, "h", 2, 6)
+    assert mgr.update_active_version(SCHEMA, {"not_a_field": 1}) is None
+
+
+def test_update_active_version_cannot_rewrite_identity(tmp_path):
+    """version and created_at define the record; a producer must not move them."""
+    mgr = _mgr(tmp_path)
+    opened = mgr.open_version(SCHEMA, "h", 2, 6)
+    mgr.update_active_version(SCHEMA, {"version": 99, "created_at": "1999-01-01"})
+
+    current = mgr.get_current_version(SCHEMA)
+    assert current.version == opened.version
+    assert current.created_at == opened.created_at
+
+
+def test_update_without_an_open_version_is_a_no_op(tmp_path):
+    assert (
+        _mgr(tmp_path).update_active_version(SCHEMA, {"ontology_triple_count": 1})
+        is None
+    )
+
+
+def test_versions_survive_a_reload(tmp_path):
+    mgr = _mgr(tmp_path)
+    mgr.open_version(SCHEMA, "h", 2, 6)
+    mgr.update_active_version(SCHEMA, {"graphrag_vector_count": 77})
+
+    assert _mgr(tmp_path).get_current_version(SCHEMA).graphrag_vector_count == 77
+
+
+def test_schemas_have_independent_histories(tmp_path):
+    mgr = _mgr(tmp_path)
+    mgr.open_version("sales", "h", 1, 1)
+    mgr.open_version("sales", "h", 1, 1)
+    mgr.open_version("hr", "h", 1, 1)
+
+    assert [v.version for v in mgr.get_versions("sales")] == [1, 2]
+    assert [v.version for v in mgr.get_versions("hr")] == [1]
+
+
+# --- migration of pre-feature workspaces ------------------------------------
+
+
+def test_legacy_workspace_is_seeded_as_version_one(tmp_path):
+    """A workspace written before recording existed keeps its current artifacts."""
+    mgr = _mgr(tmp_path)
+    mgr.update_workspace(
+        SCHEMA, "schema", {"table_count": 9, "analyzed_at": "2026-01-01"}
+    )
+    mgr.update_workspace(
+        SCHEMA, "ontology", {"ontology_file": "old.ttl", "graph_uri": "urn:g"}
+    )
+
+    opened = mgr.open_version(SCHEMA, "new-hash", 10, 40)
+
+    versions = mgr.get_versions(SCHEMA)
+    assert opened.version == 2, "the pre-existing generation must occupy version 1"
+    assert versions[0].ontology_ttl_file == "old.ttl"
+    assert versions[0].table_count == 9
+    assert versions[0].status == "archived"
+
+
+def test_empty_workspace_is_not_migrated(tmp_path):
+    mgr = _mgr(tmp_path)
+    mgr.update_workspace_connection("postgresql", "db")
+    assert mgr.open_version(SCHEMA, "h", 1, 1).version == 1
+
+
+def test_migration_runs_only_once(tmp_path):
+    mgr = _mgr(tmp_path)
+    mgr.update_workspace(SCHEMA, "ontology", {"ontology_file": "old.ttl"})
+    mgr.open_version(SCHEMA, "h", 1, 1)
+    mgr.open_version(SCHEMA, "h", 1, 1)
+
+    migrated = [
+        v
+        for v in mgr.get_versions(SCHEMA)
+        if (v.changes or {}).get("migrated_from_workspace")
+    ]
+    assert len(migrated) == 1
+
+
+# --- tolerating metadata written by other releases --------------------------
+
+
+def test_version_from_a_newer_release_loads(tmp_path):
+    """An unknown field must not make the workspace unreadable."""
+    mgr = _mgr(tmp_path)
+    mgr.open_version(SCHEMA, "h", 1, 1)
+    mgr.metadata["schemas"][SCHEMA]["versions"][0]["field_from_the_future"] = True
+    mgr._save_metadata()
+
+    assert _mgr(tmp_path).get_current_version(SCHEMA).version == 1
+
+
+def test_version_from_an_older_release_loads(tmp_path):
+    """Fields added after the workspace was written fall back to defaults."""
+    mgr = _mgr(tmp_path)
+    mgr.open_version(SCHEMA, "h", 1, 1)
+    entry = mgr.metadata["schemas"][SCHEMA]["versions"][0]
+    del entry["graphrag_collection"]
+    del entry["graphrag_files"]
+    mgr._save_metadata()
+
+    restored = _mgr(tmp_path).get_current_version(SCHEMA)
+    assert restored.graphrag_collection == ""
+    assert restored.graphrag_files == []
+
+
+# --- retention policy -------------------------------------------------------
+
+
+def test_policy_defaults_when_environment_is_clean(monkeypatch):
+    for name in (
+        "GRAPHRAG_KEEP_VERSIONS",
+        "GRAPHRAG_MAX_AGE_DAYS",
+        "ONTOLOGY_KEEP_VERSIONS",
+        "ONTOLOGY_MAX_AGE_DAYS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    assert RetentionPolicy.from_metadata(None) == RetentionPolicy()
+
+
+def test_environment_overrides_the_stored_policy(monkeypatch):
+    """An operator changing retention must affect workspaces already on disk."""
+    monkeypatch.setenv("GRAPHRAG_KEEP_VERSIONS", "7")
+    stored = {"graphrag_keep_versions": 3, "ontology_keep_versions": 5}
+
+    policy = RetentionPolicy.from_metadata(stored)
+
+    assert policy.graphrag_keep_versions == 7
+    assert policy.ontology_keep_versions == 5, "untouched fields keep the stored value"
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "abc", ""])
+def test_invalid_policy_values_fall_back(monkeypatch, value):
+    monkeypatch.setenv("ONTOLOGY_MAX_AGE_DAYS", value)
+    assert RetentionPolicy.from_metadata(None).ontology_max_age_days == 60
+
+
+def test_stored_policy_tolerates_removed_fields():
+    policy = RetentionPolicy.from_metadata({"a_field_we_dropped": 1})
+    assert policy == RetentionPolicy()
+
+
+# --- selecting versions for cleanup -----------------------------------------
+
+
+def _history(mgr: VersionMetadataManager, count: int, age_days: int) -> None:
+    """Record *count* versions, all archived and aged, plus a live one on top."""
+    for i in range(count):
+        mgr.open_version(SCHEMA, f"h{i}", 1, 1)
+        mgr.update_active_version(
+            SCHEMA,
+            {
+                "ontology_ttl_file": f"ontology_v{i + 1}.ttl",
+                "graphrag_files": [f"vector_store_{SCHEMA}_v{i + 1}.json"],
+            },
+        )
+    mgr.open_version(SCHEMA, "live", 1, 1)  # archives all of the above
+    for version in range(1, count + 1):
+        _age(mgr, SCHEMA, version, age_days)
+
+
+def test_the_active_version_is_never_a_candidate(tmp_path, monkeypatch):
+    monkeypatch.setenv("ONTOLOGY_KEEP_VERSIONS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=6, age_days=999)
+
+    doomed = {v.version for v in mgr.get_versions_to_cleanup(SCHEMA, "ontology")}
+    active = mgr.get_current_version(SCHEMA).version
+    assert active not in doomed
+
+
+def test_recent_versions_are_kept_however_many_there_are(tmp_path):
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=8, age_days=0)
+    assert mgr.get_versions_to_cleanup(SCHEMA, "ontology") == []
+
+
+def test_old_versions_beyond_the_keep_count_are_selected(tmp_path, monkeypatch):
+    monkeypatch.setenv("ONTOLOGY_KEEP_VERSIONS", "2")
+    monkeypatch.setenv("ONTOLOGY_MAX_AGE_DAYS", "30")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=6, age_days=100)
+
+    doomed = sorted(v.version for v in mgr.get_versions_to_cleanup(SCHEMA, "ontology"))
+    # 6 archived; the newest 2 are kept by count, leaving 1-4 old enough to go.
+    assert doomed == [1, 2, 3, 4]
+
+
+def test_a_short_history_is_left_alone(tmp_path):
+    """min_versions is a floor even when everything else says delete."""
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=1, age_days=9999)
+    assert mgr.get_versions_to_cleanup(SCHEMA, "ontology") == []
+
+
+def test_min_versions_spares_the_newest_candidates(tmp_path, monkeypatch):
+    """When the floor bites, the versions worth rolling back to must survive.
+
+    Reachable only because keep_count is operator-settable: with keep_count >=
+    min_versions the floor never binds. Here 3 archived versions, keep 1, floor
+    2 -- so exactly one of the two candidates may go, and it must be the older.
+    Trimming the candidate list from the wrong end would delete v2 and keep the
+    staler v1.
+    """
+    monkeypatch.setenv("ONTOLOGY_KEEP_VERSIONS", "1")
+    monkeypatch.setenv("ONTOLOGY_MAX_AGE_DAYS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=3, age_days=500)
+
+    doomed = {v.version for v in mgr.get_versions_to_cleanup(SCHEMA, "ontology")}
+    assert doomed == {1}, "the oldest candidate must be the one discarded"
+
+
+def test_all_requires_both_halves_to_agree(tmp_path, monkeypatch):
+    monkeypatch.setenv("ONTOLOGY_KEEP_VERSIONS", "2")
+    monkeypatch.setenv("GRAPHRAG_KEEP_VERSIONS", "5")
+    monkeypatch.setenv("ONTOLOGY_MAX_AGE_DAYS", "1")
+    monkeypatch.setenv("GRAPHRAG_MAX_AGE_DAYS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=6, age_days=100)
+
+    ontology = {v.version for v in mgr.get_versions_to_cleanup(SCHEMA, "ontology")}
+    both = {v.version for v in mgr.get_versions_to_cleanup(SCHEMA, "all")}
+
+    assert both < ontology, "the stricter GraphRAG policy must constrain 'all'"
+
+
+def test_a_schema_with_no_history_yields_nothing(tmp_path):
+    assert _mgr(tmp_path).get_versions_to_cleanup("never-seen", "all") == []
+
+
+# --- cleanup ----------------------------------------------------------------
+
+
+async def test_dry_run_reports_without_deleting(tmp_path, monkeypatch):
+    monkeypatch.setenv("ONTOLOGY_KEEP_VERSIONS", "1")
+    monkeypatch.setenv("ONTOLOGY_MAX_AGE_DAYS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=4, age_days=100)
+
+    ttl = tmp_path / CONN / "ontology_v1.ttl"
+    ttl.write_text("@prefix x: <urn:x> .", encoding="utf-8")
+
+    report = await DataCleanupManager(CONN, tmp_path).cleanup_ontology(
+        SCHEMA, dry_run=True
+    )
+
+    assert report["deleted"], "dry run must still report what it would remove"
+    assert ttl.exists(), "dry run must not delete anything"
+    assert _mgr(tmp_path).get_versions(SCHEMA)[0].ontology_status != "deleted"
+
+
+async def test_cleanup_deletes_ttl_files_and_marks_the_version(tmp_path, monkeypatch):
+    monkeypatch.setenv("ONTOLOGY_KEEP_VERSIONS", "1")
+    monkeypatch.setenv("ONTOLOGY_MAX_AGE_DAYS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=4, age_days=100)
+
+    ttl = tmp_path / CONN / "ontology_v1.ttl"
+    ttl.write_text("@prefix x: <urn:x> .", encoding="utf-8")
+
+    await DataCleanupManager(CONN, tmp_path).cleanup_ontology(SCHEMA, dry_run=False)
+
+    assert not ttl.exists()
+    reloaded = {v.version: v for v in _mgr(tmp_path).get_versions(SCHEMA)}
+    assert reloaded[1].ontology_status == "deleted"
+    assert reloaded[4].ontology_status == "archived", "survivors keep their status"
+
+
+async def test_cleanup_deletes_versioned_graphrag_snapshots(tmp_path, monkeypatch):
+    monkeypatch.setenv("GRAPHRAG_KEEP_VERSIONS", "1")
+    monkeypatch.setenv("GRAPHRAG_MAX_AGE_DAYS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=4, age_days=100)
+
+    snapshot = tmp_path / CONN / f"vector_store_{SCHEMA}_v1.json"
+    snapshot.write_text("{}", encoding="utf-8")
+    current = tmp_path / CONN / f"vector_store_{SCHEMA}.json"
+    current.write_text("{}", encoding="utf-8")
+
+    await DataCleanupManager(CONN, tmp_path).cleanup_graphrag(SCHEMA, dry_run=False)
+
+    assert not snapshot.exists()
+    assert current.exists(), "the unversioned current-state file must survive"
+
+
+async def test_a_shared_named_graph_survives(tmp_path, monkeypatch):
+    """Generations reuse one graph URI; deleting an old version must not drop it."""
+    monkeypatch.setenv("ONTOLOGY_KEEP_VERSIONS", "1")
+    monkeypatch.setenv("ONTOLOGY_MAX_AGE_DAYS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=4, age_days=100)
+    for entry in mgr.metadata["schemas"][SCHEMA]["versions"]:
+        entry["ontology_graph_uri"] = "urn:graph:public"
+    mgr._save_metadata()
+
+    store = mock.Mock()
+    await DataCleanupManager(CONN, tmp_path).cleanup_ontology(
+        SCHEMA, dry_run=False, oxigraph_store=store
+    )
+
+    store.delete_graph.assert_not_called()
+
+
+async def test_an_orphaned_named_graph_is_deleted(tmp_path, monkeypatch):
+    monkeypatch.setenv("ONTOLOGY_KEEP_VERSIONS", "1")
+    monkeypatch.setenv("ONTOLOGY_MAX_AGE_DAYS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=4, age_days=100)
+    versions = mgr.metadata["schemas"][SCHEMA]["versions"]
+    versions[0]["ontology_graph_uri"] = "urn:graph:retired"
+    for entry in versions[1:]:
+        entry["ontology_graph_uri"] = "urn:graph:current"
+    mgr._save_metadata()
+
+    store = mock.Mock()
+    await DataCleanupManager(CONN, tmp_path).cleanup_ontology(
+        SCHEMA, dry_run=False, oxigraph_store=store
+    )
+
+    store.delete_graph.assert_called_once_with("urn:graph:retired")
+
+
+async def test_a_shared_chromadb_collection_survives(tmp_path, monkeypatch):
+    """One collection backs every schema and generation -- see the guard's docstring."""
+    monkeypatch.setenv("GRAPHRAG_KEEP_VERSIONS", "1")
+    monkeypatch.setenv("GRAPHRAG_MAX_AGE_DAYS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=4, age_days=100)
+    for entry in mgr.metadata["schemas"][SCHEMA]["versions"]:
+        entry["graphrag_collection"] = "schema_public"
+    mgr._save_metadata()
+
+    manager = DataCleanupManager(CONN, tmp_path)
+    with mock.patch("chromadb.PersistentClient") as client:
+        await manager.cleanup_graphrag(SCHEMA, dry_run=False)
+
+    client.assert_not_called()
+
+
+async def test_cleanup_reports_the_versions_it_removed(tmp_path, monkeypatch):
+    monkeypatch.setenv("ONTOLOGY_KEEP_VERSIONS", "1")
+    monkeypatch.setenv("ONTOLOGY_MAX_AGE_DAYS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=4, age_days=100)
+
+    report = await DataCleanupManager(CONN, tmp_path).cleanup_ontology(
+        SCHEMA, dry_run=False
+    )
+
+    assert report["dry_run"] is False
+    assert not report["errors"]
+    assert all(entry["age_days"] >= 100 for entry in report["deleted"])
+
+
+async def test_nothing_to_do_is_reported_as_such(tmp_path):
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=2, age_days=0)
+
+    report = await DataCleanupManager(CONN, tmp_path).cleanup_graphrag(SCHEMA)
+
+    assert report["kept_all"] is True
+    assert report["deleted"] == []
+
+
+async def test_metadata_stays_parseable_after_cleanup(tmp_path, monkeypatch):
+    monkeypatch.setenv("ONTOLOGY_KEEP_VERSIONS", "1")
+    monkeypatch.setenv("ONTOLOGY_MAX_AGE_DAYS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=5, age_days=100)
+
+    await DataCleanupManager(CONN, tmp_path).cleanup_ontology(SCHEMA, dry_run=False)
+
+    raw = (tmp_path / CONN / "metadata.json").read_text(encoding="utf-8")
+    assert json.loads(raw)["schemas"][SCHEMA]["versions"]
+
+
+async def test_cleanup_preserves_other_workspace_sections(tmp_path, monkeypatch):
+    """Cleanup writes metadata.json; it must not drop what other writers put there."""
+    monkeypatch.setenv("ONTOLOGY_KEEP_VERSIONS", "1")
+    monkeypatch.setenv("ONTOLOGY_MAX_AGE_DAYS", "1")
+    mgr = _mgr(tmp_path)
+    _history(mgr, count=4, age_days=100)
+    mgr.update_workspace_connection("postgresql", "analytics")
+
+    await DataCleanupManager(CONN, tmp_path).cleanup_ontology(SCHEMA, dry_run=False)
+
+    workspace = _mgr(tmp_path).get_workspace()
+    assert workspace["db_name"] == "analytics"
+
+
+# --- the locked async helpers -----------------------------------------------
+
+
+async def test_open_and_update_round_trip_through_the_lock(tmp_path):
+    version = await open_schema_version(CONN, tmp_path, SCHEMA, _tables(4, 2))
+    assert version == 1
+
+    assert await get_active_version_number(CONN, tmp_path, SCHEMA) == 1
+
+    await update_schema_version(CONN, tmp_path, SCHEMA, {"graphrag_vector_count": 120})
+
+    current = _mgr(tmp_path).get_current_version(SCHEMA)
+    assert current.table_count == 4
+    assert current.column_count == 8
+    assert current.graphrag_vector_count == 120
+
+
+async def test_active_version_of_an_unknown_schema_is_none(tmp_path):
+    assert await get_active_version_number(CONN, tmp_path, "nope") is None
+
+
+# --- versioned GraphRAG snapshots -------------------------------------------
+
+
+def test_save_state_without_a_version_writes_no_snapshots(tmp_path):
+    from src.graphrag.manager import GraphRAGManager
+
+    manager = GraphRAGManager.__new__(GraphRAGManager)
+    manager._connection_id = CONN
+    manager._schema_names = []
+    manager.graph_retriever = mock.Mock()
+    manager.graph_retriever._tables_info = {}
+    manager.graph_retriever.export_graph_for_visualization.return_value = {}
+    manager.community_detector = None
+
+    assert manager.save_state(tmp_path) == []
+
+
+def test_save_state_snapshots_each_per_schema_file(tmp_path):
+    from src.graphrag.manager import GraphRAGManager
+
+    manager = GraphRAGManager.__new__(GraphRAGManager)
+    manager._connection_id = CONN
+    manager._schema_names = [SCHEMA]
+    manager.graph_retriever = mock.Mock()
+    manager.graph_retriever._tables_info = {}
+    manager.graph_retriever.export_graph_for_visualization.return_value = {}
+    manager.community_detector = None
+    manager.vector_store = mock.Mock()
+    manager.vector_store.save.side_effect = lambda p: Path(p).write_text("{}")
+
+    written = manager.save_state(tmp_path, version=3)
+
+    assert f"vector_store_{SCHEMA}_v3.json" in written
+    assert f"graph_{SCHEMA}_v3.json" in written
+    assert (
+        tmp_path / CONN / f"vector_store_{SCHEMA}.json"
+    ).exists(), "the unversioned current-state file must still be written"
+
+
+# --- end to end through the handler -----------------------------------------
+
+
+async def test_discover_schema_records_a_version(tmp_path, monkeypatch):
+    """The seam the issue was really about: a real discovery must write history.
+
+    Every other test here drives the metadata API directly, which is exactly the
+    state the bug was in -- the recording API can be perfect and still never be
+    called. This exercises the handler.
+    """
+    from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+    import src.main as main_module
+    from src.database_manager import ColumnInfo, DatabaseManager, TableInfo
+
+    monkeypatch.setenv("AUTO_GRAPHRAG", "false")
+
+    db = MagicMock(spec=DatabaseManager)
+    db.get_tables.return_value = ["customers", "orders"]
+    db.has_engine.return_value = True
+    db.prefetch_schema_constraints.return_value = None
+    db.analyze_table.side_effect = lambda name, schema=None: TableInfo(
+        name=name,
+        schema=SCHEMA,
+        columns=[
+            ColumnInfo(
+                name=f"{name}_id",
+                data_type="INTEGER",
+                is_nullable=False,
+                is_primary_key=True,
+                is_foreign_key=False,
+            )
+        ],
+        primary_keys=[f"{name}_id"],
+        foreign_keys=[],
+        row_count=1,
+    )
+
+    ctx = Mock()
+    ctx.info = AsyncMock()
+    ctx.warning = AsyncMock()
+    ctx.error = AsyncMock()
+
+    session = Mock()
+    session.connection_id = CONN
+    session.get_cached_schema.return_value = None
+    session.schema_file = None
+    session.ontology_file = None
+    session.graphrag_initialized = False
+
+    with (
+        patch("src.main.get_session_db_manager", return_value=db),
+        patch("src.main.get_session_data", return_value=session),
+        patch("src.handlers.schema.OUTPUT_DIR", tmp_path),
+    ):
+        discover = getattr(
+            main_module.discover_schema, "fn", main_module.discover_schema
+        )
+        await discover(ctx, schema_name=SCHEMA, lightweight=True)
+
+    recorded = _mgr(tmp_path).get_current_version(SCHEMA)
+    assert recorded is not None, "discover_schema must open a version"
+    assert recorded.version == 1
+    assert recorded.table_count == 2
+    assert recorded.column_count == 2
+    assert recorded.schema_hash
+
+
+async def test_a_second_discovery_archives_the_first(tmp_path, monkeypatch):
+    """Two discoveries must leave a history, not overwrite one record."""
+    await open_schema_version(CONN, tmp_path, SCHEMA, _tables(2))
+    await open_schema_version(CONN, tmp_path, SCHEMA, _tables(3))
+
+    versions = _mgr(tmp_path).get_versions(SCHEMA)
+    assert [(v.version, v.status) for v in versions] == [
+        (1, "archived"),
+        (2, "active"),
+    ]
+
+
+def test_version_info_round_trips_through_json(tmp_path):
+    original = VersionInfo(
+        version=2,
+        created_at=utc_now().isoformat(),
+        schema_hash="abc",
+        table_count=3,
+        column_count=9,
+        graphrag_vector_count=42,
+        graphrag_status="active",
+        ontology_graph_uri="urn:g",
+        ontology_triple_count=17,
+        ontology_ttl_file="o.ttl",
+        ontology_status="active",
+        graphrag_files=["vector_store_public_v2.json"],
+    )
+    from dataclasses import asdict
+
+    assert VersionInfo.from_dict(json.loads(json.dumps(asdict(original)))) == original


### PR DESCRIPTION
Closes #68.

`DataCleanupManager` implemented the **cleanup** half of the Phase 3B design, but nothing ever wrote a version record — all three references to `metadata["schemas"][x]["versions"]` were reads, so `get_versions_to_cleanup()` returned `[]` unconditionally and the whole mechanism provably did nothing.

## Recording

- `discover_schema` opens a version (schema fingerprint, table/column counts); `generate_ontology` fills in the TTL file, named graph and triple count; GraphRAG init fills in the vector count, collection and snapshot files.
- Opening a version archives its predecessor, so exactly one is ever `active`, and records the delta (table-count change, whether the structure changed).
- Workspaces predating this get their current generation seeded as version 1, rather than being orphaned behind a fresh version 1.
- `VersionInfo.from_dict` drops unknown keys and defaults missing ones, so a `metadata.json` written by a newer or older release still loads.

## Retention

- `GRAPHRAG_KEEP_VERSIONS`, `GRAPHRAG_MAX_AGE_DAYS`, `ONTOLOGY_KEEP_VERSIONS`, `ONTOLOGY_MAX_AGE_DAYS` now feed `RetentionPolicy`, with **env > stored > default** precedence so an operator can change retention for workspaces that already exist. Invalid values are logged and ignored rather than failing startup.
- Fixed the `min_versions` floor trimming its candidate list from the wrong end, which spared the *stalest* versions and deleted the newest. Unreachable while `keep_count >= min_versions`; reachable now that `keep_count` is operator-settable.

## Cleanup

- `cleanup_graphrag` / `cleanup_ontology` are async and route every metadata write through `mutate_workspace_metadata()`; file and graph deletion is off-loop.
- `GraphRAGManager.save_state` writes per-version snapshots. The unversioned files `load_state` reads stay the current-generation pointer and are never deletion candidates, so cleanup cannot break restore.
- Replaced the `# For now, just log` ChromaDB stub with a real `delete_collection`, **guarded on ownership**.
- New `cleanup_old_versions` MCP tool, `dry_run=True` by default.

## One design constraint worth flagging

GraphRAG is connection-scoped and accumulative by design (AGENTS.md: one vector store per connection so cross-schema join discovery and unified search work). Versions therefore **share** a ChromaDB collection rather than each owning one, and dropping it because an archived version referenced it would wipe the live vector store for every schema on the connection.

Giving each version its own collection would mean re-embedding the whole schema per generation and breaking cross-schema search, so the delete is guarded instead: it runs only when no surviving version references the collection. In practice that means it stays as long as the schema has a live version — real, tested code with a correct guard rather than a stub, but not an unconditional delete. Named graphs get the same treatment, since generations reuse one graph URI. Per-version GraphRAG *files* are pruned normally. Both guards are documented in `docs/configuration.md` and covered by tests.

## Verification

- 534 tests pass (52 new in `tests/test_version_retention.py`), including an end-to-end test that drives the real `discover_schema` handler and asserts a version lands in `metadata.json` — the seam the issue was actually about.
- The `test_metadata_concurrency.py` exemption is **removed**, and the AST guard immediately caught a genuine unserialized `metadata.json` write in the new cleanup code, which is fixed.
- `ruff`, `black --check`, `isort --check-only`, `mypy src/` all clean; `bandit` identical to the pre-change baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)