### PR TITLE
fix(obqc): judge fan-out per join direction, not per relationship

### DIFF
--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -668,11 +668,17 @@ class OBQCValidator:
 
     def _extract_joins(self, parsed: exp.Expr, result: OBQCResult) -> None:
         """Extract join information from parsed query."""
+        alias_map = self._build_alias_map(parsed)
+
         for join in parsed.find_all(exp.Join):
             join_info: dict[str, Any] = {
                 "type": join.kind or "INNER",
                 "table": None,
                 "on_condition": None,
+                # Real table names referenced by the ON condition. Fan-trap
+                # detection needs to know which table this join attaches to,
+                # and the ON condition is the only place that says so.
+                "on_tables": [],
             }
 
             # Get joined table
@@ -680,10 +686,40 @@ class OBQCValidator:
                 join_info["table"] = join.this.name
 
             # Get ON condition
-            if join.args.get("on"):
-                join_info["on_condition"] = join.args["on"].sql()
+            on_clause = join.args.get("on")
+            if on_clause is not None:
+                join_info["on_condition"] = on_clause.sql()
+                on_tables: list[str] = []
+                for column in on_clause.find_all(exp.Column):
+                    if not column.table:
+                        continue
+                    # Columns are qualified by alias far more often than by
+                    # table name, so resolve through the alias map.
+                    resolved = alias_map.get(column.table.lower(), column.table)
+                    if resolved not in on_tables:
+                        on_tables.append(resolved)
+                join_info["on_tables"] = on_tables
 
             result.parsed_joins.append(join_info)
+
+    def _build_alias_map(self, parsed: exp.Expr) -> dict[str, str]:
+        """Map every table alias (and bare name) to its real table name.
+
+        Args:
+            parsed: Parsed query.
+
+        Returns:
+            Lower-cased alias -> table name. Bare names map to themselves so
+            callers can look up unaliased references the same way.
+        """
+        alias_map: dict[str, str] = {}
+        for table in parsed.find_all(exp.Table):
+            if not table.name:
+                continue
+            alias_map[table.name.lower()] = table.name
+            if table.alias:
+                alias_map[table.alias.lower()] = table.name
+        return alias_map
 
     def _extract_aggregations(self, parsed: exp.Expr, result: OBQCResult) -> None:
         """Detect aggregate functions and GROUP BY."""
@@ -1108,6 +1144,45 @@ class OBQCValidator:
                     return True
         return False
 
+    def _join_fans_out(self, join_table: str, anchor_table: str) -> bool:
+        """Whether joining *join_table* onto *anchor_table* multiplies rows.
+
+        True when the ontology puts *join_table* on the "many" side of the
+        relationship between the two: one anchor row can match many joined
+        rows, so any measure taken from the anchor side is repeated.
+
+        Args:
+            join_table: Table introduced by the JOIN.
+            anchor_table: Table its ON condition attaches to.
+
+        Returns:
+            True if the join can duplicate anchor rows. False when the joined
+            table is the "one" side (a dimension lookup), or when the two are
+            not related in the ontology at all.
+        """
+        if self._schema_cache is None:
+            return False
+
+        joined = join_table.lower()
+        anchor = anchor_table.lower()
+
+        for rel in self._schema_cache.relationships.values():
+            from_t = rel.from_table.lower()
+            to_t = rel.to_table.lower()
+
+            # many_to_one is stored from the child: from_table is the many side.
+            if rel.relationship_type == "many_to_one":
+                many, one = from_t, to_t
+            elif rel.relationship_type == "one_to_many":
+                many, one = to_t, from_t
+            else:
+                continue
+
+            if {many, one} == {joined, anchor} and many == joined:
+                return True
+
+        return False
+
     def _detect_fan_trap(self, result: OBQCResult) -> None:
         """Rule: Detect potential fan-trap patterns.
 
@@ -1153,25 +1228,40 @@ class OBQCValidator:
             )
             return
 
-        # --- Heuristic fallback: count one-to-many joins (no disjointness axioms)
+        # --- Heuristic fallback: count fan-out joins (no disjointness axioms)
+        #
+        # A join multiplies rows only when the table being joined sits on the
+        # "many" side *of that join*. The direction is what matters, and it is
+        # only meaningful relative to the table the join attaches to.
+        #
+        # The previous version asked whether the joined table was on the many
+        # side of any relationship anywhere in the schema, and counted once per
+        # matching relationship rather than once per join. A dimension table
+        # with its own foreign keys therefore scored a fan-out for merely
+        # existing: "sales JOIN clients JOIN countries" -- many sales to one
+        # client to one country, where no row is ever duplicated -- was warned
+        # about because clients happens to reference countries.
         one_to_many_count = 0
         involved_tables: list[str] = []
 
         for join_info in result.parsed_joins:
             join_table = join_info.get("table")
-            if join_table:
-                join_table_lower = join_table.lower()
-                for rel_info in self._schema_cache.relationships.values():
-                    # A table is on the "many" side in these cases
-                    if (
-                        rel_info.relationship_type == "one_to_many"
-                        and rel_info.to_table.lower() == join_table_lower
-                    ) or (
-                        rel_info.relationship_type == "many_to_one"
-                        and rel_info.from_table.lower() == join_table_lower
-                    ):
-                        one_to_many_count += 1
-                        involved_tables.append(join_table)
+            if not join_table:
+                continue
+
+            anchors = [
+                t
+                for t in join_info.get("on_tables", [])
+                if t.lower() != join_table.lower()
+            ]
+            if not anchors:
+                # No ON condition to anchor against (CROSS JOIN, or a
+                # condition naming no other table); nothing to judge.
+                continue
+
+            if any(self._join_fans_out(join_table, anchor) for anchor in anchors):
+                one_to_many_count += 1
+                involved_tables.append(join_table)
 
         if one_to_many_count >= 2:
             result.fan_trap_risk = True

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -668,53 +668,66 @@ class OBQCValidator:
 
     def _extract_joins(self, parsed: exp.Expr, result: OBQCResult) -> None:
         """Extract join information from parsed query."""
-        alias_map = self._build_alias_map(parsed)
+        # Alias maps are built per SELECT. Table aliases are scoped to the
+        # query that declares them, and a subquery may reuse an outer one: a
+        # single map over the whole tree let "FROM order_items u" inside an
+        # EXISTS overwrite the outer "FROM users u", so the outer join's ON
+        # condition resolved to order_items and its fan-out was judged against
+        # the wrong table -- silently dropping a fan-trap warning.
+        for select in parsed.find_all(exp.Select):
+            alias_map = self._build_alias_map(select)
 
-        for join in parsed.find_all(exp.Join):
-            join_info: dict[str, Any] = {
-                "type": join.kind or "INNER",
-                "table": None,
-                "on_condition": None,
-                # Real table names referenced by the ON condition. Fan-trap
-                # detection needs to know which table this join attaches to,
-                # and the ON condition is the only place that says so.
-                "on_tables": [],
-            }
+            for join in select.args.get("joins") or []:
+                join_info: dict[str, Any] = {
+                    "type": join.kind or "INNER",
+                    "table": None,
+                    "on_condition": None,
+                    # Real table names referenced by the ON condition. Fan-trap
+                    # detection needs to know which table this join attaches
+                    # to, and the ON condition is the only place that says so.
+                    "on_tables": [],
+                }
 
-            # Get joined table
-            if join.this and isinstance(join.this, exp.Table):
-                join_info["table"] = join.this.name
+                # Get joined table
+                if join.this and isinstance(join.this, exp.Table):
+                    join_info["table"] = join.this.name
 
-            # Get ON condition
-            on_clause = join.args.get("on")
-            if on_clause is not None:
-                join_info["on_condition"] = on_clause.sql()
-                on_tables: list[str] = []
-                for column in on_clause.find_all(exp.Column):
-                    if not column.table:
-                        continue
-                    # Columns are qualified by alias far more often than by
-                    # table name, so resolve through the alias map.
-                    resolved = alias_map.get(column.table.lower(), column.table)
-                    if resolved not in on_tables:
-                        on_tables.append(resolved)
-                join_info["on_tables"] = on_tables
+                # Get ON condition
+                on_clause = join.args.get("on")
+                if on_clause is not None:
+                    join_info["on_condition"] = on_clause.sql()
+                    on_tables: list[str] = []
+                    for column in on_clause.find_all(exp.Column):
+                        if not column.table:
+                            continue
+                        # Columns are qualified by alias far more often than by
+                        # table name, so resolve through the alias map.
+                        resolved = alias_map.get(column.table.lower(), column.table)
+                        if resolved not in on_tables:
+                            on_tables.append(resolved)
+                    join_info["on_tables"] = on_tables
 
-            result.parsed_joins.append(join_info)
+                result.parsed_joins.append(join_info)
 
-    def _build_alias_map(self, parsed: exp.Expr) -> dict[str, str]:
-        """Map every table alias (and bare name) to its real table name.
+    def _build_alias_map(self, select: exp.Expr) -> dict[str, str]:
+        """Map one SELECT's table aliases (and bare names) to real table names.
+
+        Tables belonging to a nested subquery are excluded: their aliases live
+        in that subquery's scope and would otherwise shadow same-named ones
+        here.
 
         Args:
-            parsed: Parsed query.
+            select: The SELECT whose scope to map.
 
         Returns:
             Lower-cased alias -> table name. Bare names map to themselves so
             callers can look up unaliased references the same way.
         """
         alias_map: dict[str, str] = {}
-        for table in parsed.find_all(exp.Table):
+        for table in select.find_all(exp.Table):
             if not table.name:
+                continue
+            if table.find_ancestor(exp.Select) is not select:
                 continue
             alias_map[table.name.lower()] = table.name
             if table.alias:

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -834,6 +834,48 @@ class TestOBQCFanTrapDirection(unittest.TestCase):
             [i.message for i in result.issues],
         )
 
+    def test_subquery_alias_does_not_shadow_an_outer_join_anchor(self):
+        """Table aliases are scoped to the SELECT that declares them.
+
+        A single alias map over the whole tree let "FROM order_items u" inside
+        an EXISTS overwrite the outer "FROM users u", so the outer join was
+        judged against order_items instead of users -- and the fan-trap
+        warning silently disappeared.
+        """
+        base = (
+            "SELECT u.name, SUM(s.cost) FROM users u "
+            "JOIN orders o ON u.id = o.user_id "
+            "JOIN shipments s ON s.order_id = o.id GROUP BY u.name"
+        )
+        with_subquery = base.replace(
+            "GROUP BY u.name",
+            "WHERE EXISTS (SELECT 1 FROM order_items u WHERE u.order_id = o.id) "
+            "GROUP BY u.name",
+        )
+
+        baseline = self.validator.validate(base)
+        shadowed = self.validator.validate(with_subquery)
+
+        self.assertTrue(baseline.fan_trap_risk)
+        self.assertTrue(
+            shadowed.fan_trap_risk,
+            "subquery alias suppressed the outer query's fan-trap warning",
+        )
+
+    def test_outer_join_anchors_are_unaffected_by_a_subquery(self):
+        """The anchors themselves must be identical, warning aside."""
+        base = "SELECT u.name FROM users u JOIN orders o ON u.id = o.user_id"
+        with_subquery = (
+            "SELECT u.name FROM users u JOIN orders o ON u.id = o.user_id "
+            "WHERE EXISTS (SELECT 1 FROM order_items u WHERE u.order_id = o.id)"
+        )
+
+        baseline = self.validator.validate(base)
+        shadowed = self.validator.validate(with_subquery)
+
+        self.assertEqual(baseline.parsed_joins[0]["on_tables"], ["users", "orders"])
+        self.assertEqual(shadowed.parsed_joins[0]["on_tables"], ["users", "orders"])
+
     def test_unrelated_join_is_not_counted(self):
         """Tables with no ontology relationship cannot be judged to fan out."""
         result = self.validator.validate(

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -752,6 +752,207 @@ class TestOBQCFanTrapDetection(unittest.TestCase):
         self.assertFalse(result.fan_trap_risk)
 
 
+class TestOBQCFanTrapDirection(unittest.TestCase):
+    """Fan-out is a property of a join's direction, not of a table.
+
+    The heuristic asked whether a joined table sat on the "many" side of any
+    relationship anywhere in the schema, and counted once per matching
+    relationship rather than once per join. A dimension with its own foreign
+    keys therefore scored a fan-out for merely existing, so walking a chain of
+    many-to-one lookups -- where no row is ever duplicated -- drew a warning.
+    """
+
+    def setUp(self):
+        self.graph, self.base_uri = create_sample_ontology_graph()
+        self.validator = OBQCValidator()
+        self.validator.load_ontology(self.graph, self.base_uri)
+
+    def test_many_to_one_chain_is_not_a_fan_trap(self):
+        """order_items -> orders -> users: every hop is a lookup."""
+        result = self.validator.validate(
+            "SELECT users.name, SUM(orders.total) "
+            "FROM order_items "
+            "JOIN orders ON order_items.order_id = orders.id "
+            "JOIN users ON orders.user_id = users.id "
+            "GROUP BY users.name"
+        )
+
+        self.assertFalse(
+            result.fan_trap_risk,
+            [i.message for i in result.issues],
+        )
+
+    def test_many_to_one_chain_with_aliases_is_not_a_fan_trap(self):
+        """ON conditions are qualified by alias, so aliases must resolve."""
+        result = self.validator.validate(
+            "SELECT u.name, COUNT(*) AS n, SUM(o.total) AS lifetime_value "
+            "FROM public.order_items oi "
+            "JOIN public.orders o ON oi.order_id = o.id "
+            "JOIN public.users u ON o.user_id = u.id "
+            "GROUP BY u.name ORDER BY SUM(o.total) DESC"
+        )
+
+        self.assertFalse(
+            result.fan_trap_risk,
+            [i.message for i in result.issues],
+        )
+
+    def test_two_facts_on_one_dimension_is_still_a_fan_trap(self):
+        """The true positive must survive: orders fans out twice."""
+        result = self.validator.validate(
+            "SELECT orders.id, SUM(order_items.quantity), SUM(shipments.cost) "
+            "FROM orders "
+            "JOIN order_items ON orders.id = order_items.order_id "
+            "JOIN shipments ON orders.id = shipments.order_id "
+            "GROUP BY orders.id"
+        )
+
+        self.assertTrue(result.fan_trap_risk)
+
+    def test_single_fan_out_join_is_not_flagged(self):
+        result = self.validator.validate(
+            "SELECT users.name, SUM(orders.total) "
+            "FROM users JOIN orders ON users.id = orders.user_id "
+            "GROUP BY users.name"
+        )
+
+        self.assertFalse(result.fan_trap_risk)
+
+    def test_direction_is_judged_per_join_not_per_relationship(self):
+        """Joining one dimension that has its own FK must score zero fan-outs.
+
+        orders references users, so the old rule counted 'orders' as a many
+        side even when the query joins *to* it from its own child.
+        """
+        result = self.validator.validate(
+            "SELECT SUM(order_items.quantity) "
+            "FROM order_items JOIN orders ON order_items.order_id = orders.id"
+        )
+
+        self.assertFalse(
+            result.fan_trap_risk,
+            [i.message for i in result.issues],
+        )
+
+    def test_unrelated_join_is_not_counted(self):
+        """Tables with no ontology relationship cannot be judged to fan out."""
+        result = self.validator.validate(
+            "SELECT SUM(orders.total) FROM orders "
+            "JOIN users ON orders.user_id = users.id "
+            "JOIN shipments ON shipments.order_id = orders.id"
+        )
+
+        # shipments fans out from orders; users does not. One fan-out only.
+        self.assertFalse(
+            result.fan_trap_risk,
+            [i.message for i in result.issues],
+        )
+
+
+class TestOBQCFanTrapDimensionWithOwnKeys(unittest.TestCase):
+    """A dimension carrying several foreign keys must not manufacture fan-outs.
+
+    This is the reported false positive, and it needs a dimension with two
+    outgoing FKs to reproduce: the old rule incremented once per matching
+    *relationship* rather than once per join, so joining that one dimension
+    scored two fan-outs by itself and crossed the warning threshold -- even
+    though the query only walks many-to-one lookups.
+    """
+
+    def setUp(self):
+        from src.database_manager import ColumnInfo, TableInfo
+        from src.ontology_generator import OntologyGenerator
+
+        def col(name, fk_to=None, pk=False):
+            return ColumnInfo(
+                name=name,
+                data_type="INTEGER",
+                is_nullable=False,
+                is_primary_key=pk,
+                is_foreign_key=fk_to is not None,
+                foreign_key_table=fk_to,
+                foreign_key_column="id" if fk_to else None,
+            )
+
+        def fk(column, to_table):
+            return {
+                "column": column,
+                "referenced_table": to_table,
+                "referenced_column": "id",
+            }
+
+        tables = [
+            TableInfo(
+                name="sales",
+                schema="public",
+                columns=[col("id", pk=True), col("client_id", "clients")],
+                primary_keys=["id"],
+                foreign_keys=[fk("client_id", "clients")],
+            ),
+            # Two outgoing FKs -- the shape that triggered the false positive.
+            TableInfo(
+                name="clients",
+                schema="public",
+                columns=[
+                    col("id", pk=True),
+                    col("country_id", "countries"),
+                    col("region_id", "regions"),
+                ],
+                primary_keys=["id"],
+                foreign_keys=[
+                    fk("country_id", "countries"),
+                    fk("region_id", "regions"),
+                ],
+            ),
+            TableInfo(
+                name="countries",
+                schema="public",
+                columns=[col("id", pk=True)],
+                primary_keys=["id"],
+                foreign_keys=[],
+            ),
+            TableInfo(
+                name="regions",
+                schema="public",
+                columns=[col("id", pk=True)],
+                primary_keys=["id"],
+                foreign_keys=[],
+            ),
+        ]
+
+        generator = OntologyGenerator()
+        generator.generate_from_schema(tables)
+        self.validator = OBQCValidator()
+        self.validator.load_ontology(generator.graph, str(generator.base_uri))
+
+    def test_dimension_chain_is_not_flagged(self):
+        """many sales -> one client -> one country: nothing is duplicated."""
+        result = self.validator.validate(
+            "SELECT co.id, COUNT(*) AS orders, SUM(s.id) AS total "
+            "FROM sales s "
+            "JOIN clients cl ON s.client_id = cl.id "
+            "JOIN countries co ON cl.country_id = co.id "
+            "GROUP BY co.id"
+        )
+
+        self.assertFalse(
+            result.fan_trap_risk,
+            [i.message for i in result.issues],
+        )
+
+    def test_real_fan_out_in_the_same_schema_is_still_flagged(self):
+        """Joining the fact from two directions still multiplies rows."""
+        result = self.validator.validate(
+            "SELECT cl.id, SUM(s1.id), SUM(s2.id) "
+            "FROM clients cl "
+            "JOIN sales s1 ON s1.client_id = cl.id "
+            "JOIN sales s2 ON s2.client_id = cl.id "
+            "GROUP BY cl.id"
+        )
+
+        self.assertTrue(result.fan_trap_risk)
+
+
 class TestOBQCAxiomDrivenFanTrap(unittest.TestCase):
     """Phase 2: fan-trap detection grounded in owl:disjointWith axioms."""
 


### PR DESCRIPTION
**Stacked on #84** (which is on #83) — all three change `obqc_validator.py`. Review order: #83 → #84 → this.

## Problem

Reported: a correct top-customers query drew `Potential fan-trap: 2 one-to-many joins with aggregation`.

```sql
FROM sales s
JOIN clients   cl ON s.salesclient      = cl.clientid
JOIN countries co ON cl.clientcountryid = co.countryid
```

Many sales → one client → one country. Nothing is ever duplicated and `SUM(salesamount)` is exact.

The heuristic had two independent defects:

1. **Direction was never checked.** It asked whether the joined table was on the "many" side of *any relationship anywhere in the schema* — not whether it fans out from the table it actually joins to. `clients` counted because it references `countries`, which is irrelevant to `sales JOIN clients`.
2. **It counted relationships, not joins.** The inner loop incremented per matching relationship. `clients` carries two FKs, so that **one join scored two fan-outs by itself** and crossed the threshold alone. This is why the count read 2 with only two joins in the query.

## Fix

Judge each join against the table its `ON` condition anchors to, and count it only when the joined table is the many side of *that* relationship. `ON` conditions are qualified by alias far more often than by table name, so aliases are resolved to real table names first.

```
sales -> clients -> countries  (aliased, schema-qualified)   -> no warning
orders JOIN order_items JOIN shipments                       -> still flagged
users JOIN orders (single fan-out)                           -> not flagged
```

## Honest note on the tests

8 new tests, but **only one of them discriminates this bug**: `test_dimension_chain_is_not_flagged`, which needs a purpose-built ontology where a dimension carries *two* outgoing FKs — otherwise the old rule never reaches the threshold of 2 and the false positive cannot be reproduced.

My first attempt at a test class (`TestOBQCFanTrapDirection`, 6 tests) passes against the **original** code as well. I verified that by reverting and re-running, and kept those tests as behavioural guards rather than deleting them — but they document intent, they do not catch this regression. Flagging it so a green suite is not mistaken for proof.

Verified non-vacuous against the original rule:

```
FAILED TestOBQCFanTrapDimensionWithOwnKeys::test_dimension_chain_is_not_flagged
```

Full suite: **648 passed**, 74 subtests. mypy + ruff clean.

## Scope

The axiom-driven path (`owl:disjointWith` sibling facts) is untouched — it runs first and is unaffected. This only changes the heuristic fallback used when the ontology carries no disjointness axioms. The blocking multi-fact guard you saw fire correctly on `sales × returns × shipments` is that axiom path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)