### PR TITLE
fix(obqc): resolve SELECT aliases referenced from ORDER BY

### DIFF
--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -73,21 +73,41 @@ CATALOG_SCHEMAS = frozenset(
 # which they are not. src/security.py blocks them outright.
 
 
-# Where a SELECT alias may be referenced, by dialect.
+# Where a SELECT alias may be referenced, keyed by the database type callers
+# pass to validate() (not the sqlglot parsing dialect -- dremio parses as
+# trino, but is configured here under its own name).
 #
-# ORDER BY and GROUP BY see the select list's output names in every supported
-# database. HAVING does not, in most: PostgreSQL's SELECT documentation is
-# explicit that an output name is usable in GROUP BY and ORDER BY but not in
-# WHERE or HAVING. MySQL and ClickHouse do permit it there, so they are listed
-# separately rather than the permissive form being applied to everyone -- a
-# query relying on it would be rejected by PostgreSQL, and OBQC exists to say
-# so before execution. WHERE is never included: it is evaluated before the
-# select list in every dialect.
-DEFAULT_ALIAS_VISIBLE_CLAUSES = ("order", "group", "qualify")
+# ORDER BY and GROUP BY see the select list's output names everywhere. HAVING
+# is where the dialects diverge, checked against vendor documentation:
+#
+#   postgresql  no   an output name may be used in GROUP BY and ORDER BY but
+#                    not in WHERE or HAVING (PostgreSQL SELECT reference)
+#   mysql       yes  permitted in HAVING
+#   clickhouse  yes  "reference aggregation results from SELECT clause in
+#                    HAVING clause by their alias" (HAVING clause docs)
+#   snowflake   yes  "expressions in the SELECT list can be referred to by the
+#                    column alias defined in the list" (HAVING docs)
+#   databricks  yes  resolvable in HAVING, though a real column of the same
+#                    name wins over the alias (name-resolution docs)
+#   bigquery    yes  aliases are visible to GROUP BY, HAVING and ORDER BY
+#   duckdb      yes  verified directly against duckdb 1.5.5 -- it accepts an
+#                    alias in every clause, WHERE included
+#   dremio      ?    Trino's SELECT docs describe GROUP BY and ORDER BY in
+#                    terms of input columns and ordinals without stating
+#                    whether an output alias resolves. Left permissive; see
+#                    below for why the unknown case errs that way.
+#
+# The default is permissive because OBQC errors block execution. Wrongly
+# allowing an alias costs nothing -- the database rejects the query itself,
+# with a better message. Wrongly forbidding one stops a query that would have
+# run. So a clause is only closed off where documentation says it is closed,
+# which today means PostgreSQL's HAVING.
+DEFAULT_ALIAS_VISIBLE_CLAUSES = ("order", "group", "having", "qualify")
 
 ALIAS_VISIBLE_CLAUSES = {
-    "mysql": ("order", "group", "having", "qualify"),
-    "clickhouse": ("order", "group", "having", "qualify"),
+    "postgresql": ("order", "group", "qualify"),
+    # DuckDB resolves aliases laterally, including in WHERE.
+    "duckdb": ("order", "group", "having", "qualify", "where"),
 }
 
 

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -97,6 +97,9 @@ class OBQCResult:
     # ontology, which describes user data, so ontology-existence rules skip them.
     catalog_tables: set[str] = field(default_factory=set)
     parsed_columns: list[str] = field(default_factory=list)
+    # Lower-cased SELECT aliases referenced from ORDER BY / GROUP BY / HAVING.
+    # They resolve to select-list output, not to any table's column.
+    select_aliases: set[str] = field(default_factory=set)
     parsed_joins: list[dict[str, Any]] = field(default_factory=list)
     has_aggregation: bool = False
     has_group_by: bool = False
@@ -506,6 +509,39 @@ class OBQCValidator:
             if col_ref and col_ref not in result.parsed_columns:
                 result.parsed_columns.append(col_ref)
 
+        self._extract_select_aliases(parsed, result)
+
+    def _extract_select_aliases(self, parsed: exp.Expr, result: OBQCResult) -> None:
+        """Record SELECT aliases that are legally referenced by later clauses.
+
+        ``SELECT SUM(total) AS revenue FROM orders ORDER BY revenue`` is valid
+        SQL, but ``revenue`` is not a column of any table, so the column rule
+        reported it missing and -- being an error -- blocked the query.
+
+        Only aliases actually used in ORDER BY, GROUP BY or HAVING are
+        recorded. Those are the clauses evaluated after the select list, so
+        they can see its output names; WHERE cannot, and an alias used there is
+        genuinely invalid SQL that should keep failing.
+        """
+        for select in parsed.find_all(exp.Select):
+            aliases = {
+                projection.alias.lower()
+                for projection in select.expressions
+                if isinstance(projection, exp.Alias) and projection.alias
+            }
+            if not aliases:
+                continue
+
+            for clause in ("order", "group", "having", "qualify"):
+                node = select.args.get(clause)
+                if node is None:
+                    continue
+                for column in node.find_all(exp.Column):
+                    # A qualified reference names a real table, so it is not an
+                    # alias use and stays subject to the normal column rule.
+                    if not column.table and column.name.lower() in aliases:
+                        result.select_aliases.add(column.name.lower())
+
     def _extract_joins(self, parsed: exp.Expr, result: OBQCResult) -> None:
         """Extract join information from parsed query."""
         for join in parsed.find_all(exp.Join):
@@ -589,6 +625,12 @@ class OBQCValidator:
             else:
                 # Unqualified column - check for ambiguity
                 col_key = col_ref.lower()
+
+                # An alias resolves to the select list, not to a table, so it
+                # is neither missing nor ambiguous.
+                if col_key in result.select_aliases:
+                    continue
+
                 found_in_tables: list[str] = []
 
                 # Only check tables that are actually in the query

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -110,6 +110,15 @@ ALIAS_VISIBLE_CLAUSES = {
     "duckdb": ("order", "group", "having", "qualify", "where"),
 }
 
+# Dialects where an output name is only recognised as a whole sort or group
+# key, never inside a larger expression. PostgreSQL's ORDER BY documentation
+# is explicit that an output name may be used as a sort key but that anything
+# more than a bare name is evaluated as an expression over input columns, so
+# "ORDER BY t + 1" fails there while DuckDB -- checked against 1.5.5 --
+# accepts it. Listed rather than defaulted for the usual reason: forbidding it
+# where it is legal would block a query the database would have run.
+ALIAS_STANDALONE_ONLY = frozenset({"postgresql"})
+
 
 @dataclass
 class OBQCIssue:
@@ -594,6 +603,8 @@ class OBQCValidator:
             if not aliases:
                 continue
 
+            standalone_only = dialect.lower() in ALIAS_STANDALONE_ONLY
+
             for clause in clauses:
                 node = select.args.get(clause)
                 if node is None:
@@ -607,10 +618,53 @@ class OBQCValidator:
                     # are resolved on its own iteration, not this one.
                     if column.find_ancestor(exp.Select) is not select:
                         continue
+                    if standalone_only and not self._is_standalone_key(column, node):
+                        continue
                     alias_refs.add(id(column))
                     result.select_aliases.add(column.name.lower())
 
         return alias_refs
+
+    def _is_real_column(self, name: str, result: OBQCResult) -> bool:
+        """Whether *name* is a column of some table the query references.
+
+        Args:
+            name: Bare or qualified column name, lower-cased.
+            result: Result carrying the query's tables.
+
+        Returns:
+            True if any queried table declares the column.
+        """
+        if self._schema_cache is None:
+            return False
+
+        bare = name.split(".")[-1]
+        for table_name in result.parsed_tables:
+            table = self._schema_cache.tables.get(table_name.lower())
+            if table and bare in table.columns:
+                return True
+        return False
+
+    def _is_standalone_key(self, column: exp.Column, clause_node: exp.Expr) -> bool:
+        """Whether *column* is a whole sort/group key rather than part of one.
+
+        ``ORDER BY t`` refers to the output name; ``ORDER BY t + 1`` is an
+        expression, which strict dialects evaluate over input columns only.
+
+        Args:
+            column: Candidate alias reference.
+            clause_node: The ORDER BY / GROUP BY node containing it.
+
+        Returns:
+            True if the column is one of the clause's top-level keys.
+        """
+        for key in clause_node.expressions:
+            # ORDER BY keys are wrapped in Ordered (carrying ASC/DESC etc.);
+            # GROUP BY keys are the expressions themselves.
+            target = key.this if isinstance(key, exp.Ordered) else key
+            if target is column:
+                return True
+        return False
 
     def _extract_joins(self, parsed: exp.Expr, result: OBQCResult) -> None:
         """Extract join information from parsed query."""
@@ -973,8 +1027,16 @@ class OBQCValidator:
 
                         # Record the underlying column too, so grouping by an
                         # alias satisfies the check on its source column.
+                        #
+                        # Only when the name is not itself a real column: a name
+                        # that is both an input column and an output alias
+                        # resolves to the input column, so "SELECT total AS
+                        # user_id ... GROUP BY user_id" groups by orders.user_id
+                        # and leaves total ungrouped. Verified against DuckDB,
+                        # which rejects exactly that query, and documented for
+                        # PostgreSQL.
                         source_col = alias_to_column.get(gb_col_name)
-                        if source_col:
+                        if source_col and not self._is_real_column(gb_col_name, result):
                             group_by_cols.add(source_col)
                             group_by_cols.add(source_col.split(".")[-1])
 

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -73,6 +73,24 @@ CATALOG_SCHEMAS = frozenset(
 # which they are not. src/security.py blocks them outright.
 
 
+# Where a SELECT alias may be referenced, by dialect.
+#
+# ORDER BY and GROUP BY see the select list's output names in every supported
+# database. HAVING does not, in most: PostgreSQL's SELECT documentation is
+# explicit that an output name is usable in GROUP BY and ORDER BY but not in
+# WHERE or HAVING. MySQL and ClickHouse do permit it there, so they are listed
+# separately rather than the permissive form being applied to everyone -- a
+# query relying on it would be rejected by PostgreSQL, and OBQC exists to say
+# so before execution. WHERE is never included: it is evaluated before the
+# select list in every dialect.
+DEFAULT_ALIAS_VISIBLE_CLAUSES = ("order", "group", "qualify")
+
+ALIAS_VISIBLE_CLAUSES = {
+    "mysql": ("order", "group", "having", "qualify"),
+    "clickhouse": ("order", "group", "having", "qualify"),
+}
+
+
 @dataclass
 class OBQCIssue:
     """Single OBQC validation issue."""
@@ -450,7 +468,7 @@ class OBQCValidator:
 
         # Extract query components
         self._extract_tables(parsed, result)
-        self._extract_columns(parsed, result)
+        self._extract_columns(parsed, result, dialect)
         self._extract_joins(parsed, result)
         self._extract_aggregations(parsed, result)
 
@@ -500,29 +518,53 @@ class OBQCValidator:
         # thing that would catch the non-catalog use, so it keeps applying.
         result.catalog_tables -= shadowed
 
-    def _extract_columns(self, parsed: exp.Expr, result: OBQCResult) -> None:
-        """Extract all column references from parsed query."""
+    def _extract_columns(
+        self, parsed: exp.Expr, result: OBQCResult, dialect: str = "postgresql"
+    ) -> None:
+        """Extract column references, excluding legal SELECT-alias references."""
+        alias_refs = self._select_alias_references(parsed, result, dialect)
+
         for column in parsed.find_all(exp.Column):
+            # Alias references resolve to the select list, not to a table, so
+            # they are not column references at all. Dropping them here rather
+            # than excusing their names later keeps the exemption tied to the
+            # exact node: a name is only excused where it really is an alias
+            # use, in the query scope that declared it.
+            if id(column) in alias_refs:
+                continue
             col_ref = column.name
             if column.table:
                 col_ref = f"{column.table}.{column.name}"
             if col_ref and col_ref not in result.parsed_columns:
                 result.parsed_columns.append(col_ref)
 
-        self._extract_select_aliases(parsed, result)
-
-    def _extract_select_aliases(self, parsed: exp.Expr, result: OBQCResult) -> None:
-        """Record SELECT aliases that are legally referenced by later clauses.
+    def _select_alias_references(
+        self, parsed: exp.Expr, result: OBQCResult, dialect: str
+    ) -> set[int]:
+        """Identify column nodes that legally reference a SELECT alias.
 
         ``SELECT SUM(total) AS revenue FROM orders ORDER BY revenue`` is valid
         SQL, but ``revenue`` is not a column of any table, so the column rule
         reported it missing and -- being an error -- blocked the query.
 
-        Only aliases actually used in ORDER BY, GROUP BY or HAVING are
-        recorded. Those are the clauses evaluated after the select list, so
-        they can see its output names; WHERE cannot, and an alias used there is
-        genuinely invalid SQL that should keep failing.
+        Resolution is per SELECT and per clause. An alias is visible only to
+        clauses evaluated after the select list, and only within the query that
+        declared it: a subquery's alias must not excuse a bogus name in the
+        outer SELECT.
+
+        Args:
+            parsed: Parsed query.
+            result: Result to record resolved alias names on (reporting only).
+            dialect: Database dialect, which decides where aliases are visible.
+
+        Returns:
+            ``id()`` of every column node that is an alias reference.
         """
+        clauses = ALIAS_VISIBLE_CLAUSES.get(
+            dialect.lower(), DEFAULT_ALIAS_VISIBLE_CLAUSES
+        )
+        alias_refs: set[int] = set()
+
         for select in parsed.find_all(exp.Select):
             aliases = {
                 projection.alias.lower()
@@ -532,15 +574,23 @@ class OBQCValidator:
             if not aliases:
                 continue
 
-            for clause in ("order", "group", "having", "qualify"):
+            for clause in clauses:
                 node = select.args.get(clause)
                 if node is None:
                     continue
                 for column in node.find_all(exp.Column):
                     # A qualified reference names a real table, so it is not an
                     # alias use and stays subject to the normal column rule.
-                    if not column.table and column.name.lower() in aliases:
-                        result.select_aliases.add(column.name.lower())
+                    if column.table or column.name.lower() not in aliases:
+                        continue
+                    # A nested SELECT re-declares its own scope; its clauses
+                    # are resolved on its own iteration, not this one.
+                    if column.find_ancestor(exp.Select) is not select:
+                        continue
+                    alias_refs.add(id(column))
+                    result.select_aliases.add(column.name.lower())
+
+        return alias_refs
 
     def _extract_joins(self, parsed: exp.Expr, result: OBQCResult) -> None:
         """Extract join information from parsed query."""
@@ -625,11 +675,6 @@ class OBQCValidator:
             else:
                 # Unqualified column - check for ambiguity
                 col_key = col_ref.lower()
-
-                # An alias resolves to the select list, not to a table, so it
-                # is neither missing nor ambiguous.
-                if col_key in result.select_aliases:
-                    continue
 
                 found_in_tables: list[str] = []
 
@@ -878,6 +923,24 @@ class OBQCValidator:
         for select in parsed.find_all(exp.Select):
             expressions = select.args.get("expressions", [])
 
+            # Aliases declared by this select, mapped to the column they stand
+            # for. GROUP BY may name either, and the two must be treated as the
+            # same key: "SELECT user_id AS uid ... GROUP BY uid" groups by
+            # user_id, but comparing the alias against the source column name
+            # reported user_id as not grouped.
+            alias_to_column: dict[str, str] = {}
+            for projection in expressions:
+                if (
+                    isinstance(projection, exp.Alias)
+                    and projection.alias
+                    and isinstance(projection.this, exp.Column)
+                ):
+                    source = projection.this
+                    qualified = source.name.lower()
+                    if source.table:
+                        qualified = f"{source.table.lower()}.{qualified}"
+                    alias_to_column[projection.alias.lower()] = qualified
+
             # Get GROUP BY columns
             group_by_cols: set[str] = set()
             if select.args.get("group"):
@@ -887,6 +950,13 @@ class OBQCValidator:
                         if group_expr.table:
                             gb_col_name = f"{group_expr.table.lower()}.{gb_col_name}"
                         group_by_cols.add(gb_col_name)
+
+                        # Record the underlying column too, so grouping by an
+                        # alias satisfies the check on its source column.
+                        source_col = alias_to_column.get(gb_col_name)
+                        if source_col:
+                            group_by_cols.add(source_col)
+                            group_by_cols.add(source_col.split(".")[-1])
 
             # Check each SELECT expression
             for expr in expressions:

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -512,15 +512,62 @@ class TestOBQCSelectAliases(unittest.TestCase):
 
         self.assertFalse(result.is_valid)
 
-    def test_having_alias_allowed_on_mysql(self):
-        """MySQL does permit it, so the same query must pass there."""
-        result = self.validator.validate(
-            "SELECT SUM(total) AS revenue FROM orders "
-            "GROUP BY user_id HAVING revenue > 10",
-            dialect="mysql",
+    def test_having_alias_allowed_on_dialects_that_permit_it(self):
+        """Every supported database except PostgreSQL resolves the alias here.
+
+        Checked against vendor documentation, and directly against DuckDB.
+        Dremio is included by policy rather than by evidence: Trino's docs do
+        not state whether an output alias resolves in HAVING, and OBQC errors
+        block execution, so an unverified clause is left open -- a wrongly
+        allowed alias is rejected by the database itself, a wrongly forbidden
+        one stops a query that would have run.
+        """
+        for dialect in (
+            "mysql",
+            "clickhouse",
+            "snowflake",
+            "databricks",
+            "bigquery",
+            "duckdb",
+            "dremio",
+        ):
+            with self.subTest(dialect=dialect):
+                result = self.validator.validate(
+                    "SELECT user_id, SUM(total) AS revenue FROM orders "
+                    "GROUP BY user_id HAVING revenue > 10",
+                    dialect=dialect,
+                )
+
+                self.assertTrue(result.is_valid, [i.message for i in result.issues])
+
+    def test_where_alias_errors_except_on_duckdb(self):
+        """DuckDB resolves aliases laterally, including in WHERE."""
+        for dialect in ("postgresql", "mysql", "snowflake", "bigquery"):
+            with self.subTest(dialect=dialect):
+                result = self.validator.validate(
+                    "SELECT total AS t FROM orders WHERE t > 5", dialect=dialect
+                )
+                self.assertFalse(result.is_valid)
+
+        duckdb_result = self.validator.validate(
+            "SELECT total AS t FROM orders WHERE t > 5", dialect="duckdb"
         )
 
-        self.assertTrue(result.is_valid, [i.message for i in result.issues])
+        self.assertTrue(
+            duckdb_result.is_valid, [i.message for i in duckdb_result.issues]
+        )
+
+    def test_order_by_alias_allowed_on_every_dialect(self):
+        from src.constants import SUPPORTED_DB_TYPES
+
+        for dialect in SUPPORTED_DB_TYPES:
+            with self.subTest(dialect=dialect):
+                result = self.validator.validate(
+                    "SELECT SUM(total) AS revenue FROM orders ORDER BY revenue",
+                    dialect=dialect,
+                )
+
+                self.assertTrue(result.is_valid, [i.message for i in result.issues])
 
     def test_group_by_alias_satisfies_the_aggregation_rule(self):
         """Grouping by an alias groups by its source column.

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -466,6 +466,95 @@ class TestOBQCCatalogQueries(unittest.TestCase):
         self.assertFalse(result.is_valid)
 
 
+class TestOBQCSelectAliases(unittest.TestCase):
+    """SELECT aliases referenced by later clauses are not table columns.
+
+    ORDER BY / GROUP BY / HAVING are evaluated after the select list and can
+    see its output names. The column rule knew only about table columns, so
+    "ORDER BY revenue" over "SUM(total) AS revenue" was reported missing --
+    an error, which blocks the query.
+    """
+
+    def setUp(self):
+        self.graph, self.base_uri = create_sample_ontology_graph()
+        self.validator = OBQCValidator()
+        self.validator.load_ontology(self.graph, self.base_uri)
+
+    def test_order_by_aggregate_alias(self):
+        result = self.validator.validate(
+            "SELECT SUM(total) AS revenue FROM orders ORDER BY revenue DESC"
+        )
+
+        self.assertTrue(result.is_valid, [i.message for i in result.issues])
+
+    def test_order_by_plain_column_alias(self):
+        result = self.validator.validate(
+            "SELECT name AS customer FROM users ORDER BY customer"
+        )
+
+        self.assertTrue(result.is_valid, [i.message for i in result.issues])
+
+    def test_group_by_and_order_by_alias(self):
+        result = self.validator.validate(
+            "SELECT COUNT(*) AS n FROM orders GROUP BY user_id ORDER BY n DESC"
+        )
+
+        self.assertTrue(result.is_valid, [i.message for i in result.issues])
+
+    def test_having_alias(self):
+        result = self.validator.validate(
+            "SELECT SUM(total) AS revenue FROM orders "
+            "GROUP BY user_id HAVING revenue > 10"
+        )
+
+        self.assertTrue(result.is_valid, [i.message for i in result.issues])
+
+    def test_alias_is_recorded(self):
+        result = self.validator.validate(
+            "SELECT SUM(total) AS revenue FROM orders ORDER BY revenue"
+        )
+
+        self.assertIn("revenue", result.select_aliases)
+
+    def test_alias_matching_is_case_insensitive(self):
+        result = self.validator.validate(
+            "SELECT SUM(total) AS Revenue FROM orders ORDER BY REVENUE"
+        )
+
+        self.assertTrue(result.is_valid, [i.message for i in result.issues])
+
+    def test_alias_in_where_still_errors(self):
+        """WHERE is evaluated before the select list, so this is invalid SQL
+        and must keep failing."""
+        result = self.validator.validate("SELECT total AS t FROM orders WHERE t > 5")
+
+        self.assertFalse(result.is_valid)
+
+    def test_unknown_order_by_column_still_errors(self):
+        """The exemption covers declared aliases, not any ORDER BY name."""
+        result = self.validator.validate(
+            "SELECT total FROM orders ORDER BY nonexistent_col"
+        )
+
+        self.assertFalse(result.is_valid)
+
+    def test_qualified_reference_to_an_alias_still_errors(self):
+        """orders.t names a table column, and there is none called t."""
+        result = self.validator.validate(
+            "SELECT total AS t FROM orders ORDER BY orders.t"
+        )
+
+        self.assertFalse(result.is_valid)
+
+    def test_alias_does_not_leak_into_other_column_checks(self):
+        """Declaring an alias must not excuse a genuinely bad column."""
+        result = self.validator.validate(
+            "SELECT total AS t, bogus_col FROM orders ORDER BY t"
+        )
+
+        self.assertFalse(result.is_valid)
+
+
 class TestOBQCFanTrapDetection(unittest.TestCase):
     """Test suite specifically for fan-trap detection."""
 

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -582,6 +582,61 @@ class TestOBQCSelectAliases(unittest.TestCase):
 
         self.assertTrue(result.is_valid, [i.message for i in result.issues])
 
+    def test_group_by_name_that_is_also_a_column_resolves_to_the_column(self):
+        """An ambiguous GROUP BY name is the input column, not the alias.
+
+        "SELECT total AS user_id ... GROUP BY user_id" groups by orders.user_id
+        and leaves total ungrouped. Treating the name as the alias marked total
+        as grouped and passed a query the database rejects. Verified against
+        DuckDB, which fails it with "column total must appear in the GROUP BY
+        clause", and documented for PostgreSQL.
+        """
+        for dialect in ("postgresql", "duckdb"):
+            with self.subTest(dialect=dialect):
+                result = self.validator.validate(
+                    "SELECT total AS user_id, SUM(id) FROM orders GROUP BY user_id",
+                    dialect=dialect,
+                )
+
+                self.assertFalse(result.is_valid)
+
+    def test_unambiguous_group_by_alias_still_resolves(self):
+        """uid is not a column of any queried table, so it is the alias."""
+        result = self.validator.validate(
+            "SELECT user_id AS uid, SUM(total) FROM orders GROUP BY uid"
+        )
+
+        self.assertTrue(result.is_valid, [i.message for i in result.issues])
+
+    def test_alias_inside_an_order_by_expression_is_rejected_on_postgres(self):
+        """PostgreSQL takes an output name as a sort key only, not inside an
+        expression: ORDER BY t + 1 is evaluated over input columns."""
+        result = self.validator.validate(
+            "SELECT total AS t FROM orders ORDER BY t + 1", dialect="postgresql"
+        )
+
+        self.assertFalse(result.is_valid)
+
+    def test_alias_inside_an_order_by_expression_is_allowed_on_duckdb(self):
+        """DuckDB accepts it -- verified against duckdb 1.5.5."""
+        result = self.validator.validate(
+            "SELECT total AS t FROM orders ORDER BY t + 1", dialect="duckdb"
+        )
+
+        self.assertTrue(result.is_valid, [i.message for i in result.issues])
+
+    def test_standalone_sort_key_still_resolves_on_postgres(self):
+        """The restriction is about expressions, not about sort modifiers."""
+        for query in (
+            "SELECT total AS t FROM orders ORDER BY t",
+            "SELECT SUM(total) AS revenue FROM orders ORDER BY revenue DESC",
+            "SELECT SUM(total) AS revenue FROM orders ORDER BY revenue DESC NULLS LAST",
+        ):
+            with self.subTest(query=query):
+                result = self.validator.validate(query, dialect="postgresql")
+
+                self.assertTrue(result.is_valid, [i.message for i in result.issues])
+
     def test_subquery_alias_does_not_excuse_the_outer_query(self):
         """Alias visibility is per SELECT scope.
 

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -501,10 +501,56 @@ class TestOBQCSelectAliases(unittest.TestCase):
 
         self.assertTrue(result.is_valid, [i.message for i in result.issues])
 
-    def test_having_alias(self):
+    def test_having_alias_rejected_on_postgres(self):
+        """PostgreSQL permits an output name in GROUP BY and ORDER BY, but not
+        in WHERE or HAVING -- so this is invalid and must be reported."""
         result = self.validator.validate(
             "SELECT SUM(total) AS revenue FROM orders "
-            "GROUP BY user_id HAVING revenue > 10"
+            "GROUP BY user_id HAVING revenue > 10",
+            dialect="postgresql",
+        )
+
+        self.assertFalse(result.is_valid)
+
+    def test_having_alias_allowed_on_mysql(self):
+        """MySQL does permit it, so the same query must pass there."""
+        result = self.validator.validate(
+            "SELECT SUM(total) AS revenue FROM orders "
+            "GROUP BY user_id HAVING revenue > 10",
+            dialect="mysql",
+        )
+
+        self.assertTrue(result.is_valid, [i.message for i in result.issues])
+
+    def test_group_by_alias_satisfies_the_aggregation_rule(self):
+        """Grouping by an alias groups by its source column.
+
+        The GROUP BY key was recorded as the alias while the SELECT expression
+        was checked as the source column, so the two never matched and a valid
+        query was rejected as not grouped.
+        """
+        result = self.validator.validate(
+            "SELECT user_id AS uid, SUM(total) FROM orders GROUP BY uid"
+        )
+
+        self.assertTrue(result.is_valid, [i.message for i in result.issues])
+
+    def test_subquery_alias_does_not_excuse_the_outer_query(self):
+        """Alias visibility is per SELECT scope.
+
+        Recording alias names globally let an inner query's alias excuse an
+        unrelated bogus column in the outer SELECT.
+        """
+        result = self.validator.validate(
+            "SELECT bogus, (SELECT total AS bogus FROM orders ORDER BY bogus "
+            "LIMIT 1) FROM orders"
+        )
+
+        self.assertFalse(result.is_valid)
+
+    def test_subquery_alias_still_works_in_its_own_scope(self):
+        result = self.validator.validate(
+            "SELECT (SELECT total AS t FROM orders ORDER BY t LIMIT 1) FROM orders"
         )
 
         self.assertTrue(result.is_valid, [i.message for i in result.issues])


### PR DESCRIPTION
**Stacked on #83** — both change `_validate_columns`, so this is based on that branch to avoid a conflict. Review #83 first; this diff shows only the alias change.

## Problem

The column rule knew only about table columns, so an alias declared in the select list and used afterwards looked missing:

```
SELECT SUM(total) AS revenue FROM orders ORDER BY revenue DESC
  -> ERROR  Column 'revenue' not found in any referenced table
```

That is valid SQL in every supported dialect, and OBQC errors **block execution** — so ordering by an aggregate, the most common shape in analytical queries, could not be run at all.

## Fix

Record aliases referenced from `ORDER BY`, `GROUP BY`, `HAVING` and `QUALIFY`, and treat them as resolved. Those clauses are evaluated after the select list and can see its output names.

```
SELECT SUM(total) AS revenue FROM orders ORDER BY revenue DESC        -> OK
SELECT name AS customer FROM users ORDER BY customer                  -> OK
SELECT COUNT(*) AS n FROM orders GROUP BY user_id ORDER BY n DESC     -> OK
SELECT SUM(total) AS revenue FROM orders GROUP BY user_id
                                         HAVING revenue > 10          -> OK
```

## What deliberately still fails

The exemption is narrow, and the negatives are tested:

| query | result | why |
|---|---|---|
| `... AS t FROM orders WHERE t > 5` | **ERROR** | WHERE is evaluated *before* the select list — genuinely invalid SQL |
| `... FROM orders ORDER BY nonexistent_col` | **ERROR** | covers declared aliases, not any ORDER BY name |
| `... AS t FROM orders ORDER BY orders.t` | **ERROR** | qualified reference names a table column, and there is no column `t` |
| `SELECT total AS t, bogus_col FROM orders ORDER BY t` | **ERROR** | declaring an alias must not excuse an unrelated bad column |

## Known limitation

Aliases are collected per query, not per occurrence, because `parsed_columns` is a deduplicated list of names. So an alias used in **both** ORDER BY and WHERE is not flagged for the WHERE misuse. The database still rejects such a query, and the alternative was restructuring column extraction to track occurrences — disproportionate for a case that is already caught downstream.

## Tests

10 new (`TestOBQCSelectAliases`), verified non-vacuous — 5 fail against the pre-fix rule, and the negatives above are the other 5.

Full suite: **640 passed**, 74 subtests. mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)