### PR TITLE
chore: remove the dead MCP_SHUTDOWN_TIMEOUT setting

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -77,11 +77,6 @@ MCP_TRANSPORT=http
 MCP_SERVER_HOST=localhost
 MCP_SERVER_PORT=9000
 
-# Shutdown timeout for graceful connection closure (seconds)
-# Lower values = faster shutdown but may interrupt active requests
-# Higher values = cleaner shutdown but slower Ctrl+C response
-MCP_SHUTDOWN_TIMEOUT=2
-
 # Session Idle Timeout
 # Sessions idle longer than this are automatically evicted (resources freed).
 # Set to 0 to disable idle eviction entirely.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,11 +78,6 @@ MCP_TRANSPORT=http
 MCP_SERVER_HOST=localhost
 MCP_SERVER_PORT=9000
 
-# Shutdown timeout for graceful connection closure (seconds)
-# Lower values = faster shutdown but may interrupt active requests
-# Higher values = cleaner shutdown but slower Ctrl+C response
-MCP_SHUTDOWN_TIMEOUT=2
-
 # Session Idle Timeout
 # Sessions idle longer than this are automatically evicted (resources freed).
 # Set to 0 to disable idle eviction entirely.
@@ -221,7 +216,6 @@ DATABRICKS_SCHEMA=default
 | `MCP_TRANSPORT` | `http` | MCP transport mode: `http` or `sse` |
 | `MCP_SERVER_HOST` | `localhost` | Host address the server binds to |
 | `MCP_SERVER_PORT` | `9000` | Port the server listens on |
-| `MCP_SHUTDOWN_TIMEOUT` | `2` | Seconds to wait for graceful shutdown |
 | `SESSION_IDLE_TIMEOUT_SECONDS` | `1800` | Idle timeout before session eviction (0 to disable) |
 | `SESSION_SCAN_INTERVAL_SECONDS` | `60` | How often to scan for idle sessions |
 | `MCP_MASTER_PASSWORD` | *(unset)* | Master password for encrypting credentials in memory |

--- a/server.py
+++ b/server.py
@@ -321,14 +321,6 @@ def main():
         )
         logger.info("📡 Server ready for MCP protocol messages")
 
-        # Configure FastMCP with shorter shutdown timeout for cleaner exits
-        # This reduces the timeout window for SSE connections during shutdown
-        import os
-
-        os.environ.setdefault(
-            "MCP_SHUTDOWN_TIMEOUT", "2"
-        )  # 2 seconds instead of default 5
-
         mcp.run(
             transport=config.mcp_transport,
             host=config.mcp_server_host,


### PR DESCRIPTION
## Problem

`server.py` set `MCP_SHUTDOWN_TIMEOUT` into the process environment:

```python
os.environ.setdefault("MCP_SHUTDOWN_TIMEOUT", "2")  # 2 seconds instead of default 5
```

Nothing ever read it back. It appeared exactly once in all Python in the repo — that line — and it is a *write*. No installed dependency references the name either: not `fastmcp`, `mcp`, `uvicorn`, or `starlette`. The call was inert.

The comment was also wrong: there is no "default 5" to reduce. The value that actually governs shutdown is hardcoded by fastmcp as `timeout_graceful_shutdown=2` (`fastmcp/server/mixins/transport.py:345`), so even the intended effect would have been a no-op.

## Why it mattered

The dead line itself was harmless — the documentation around it was not. Both config surfaces presented it as a working knob:

- `.env.template` — `MCP_SHUTDOWN_TIMEOUT=2` under "Shutdown timeout for graceful connection closure"
- `docs/configuration.md` — `` | `MCP_SHUTDOWN_TIMEOUT` | `2` | Seconds to wait for graceful shutdown | ``

So setting `MCP_SHUTDOWN_TIMEOUT=30` in `.env` to stop uvicorn cancelling SSE streams at shutdown would do nothing, with no error. This removes all three references rather than documenting a knob that does not exist.

## Verification

- No occurrence of `MCP_SHUTDOWN_TIMEOUT` remains anywhere outside `.venv`
- The local `import os` in `main()` was removed with it; the other `os` usages in `server.py` have their own import at line 166
- Server boots: `Uvicorn running on http://localhost:9099`
- Full suite: **550 passed**, 70 subtests. ruff clean.

## Note

This only removes the dead setting; it does not change shutdown behaviour, which stays at fastmcp's hardcoded 2s. Wiring a real knob (passing `uvicorn_config={"timeout_graceful_shutdown": ...}` through `mcp.run()`) would be a separate, behaviour-changing PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)