### PR TITLE
feat(graphrag): let clients index business context for schema elements

### DIFF
--- a/src/graphrag/manager.py
+++ b/src/graphrag/manager.py
@@ -220,6 +220,84 @@ class GraphRAGManager:
             for elem, score in results
         ]
 
+    def add_semantic_context(
+        self,
+        target: str,
+        context: str,
+        source: str = "client",
+    ) -> dict[str, Any]:
+        """Index client-supplied business context for a table or column.
+
+        Schema search can only match what the schema says about itself, which
+        is usually abbreviations: ``salesamount``, ``unitcost``,
+        ``returnquantity``. Nothing in those names carries the vocabulary users
+        actually ask in -- "profit", "margin", "churn" -- so the concepts are
+        unreachable no matter how good the embedding model is.
+
+        This lets the calling model write that missing vocabulary into the
+        index as an additional searchable element. It does not modify the
+        schema element itself, so re-running discovery cannot silently
+        overwrite it and the original description stays intact.
+
+        The context is indexed only; it is not written to the ontology or RDF
+        store, and it does not survive a backend switch or index rebuild (both
+        discard derived vectors). Treat it as session enrichment, not durable
+        knowledge.
+
+        Args:
+            target: Schema element the context describes, as ``table`` or
+                ``table.column``. Recorded in metadata so results can be traced
+                back; it does not have to exist yet.
+            context: Business meaning in natural language. Include the words
+                users would search with, and any formula worth surfacing.
+            source: Where the context came from, for provenance in results.
+
+        Returns:
+            Summary of what was indexed: element id, target and character count.
+
+        Raises:
+            RuntimeError: If GraphRAG has not been initialized.
+            ValueError: If *target* or *context* is blank.
+        """
+        if not self._initialized:
+            raise RuntimeError(
+                "GraphRAG not initialized. Call initialize_from_schema() first."
+            )
+
+        target = target.strip()
+        context = context.strip()
+        if not target:
+            raise ValueError("target must name a table or table.column")
+        if not context:
+            raise ValueError("context must not be empty")
+
+        # The target is embedded alongside the prose so a search for the column
+        # name still reaches its context, not only a search for the concept.
+        description = f"{target.replace('.', ' ').replace('_', ' ')} {context}"
+        embedding = self.embedder._embed_text(description)
+
+        element_id = f"semantic_context:{target}"
+        self.vector_store.add_element(
+            element_type="semantic_context",
+            element_id=element_id,
+            name=target,
+            description=description,
+            embedding=embedding,
+            metadata={
+                "target": target,
+                "context": context,
+                "source": source,
+            },
+        )
+        self.vector_store.build_index()
+
+        logger.info(f"Indexed semantic context for '{target}' ({len(context)} chars)")
+        return {
+            "element_id": element_id,
+            "target": target,
+            "characters": len(context),
+        }
+
     def find_relevant_tables(
         self,
         query: str,

--- a/src/graphrag/manager.py
+++ b/src/graphrag/manager.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .community_detector import CommunityDetector
-from .embedder import SchemaEmbedder
+from .embedder import MODEL_TFIDF, SchemaEmbedder
 from .retriever import GraphRetriever
 
 if TYPE_CHECKING:
@@ -244,6 +244,15 @@ class GraphRAGManager:
         discard derived vectors). Treat it as session enrichment, not durable
         knowledge.
 
+        Calling this again for the same target replaces the previous context
+        rather than adding a second entry, so it can be revised.
+
+        Under the ``tfidf`` backend the context is stored but is effectively
+        unsearchable: that vectorizer's vocabulary is fixed when the schema is
+        indexed, so words the context introduces -- exactly the ones worth
+        adding -- are out of vocabulary and score 0.0. The returned
+        ``searchable`` flag reports this so callers are not misled.
+
         Args:
             target: Schema element the context describes, as ``table`` or
                 ``table.column``. Recorded in metadata so results can be traced
@@ -253,7 +262,9 @@ class GraphRAGManager:
             source: Where the context came from, for provenance in results.
 
         Returns:
-            Summary of what was indexed: element id, target and character count.
+            Summary of what was indexed: element id, target, character count,
+            whether it replaced existing context, whether it is searchable, and
+            a warning when it is not.
 
         Raises:
             RuntimeError: If GraphRAG has not been initialized.
@@ -277,7 +288,13 @@ class GraphRAGManager:
         embedding = self.embedder._embed_text(description)
 
         element_id = f"semantic_context:{target}"
-        self.vector_store.add_element(
+        replaced = self.vector_store.get_by_id(element_id) is not None
+
+        # upsert, not add: both stores keep the *first* write for an id -- the
+        # ChromaDB collection ignores the second add and the JSON store appends
+        # a duplicate whose lookups still return the stale entry -- so a revised
+        # context would report success while the old one kept answering.
+        self.vector_store.upsert_element(
             element_type="semantic_context",
             element_id=element_id,
             name=target,
@@ -291,12 +308,33 @@ class GraphRAGManager:
         )
         self.vector_store.build_index()
 
-        logger.info(f"Indexed semantic context for '{target}' ({len(context)} chars)")
-        return {
+        # TF-IDF fits its vocabulary on the schema corpus and never refits, so
+        # the vocabulary this context introduces cannot be matched. Storing it
+        # is harmless and keeps the record, but saying nothing would leave the
+        # caller believing the concept is now findable.
+        searchable = self.embedder.embedding_model != MODEL_TFIDF
+        result: dict[str, Any] = {
             "element_id": element_id,
             "target": target,
             "characters": len(context),
+            "replaced_existing": replaced,
+            "searchable": searchable,
         }
+        if not searchable:
+            warning = (
+                "Stored but not searchable: the 'tfidf' backend fixes its "
+                "vocabulary when the schema is indexed, so words this context "
+                "introduces score 0.0. Set GRAPHRAG_EMBEDDING_MODEL=minilm and "
+                "re-run discover_schema() to make enrichment effective."
+            )
+            result["warning"] = warning
+            logger.warning(f"Semantic context for '{target}': {warning}")
+        else:
+            logger.info(
+                f"Indexed semantic context for '{target}' ({len(context)} chars)"
+            )
+
+        return result
 
     def find_relevant_tables(
         self,

--- a/src/graphrag/vector_store.py
+++ b/src/graphrag/vector_store.py
@@ -90,6 +90,40 @@ class VectorStore:
         self.elements.append(element)
         self._index_built = False  # Invalidate index
 
+    def upsert_element(
+        self,
+        element_type: str,
+        element_id: str,
+        name: str,
+        description: str,
+        embedding: np.ndarray,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Add an element, replacing any existing one with the same id.
+
+        ``add_element`` appends unconditionally, so re-adding under a stable id
+        leaves two entries sharing it -- and lookups return the stale first
+        one while both compete in search. Callers that own an id and expect to
+        revise it must use this instead.
+
+        Args:
+            element_type: Type of element ("table", "column", "relationship")
+            element_id: Unique identifier; existing entries are removed first
+            name: Element name
+            description: Text description
+            embedding: Vector embedding
+            metadata: Optional metadata dictionary
+        """
+        self.elements = [e for e in self.elements if e.element_id != element_id]
+        self.add_element(
+            element_type=element_type,
+            element_id=element_id,
+            name=name,
+            description=description,
+            embedding=embedding,
+            metadata=metadata,
+        )
+
     def add_elements_batch(self, elements: list[Any]) -> None:
         """
         Add multiple schema elements in batch.

--- a/src/graphrag/vector_store_chromadb.py
+++ b/src/graphrag/vector_store_chromadb.py
@@ -204,6 +204,58 @@ class ChromaDBVectorStore:
             logger.error(f"Failed to add element {element_id}: {e}")
             raise
 
+    def upsert_element(
+        self,
+        element_type: str,
+        element_id: str,
+        name: str,
+        description: str,
+        embedding: np.ndarray,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Add an element, replacing any existing one with the same id.
+
+        ``add`` silently keeps the first write when an id already exists, so
+        re-adding under a stable id looks like it succeeded while leaving the
+        old vector and metadata in place. Callers that own an id and expect to
+        revise it must use this instead.
+
+        Args:
+            element_type: Type of element ("table", "column", "relationship")
+            element_id: Unique identifier; an existing entry is overwritten
+            name: Element name
+            description: Text description
+            embedding: Vector embedding
+            metadata: Optional metadata dictionary
+        """
+        chroma_metadata: dict[str, Any] = {
+            "element_type": element_type,
+            "name": name,
+            "description": description,
+        }
+        if metadata:
+            for key, value in metadata.items():
+                if isinstance(value, (str, int, float, bool)):
+                    chroma_metadata[key] = value
+                else:
+                    chroma_metadata[key] = json.dumps(value)
+
+        if embedding.shape[0] != self.dimension:
+            if embedding.shape[0] < self.dimension:
+                embedding = np.pad(embedding, (0, self.dimension - embedding.shape[0]))
+            else:
+                embedding = embedding[: self.dimension]
+
+        try:
+            self.collection.upsert(
+                ids=[element_id],
+                embeddings=[embedding.tolist()],
+                metadatas=[chroma_metadata],
+            )
+        except Exception as e:
+            logger.error(f"Failed to upsert element {element_id}: {e}")
+            raise
+
     def add_elements_batch(self, elements: list[Any]) -> None:
         """
         Add multiple schema elements in batch.

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -524,7 +524,13 @@ async def graphrag_add_semantic_context(
             target=target, context=context
         )
 
-        await ctx.info(f"Indexed semantic context for {target}")
+        if result.get("searchable"):
+            await ctx.info(f"Indexed semantic context for {target}")
+        else:
+            await ctx.info(
+                f"Stored semantic context for {target}, but it is not "
+                "searchable under the current embedding backend"
+            )
 
         return {
             "success": True,

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -503,6 +503,49 @@ async def graphrag_search(
         return err
 
 
+async def graphrag_add_semantic_context(
+    ctx: Context,
+    target: str,
+    context: str,
+    services: "HandlerContext",
+) -> dict[str, Any]:
+    """Index client-supplied business context for a schema element."""
+    session = services.get_session_data(ctx)
+
+    if not session.graphrag_initialized or session.graphrag_manager is None:
+        err: dict[str, Any] = services.create_error_response(
+            "GraphRAG not initialized. Please call discover_schema() first.",
+            "graphrag_not_initialized",
+        )
+        return err
+
+    try:
+        result = session.graphrag_manager.add_semantic_context(
+            target=target, context=context
+        )
+
+        await ctx.info(f"Indexed semantic context for {target}")
+
+        return {
+            "success": True,
+            **result,
+            "note": (
+                "Indexed for semantic search only. Not written to the ontology "
+                "or RDF store, and discarded if the index is rebuilt."
+            ),
+        }
+
+    except ValueError as e:
+        err = services.create_error_response(str(e), "invalid_argument")
+        return err
+    except Exception as e:
+        logger.exception(f"Adding semantic context failed: {e}")
+        err = services.create_error_response(
+            f"Adding semantic context failed: {e!s}", "graphrag_error"
+        )
+        return err
+
+
 async def graphrag_query_context(
     ctx: Context,
     query: str,

--- a/src/main.py
+++ b/src/main.py
@@ -730,6 +730,14 @@ async def add_semantic_context(
     session enrichment, not durable knowledge; use add_rdf_knowledge for facts
     that must persist.
 
+    Calling this again for the same target REPLACES the previous context, so
+    it can be revised freely.
+
+    Check the returned "searchable" flag. Under the offline "tfidf" embedding
+    backend the context is stored but cannot be matched, and the response
+    carries a "warning" explaining why - do not report the concept as findable
+    in that case.
+
     REQUIRES: discover_schema must have been called first.
 
     Args:
@@ -740,7 +748,8 @@ async def add_semantic_context(
             unitcost. Used for profitability and margin analysis."
 
     Returns:
-        Dictionary with the indexed element id, target and character count
+        Dictionary with the indexed element id, target, character count,
+        whether it replaced existing context, and whether it is searchable
     """
     return await _h_graphrag.graphrag_add_semantic_context(
         ctx,

--- a/src/main.py
+++ b/src/main.py
@@ -666,7 +666,9 @@ async def graphrag_search(
     ctx: Context,
     query: _QueryText | None = None,
     top_k: int = 5,
-    element_type: Literal["table", "column", "relationship"] | None = None,
+    element_type: (
+        Literal["table", "column", "relationship", "semantic_context"] | None
+    ) = None,
     overview: bool = False,
 ) -> dict[str, Any]:
     """Search schema using natural language via GraphRAG, or get a schema overview.
@@ -674,10 +676,15 @@ async def graphrag_search(
     GraphRAG is auto-initialized by discover_schema. Pass overview=True to get
     schema statistics and community clustering instead of search results.
 
+    Matching is semantic, but it can only match what the schema says about
+    itself. If a concept lives in business vocabulary the column names do not
+    use ("profit", "churn"), index it first with add_semantic_context.
+
     Args:
         query: Natural language search query (required unless overview=True)
         top_k: Number of results to return
-        element_type: Filter by type ("table", "column", "relationship", or None)
+        element_type: Filter by type ("table", "column", "relationship",
+            "semantic_context", or None)
         overview: If True, return schema statistics and communities instead of search
 
     Returns:
@@ -695,6 +702,50 @@ async def graphrag_search(
         query,
         top_k,
         element_type,
+        services=_services(),
+    )
+
+
+@mcp.tool()
+async def add_semantic_context(
+    ctx: Context,
+    target: _Identifier,
+    context: _QueryText,
+) -> dict[str, Any]:
+    """Teach GraphRAG what a table or column means in business terms.
+
+    Schema search can only match vocabulary the schema itself contains, which
+    is usually abbreviations - salesamount, unitcost, returnquantity. Questions
+    about "profit", "margin" or "churn" therefore find nothing, because no
+    column name carries those words. Use this to supply the missing vocabulary
+    so later graphrag_search calls can reach the right elements.
+
+    Write what an analyst would need to know: what the element measures, the
+    words users would search for it with, and any formula worth surfacing.
+
+    The context is added to the semantic index as a separate element. It does
+    NOT modify the schema, the ontology, or the RDF store, so rerunning
+    discover_schema cannot overwrite it - but it is discarded if the index is
+    rebuilt (for example after changing GRAPHRAG_EMBEDDING_MODEL). Treat it as
+    session enrichment, not durable knowledge; use add_rdf_knowledge for facts
+    that must persist.
+
+    REQUIRES: discover_schema must have been called first.
+
+    Args:
+        target: Element the context describes, as "table" or "table.column".
+        context: Business meaning in natural language, including the terms
+            users would search with. Example for sales.salesamount:
+            "Revenue per line item. Profit margin is salesamount minus
+            unitcost. Used for profitability and margin analysis."
+
+    Returns:
+        Dictionary with the indexed element id, target and character count
+    """
+    return await _h_graphrag.graphrag_add_semantic_context(
+        ctx,
+        target,
+        context,
         services=_services(),
     )
 

--- a/tests/test_graphrag_chromadb_fingerprint.py
+++ b/tests/test_graphrag_chromadb_fingerprint.py
@@ -69,6 +69,53 @@ class TestClearPreservesFingerprint:
         assert "embedding_schema_version" in metadata
 
 
+class TestUpsertReplaces:
+    """add() keeps the first write for an id; upsert() must not."""
+
+    def test_add_silently_keeps_the_first_write(self, chroma_dir):
+        """Documents why upsert_element exists -- this is ChromaDB behaviour,
+        not something the wrapper chose."""
+        store = _open()
+        _add(store)
+        store.add_element(
+            element_type="table",
+            element_id="sales",
+            name="sales",
+            description="second write",
+            embedding=np.full(384, 0.5, dtype=np.float32),
+            metadata={"marker": "SECOND"},
+        )
+
+        stored = store.collection.get(ids=["sales"])
+
+        assert store.collection.count() == 1
+        assert stored["metadatas"][0].get("marker") is None
+
+    def test_upsert_replaces_the_existing_element(self, chroma_dir):
+        store = _open()
+        store.upsert_element(
+            element_type="semantic_context",
+            element_id="semantic_context:sales.amt",
+            name="sales.amt",
+            description="first",
+            embedding=np.ones(384, dtype=np.float32),
+            metadata={"context": "FIRST"},
+        )
+        store.upsert_element(
+            element_type="semantic_context",
+            element_id="semantic_context:sales.amt",
+            name="sales.amt",
+            description="second",
+            embedding=np.full(384, 0.5, dtype=np.float32),
+            metadata={"context": "SECOND"},
+        )
+
+        stored = store.collection.get(ids=["semantic_context:sales.amt"])
+
+        assert store.collection.count() == 1
+        assert stored["metadatas"][0]["context"] == "SECOND"
+
+
 class TestBackendMismatchRebuilds:
     """The invalidation itself still has to work."""
 

--- a/tests/test_graphrag_semantic_context.py
+++ b/tests/test_graphrag_semantic_context.py
@@ -147,6 +147,43 @@ class TestIndexing:
         assert "sales salesamount" in stored.description
         assert "Profit margin driver." in stored.description
 
+    def test_second_call_replaces_the_previous_context(self, manager):
+        """Revision must actually take effect.
+
+        Both stores keep the *first* write for an id -- ChromaDB ignores the
+        second add, the JSON store appends a duplicate whose lookups still
+        return the stale entry -- so a revised context reported success while
+        the superseded one kept answering.
+        """
+        manager.add_semantic_context("sales.salesamount", "FIRST version")
+        result = manager.add_semantic_context("sales.salesamount", "SECOND version")
+
+        assert result["replaced_existing"] is True
+
+        matching = [
+            e
+            for e in manager.vector_store.elements
+            if e.element_id == "semantic_context:sales.salesamount"
+        ]
+        assert len(matching) == 1, "stale duplicate left in the index"
+        assert matching[0].metadata["context"] == "SECOND version"
+
+    def test_first_call_reports_no_replacement(self, manager):
+        result = manager.add_semantic_context("sales.unitcost", "Cost of goods sold.")
+
+        assert result["replaced_existing"] is False
+
+    def test_tfidf_reports_the_context_as_unsearchable(self, manager):
+        """TF-IDF fixes its vocabulary at indexing time, so added words never
+        match. Storing it silently would imply the concept is now findable."""
+        result = manager.add_semantic_context(
+            "sales.salesamount", "Revenue and profit margin metric."
+        )
+
+        assert result["searchable"] is False
+        assert "tfidf" in result["warning"]
+        assert "minilm" in result["warning"]
+
     def test_whitespace_is_trimmed(self, manager):
         result = manager.add_semantic_context(
             "  sales.unitcost  ", "  Cost of goods sold.  "
@@ -198,6 +235,36 @@ class TestSearchReachability:
 
         assert after[0]["element"]["id"] == "semantic_context:sales.salesamount"
         assert after[0]["similarity_score"] > best_schema_score * 1.5
+
+    def test_minilm_reports_the_context_as_searchable(self, semantic_manager):
+        result = semantic_manager.add_semantic_context(
+            "sales.salesamount", "Profit margin driver."
+        )
+
+        assert result["searchable"] is True
+        assert "warning" not in result
+
+    def test_revised_context_is_what_search_returns(self, semantic_manager):
+        """The stale entry must not keep answering after a revision."""
+        semantic_manager.add_semantic_context(
+            "sales.salesamount", "Counts warehouse pallets shipped."
+        )
+        semantic_manager.add_semantic_context(
+            "sales.salesamount",
+            "Revenue per line item. Profit margin is salesamount minus unitcost.",
+        )
+
+        # top_k must exceed the element count, or a stale duplicate can simply
+        # fall outside the window and the test passes without the fix.
+        results = semantic_manager.search_schema("profit margin", top_k=50)
+        contexts = [
+            r["element"]["metadata"]["context"]
+            for r in results
+            if r["element"]["type"] == "semantic_context"
+        ]
+
+        assert len(contexts) == 1
+        assert "Profit margin" in contexts[0]
 
     def test_context_can_be_filtered_out(self, semantic_manager):
         semantic_manager.add_semantic_context(

--- a/tests/test_graphrag_semantic_context.py
+++ b/tests/test_graphrag_semantic_context.py
@@ -1,0 +1,211 @@
+"""Tests for client-supplied semantic context in the GraphRAG index.
+
+Schema search can only match vocabulary the schema itself contains. These
+tests pin the gap that motivates the feature -- a concept expressed only in
+business terms is unreachable from abbreviated column names -- and verify that
+indexing context closes it without disturbing the schema elements themselves.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+src_path = Path(__file__).parent.parent / "src"
+sys.path.insert(0, str(src_path))
+
+from graphrag.manager import GraphRAGManager  # noqa: E402
+
+TABLES = [
+    {
+        "name": "sales",
+        "schema": "public",
+        "columns": [
+            {
+                "name": "salesamount",
+                "data_type": "DECIMAL",
+                "is_nullable": False,
+                "is_primary_key": False,
+                "is_foreign_key": False,
+                "foreign_key_table": None,
+            },
+            {
+                "name": "unitcost",
+                "data_type": "DECIMAL",
+                "is_nullable": False,
+                "is_primary_key": False,
+                "is_foreign_key": False,
+                "foreign_key_table": None,
+            },
+        ],
+        "foreign_keys": [],
+    },
+    {
+        "name": "banks",
+        "schema": "public",
+        "columns": [
+            {
+                "name": "balanceamt",
+                "data_type": "DECIMAL",
+                "is_nullable": False,
+                "is_primary_key": False,
+                "is_foreign_key": False,
+                "foreign_key_table": None,
+            }
+        ],
+        "foreign_keys": [],
+    },
+]
+
+
+def _minilm_is_cached() -> bool:
+    """Whether MiniLM is usable without triggering a ~79MB download."""
+    if os.getenv("ORIONBELT_TEST_EMBEDDING_DOWNLOAD") == "1":
+        return True
+    cache = Path.home() / ".cache" / "chroma" / "onnx_models" / "all-MiniLM-L6-v2"
+    return cache.exists()
+
+
+@pytest.fixture
+def manager(tmp_path, monkeypatch):
+    """An initialized manager backed by the JSON store, isolated per test."""
+    monkeypatch.setenv("GRAPHRAG_EMBEDDING_MODEL", "tfidf")
+    monkeypatch.setattr("graphrag.manager.CHROMADB_AVAILABLE", False)
+    mgr = GraphRAGManager(connection_id="test", schema_name="public")
+    mgr.initialize_from_schema(tables_info=TABLES, schema_name="public")
+    return mgr
+
+
+class TestValidation:
+    """Bad input is rejected before anything is indexed."""
+
+    def test_requires_initialization(self, monkeypatch):
+        monkeypatch.setenv("GRAPHRAG_EMBEDDING_MODEL", "tfidf")
+        monkeypatch.setattr("graphrag.manager.CHROMADB_AVAILABLE", False)
+        mgr = GraphRAGManager(connection_id="test", schema_name="public")
+
+        with pytest.raises(RuntimeError, match="not initialized"):
+            mgr.add_semantic_context("sales.salesamount", "revenue")
+
+    @pytest.mark.parametrize(
+        ("target", "context"),
+        [
+            ("", "revenue per line item"),
+            ("   ", "revenue per line item"),
+            ("sales.salesamount", ""),
+            ("sales.salesamount", "   "),
+        ],
+    )
+    def test_blank_arguments_rejected(self, manager, target, context):
+        with pytest.raises(ValueError):
+            manager.add_semantic_context(target, context)
+
+
+class TestIndexing:
+    """What gets written to the store."""
+
+    def test_returns_summary(self, manager):
+        result = manager.add_semantic_context(
+            "sales.salesamount", "Revenue per line item."
+        )
+
+        assert result["element_id"] == "semantic_context:sales.salesamount"
+        assert result["target"] == "sales.salesamount"
+        assert result["characters"] == len("Revenue per line item.")
+
+    def test_stored_as_its_own_element_type(self, manager):
+        manager.add_semantic_context("sales.salesamount", "Revenue per line item.")
+
+        stored = manager.vector_store.get_by_id("semantic_context:sales.salesamount")
+
+        assert stored is not None
+        assert stored.element_type == "semantic_context"
+        assert stored.metadata["target"] == "sales.salesamount"
+        assert stored.metadata["source"] == "client"
+
+    def test_does_not_modify_the_schema_element(self, manager):
+        """Re-running discovery must not be able to clobber the context, and
+        the column's own description must stay as discovery wrote it."""
+        before = manager.vector_store.get_by_id("sales.salesamount")
+        assert before is not None
+        original = before.description
+
+        manager.add_semantic_context("sales.salesamount", "Profit margin driver.")
+
+        after = manager.vector_store.get_by_id("sales.salesamount")
+        assert after is not None
+        assert after.description == original
+
+    def test_target_is_embedded_with_the_prose(self, manager):
+        """Searching the column name should still reach its context."""
+        manager.add_semantic_context("sales.salesamount", "Profit margin driver.")
+
+        stored = manager.vector_store.get_by_id("semantic_context:sales.salesamount")
+
+        assert stored is not None
+        assert "sales salesamount" in stored.description
+        assert "Profit margin driver." in stored.description
+
+    def test_whitespace_is_trimmed(self, manager):
+        result = manager.add_semantic_context(
+            "  sales.unitcost  ", "  Cost of goods sold.  "
+        )
+
+        assert result["target"] == "sales.unitcost"
+        stored = manager.vector_store.get_by_id("semantic_context:sales.unitcost")
+        assert stored is not None
+        assert stored.metadata["context"] == "Cost of goods sold."
+
+
+@pytest.mark.skipif(
+    not _minilm_is_cached(),
+    reason=(
+        "MiniLM model not cached; set ORIONBELT_TEST_EMBEDDING_DOWNLOAD=1 to "
+        "allow the ~79MB download"
+    ),
+)
+class TestSearchReachability:
+    """The point of the feature: making an unreachable concept findable."""
+
+    @pytest.fixture
+    def semantic_manager(self, monkeypatch):
+        monkeypatch.setenv("GRAPHRAG_EMBEDDING_MODEL", "minilm")
+        monkeypatch.setattr("graphrag.manager.CHROMADB_AVAILABLE", False)
+        mgr = GraphRAGManager(connection_id="test", schema_name="public")
+        mgr.initialize_from_schema(tables_info=TABLES, schema_name="public")
+        return mgr
+
+    def test_context_becomes_the_top_hit_for_its_concept(self, semantic_manager):
+        """'profit margin' appears in no column name, so only the added
+        context can carry it.
+
+        The raw columns do score something on their own -- the model relates
+        cost and amount to margin -- so the assertion is that the context wins
+        by a clear margin, not merely that it appears.
+        """
+        query = "which product lines have the best profit margin"
+
+        before = semantic_manager.search_schema(query, top_k=3)
+        best_schema_score = before[0]["similarity_score"]
+
+        semantic_manager.add_semantic_context(
+            "sales.salesamount",
+            "Revenue per line item. Profit margin is salesamount minus "
+            "unitcost. Used for profitability analysis.",
+        )
+        after = semantic_manager.search_schema(query, top_k=3)
+
+        assert after[0]["element"]["id"] == "semantic_context:sales.salesamount"
+        assert after[0]["similarity_score"] > best_schema_score * 1.5
+
+    def test_context_can_be_filtered_out(self, semantic_manager):
+        semantic_manager.add_semantic_context(
+            "sales.salesamount", "Profit margin driver."
+        )
+
+        results = semantic_manager.search_schema(
+            "profit margin", top_k=5, element_type="column"
+        )
+
+        assert all(r["element"]["type"] == "column" for r in results)


### PR DESCRIPTION
**Replaces #80**, which GitHub auto-closed when its base branch (`feat/graphrag-semantic-embeddings`, the #79 stack base) was deleted on merge. It could not be reopened afterwards because the head had been rebased off that base. **The review discussion lives on #80** — same content, retargeted to `main`.

## Problem

Even with semantic embeddings (#79), search can only match vocabulary the schema *contains*. Real column names are abbreviations — `salesamount`, `unitcost`, `returnquantity` — so questions about "profit", "margin" or "churn" have nothing to land on.

## Fix

`add_semantic_context(target, context)` lets the client write the missing vocabulary into the index. Measured on a sales/banks schema, *"which product lines have the best profit margin"*:

| | top hit | score |
|---|---|---|
| before | `sales.unitcost` | 0.261 |
| after | `semantic_context:sales.salesamount` | **0.567** |

## Includes both fixes from the #80 review

1. **Re-adding context did not replace it.** Both stores keep the *first* write — ChromaDB ignores the second `add`, the JSON store appends a duplicate whose lookups still return the stale entry — so a revision reported success while the old text kept answering. Both stores gained `upsert_element`; the result reports `replaced_existing`.
2. **Silent no-op on `tfidf`.** That vectorizer fixes its vocabulary at indexing time, so added words score 0.0. The result now carries `searchable: False` plus a warning, and the tool docstring tells the caller not to report the concept as findable.

## Design notes

- Separate element, not an edit — re-running `discover_schema` cannot overwrite it.
- Target embedded with the prose, so searching the column name still reaches its context.
- Index-only: not written to the ontology or RDF store, discarded on index rebuild. `add_rdf_knowledge` is for facts that must persist.
- `graphrag_search` gains `semantic_context` as an `element_type` filter.

## Tests

17 in the file. Verified non-vacuous by swapping `upsert_element` back to `add_element`. Two reachability tests skip when the MiniLM model is not cached (`ORIONBELT_TEST_EMBEDDING_DOWNLOAD=1` forces them).

Full suite: **598 passed**, 70 subtests. mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)