### PR TITLE
test: make test_evict_idle_sessions actually run

### DIFF
--- a/tests/test_server_state.py
+++ b/tests/test_server_state.py
@@ -75,7 +75,16 @@ class TestClearSessionState(unittest.TestCase):
         self.assertFalse(session.oxigraph_initialized)
 
 
-class TestServerState(unittest.TestCase):
+class TestServerState(unittest.IsolatedAsyncioTestCase):
+    """Async-capable base, because test_evict_idle_sessions is a coroutine.
+
+    Under plain TestCase an ``async def`` test is never awaited: unittest calls
+    it, gets a coroutine back, discards it and reports a pass. The eviction test
+    below silently did nothing for its whole life -- it only surfaced as a
+    RuntimeWarning about a coroutine never awaited. Sync test methods run
+    unchanged under this base.
+    """
+
     def test_session_lifecycle(self):
         ss = ServerState()
         s = ss.get_session("s1")


### PR DESCRIPTION
Follow-up from #73 review.

`TestServerState` was a plain `unittest.TestCase` holding one `async def` test. unittest calls such a method, gets a coroutine back, discards it, and reports a pass — so `test_evict_idle_sessions` has **never executed**, and `ServerState._evict_idle_sessions` was effectively untested. The only symptom was a `RuntimeWarning: coroutine ... was never awaited`, easily lost among the suite's other warnings.

Switching the class to `unittest.IsolatedAsyncioTestCase` awaits it. The sync test methods in the class run unchanged.

**Verification** — I confirmed the test body now actually executes by temporarily breaking its assertion (`assertEqual(ss.session_count, 999)`) and watching it fail; before this change the same mutation still "passed". The eviction logic itself was correct, so no production code needed touching.

An AST scan over `tests/` for async test methods on non-async `TestCase` classes found no other instances of this pattern.

547 tests pass; the two `never awaited` warnings are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)