### PR TITLE
fix(obqc): apply validation rules per SELECT, not across the query

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ connect_database("postgresql") -> execute_sql_query(...)
 | [Tools Reference](docs/tools-reference.md)         | Full parameter docs, return values, and usage examples                        |
 | [Configuration](docs/configuration.md)             | Environment variables, transport setup, troubleshooting                       |
 | [GraphRAG](docs/graphrag.md)                       | Graph-based schema intelligence and OBML workflow                             |
+| [OBQC Overview](docs/obqc-overview.md)             | Short explanation of how OBQC works inside OrionBelt Analytics                |
 | [OBQC](docs/obqc.md)                               | Validation rules, severity levels, blocking behavior, annotation requirements |
 | [Fan-Trap Prevention](docs/fan-trap-prevention.md) | The fan-trap problem, detection, and safe SQL patterns                        |
 | [Integrations](docs/integrations.md)               | LangChain, OpenAI, CrewAI, Google ADK, Vercel, n8n, ChatGPT                   |

--- a/docs/obqc-overview.md
+++ b/docs/obqc-overview.md
@@ -1,0 +1,109 @@
+# OBQC in OrionBelt Analytics
+
+OBQC means **Ontology-Based Query Check**. In OrionBelt Analytics (OBA), it is
+the deterministic safety layer that checks SQL against the loaded RDF/OWL
+ontology before a query is allowed to reach the database.
+
+OBQC does not call an LLM. It parses SQL, compares the query structure with the
+ontology, and returns structured errors or warnings that the calling assistant
+can use to correct the SQL.
+
+## Why OBA Uses OBQC
+
+LLMs can generate plausible SQL that is still structurally wrong. Typical
+failures include misspelled columns, joins that do not follow foreign keys,
+missing `GROUP BY` columns, and analytical fan-traps that silently multiply
+totals.
+
+OBQC gives OBA a deterministic check after SQL generation and before execution:
+
+- **Errors block execution.** The query is not sent to the database.
+- **Warnings allow execution.** The warning is returned with the result so the
+  assistant can explain or revise the query.
+- **No ontology means limited validation.** OBA can still do syntax and security
+  checks, but semantic validation needs an OrionBelt ontology.
+
+## How It Works
+
+1. OBA connects to a database and discovers the schema.
+2. `generate_ontology()` or `load_my_ontology()` creates or loads an ontology
+   with `oba:` annotations for tables, columns, SQL types, primary keys, foreign
+   keys, join conditions, and relationship direction.
+3. OBA creates a session-local `OBQCValidator` from that ontology.
+4. When `execute_sql_query()` receives SQL, OBQC parses it with `sqlglot`.
+5. OBQC extracts the referenced tables, columns, joins, aggregations, aliases,
+   and join anchors.
+6. OBQC validates those parts against the ontology cache.
+7. If the query has no blocking errors, OBA executes it and attaches any OBQC
+   warnings to the response.
+
+`execute_sql_query()` is the only entry point that runs OBQC. The separate
+security and dialect-syntax checks in `DatabaseManager.validate_sql_syntax()`
+are unrelated to it and carry no ontology awareness.
+
+In the main execution path, `execute_sql_query()` runs OBQC before database
+execution. If OBQC returns an error, OBA returns an `obqc_error` response instead
+of executing the SQL.
+
+## What OBQC Checks
+
+| Check | Purpose |
+| --- | --- |
+| Table existence | Every referenced table must exist in the ontology. |
+| Column existence | Qualified and unqualified columns must resolve to real columns. |
+| Join validity | Joins should match declared ontology relationships. |
+| Type compatibility | `WHERE` and `ON` comparisons should use compatible types. |
+| Aggregation correctness | Non-aggregated selected columns must be in `GROUP BY`. |
+| Fan-trap risk | Aggregations across multiple fan-out joins are flagged. |
+
+Three things sit outside those rules, because treating them as violations
+blocked correct SQL:
+
+- **Database catalog schemas are exempt from the table rule.** `information_schema`,
+  `pg_catalog`, `system` and friends describe the database itself, so they are
+  never in an ontology of user data. MySQL's `mysql` schema is deliberately not
+  exempt -- it holds accounts and grants rather than metadata, and
+  `src/security.py` blocks those tables outright.
+- **`SELECT` aliases are not columns.** `ORDER BY revenue` over
+  `SUM(total) AS revenue` resolves to the select list. Where an alias may be
+  referenced varies by database, so OBQC follows each dialect: PostgreSQL
+  accepts one in `GROUP BY` and `ORDER BY` but not `HAVING`, while DuckDB
+  resolves aliases in every clause including `WHERE`.
+- **Rules apply per `SELECT`.** Tables, columns and aggregation in a subquery
+  belong to that subquery. A name in one scope is not resolved against another,
+  except that a correlated subquery may still see its enclosing query's tables.
+
+## Fan-Trap Protection
+
+A fan-trap happens when a query aggregates after joining across multiple
+one-to-many paths. The SQL may run successfully, but totals can be inflated
+because rows are multiplied before aggregation.
+
+OBQC checks fan-traps in two ways:
+
+- It first uses ontology axioms such as `owl:disjointWith` for sibling fact
+  tables that share a dimension.
+- If those axioms are not present, it uses relationship metadata and join
+  direction to count fan-out joins in the actual query.
+
+The direction matters: joining from a fact table to a dimension is usually a
+lookup, while joining from a dimension to multiple fact tables can multiply
+rows. OBQC judges fan-out per join, not just by asking whether a table is on the
+many side somewhere in the schema.
+
+## Example Flow
+
+```text
+connect_database()
+  -> discover_schema()
+  -> generate_ontology()
+  -> execute_sql_query()
+       -> OBQC parses SQL
+       -> OBQC checks ontology rules
+       -> errors block, warnings attach
+       -> database execution only if valid
+```
+
+For detailed rule behavior, severity handling, and required ontology
+annotations, see [OBQC -- Ontology-Based Query Check](obqc.md). For analytical
+data multiplication examples, see [Fan-Trap Prevention](fan-trap-prevention.md).

--- a/docs/obqc.md
+++ b/docs/obqc.md
@@ -42,6 +42,8 @@ SELECT * FROM cusotmers;
 
 When a table is not found, OBQC suggests up to 10 available table names from the ontology.
 
+Tables reached through a database catalog schema -- `information_schema`, `pg_catalog`, `system`, `performance_schema`, `snowflake`, `sys` -- are exempt: they describe the database rather than user data, so they are never part of a generated ontology. MySQL's `mysql` schema is **not** exempt, because it holds accounts and grants rather than metadata; `src/security.py` blocks those tables outright. A bare name that merely looks like a catalog table (`FROM tables`) is still checked.
+
 ### Column existence (ERROR)
 
 Checks that every column reference resolves to an actual column in its table.
@@ -51,7 +53,12 @@ Checks that every column reference resolves to an actual column in its table.
 SELECT emial FROM customers;
 ```
 
-For qualified references (`table.column`), the column is checked against the specific table. For unqualified references, OBQC searches all tables in the query.
+For qualified references (`table.column`), the column is checked against the specific table. For unqualified references, OBQC searches the tables in that reference's own scope -- the `SELECT` it appears in, plus any enclosing ones, so a correlated subquery can still use the outer query's tables. A subquery's tables never resolve names in the outer query.
+
+Two kinds of name are not columns and are not reported missing:
+
+- **`SELECT` aliases** referenced from a later clause. `ORDER BY revenue` over `SUM(total) AS revenue` resolves to the select list. Visibility follows the dialect: PostgreSQL allows an output name in `GROUP BY` and `ORDER BY` but not `HAVING` or `WHERE`, and only as a whole sort key (`ORDER BY t + 1` is an expression over input columns); DuckDB resolves aliases in every clause. A name that is *both* an alias and a real column resolves to the column.
+- **Columns of a catalog table**, which the ontology does not describe. If a query touches one, an unqualified name that matches no user table is left alone rather than reported.
 
 ### Ambiguous columns (WARNING)
 
@@ -68,11 +75,18 @@ OBQC suggests qualifying the column with the table name.
 
 #### Missing join condition (ERROR)
 
-Multiple tables in the query without explicit `JOIN ... ON` conditions (Cartesian product).
+Multiple tables in the same `SELECT` without explicit `JOIN ... ON` conditions (Cartesian product).
 
 ```sql
 -- ERROR: Multiple tables without explicit JOIN (Cartesian product)
 SELECT * FROM customers, orders;
+```
+
+Judged per `SELECT`. A subquery contributes its own tables to its own scope, so this is fine:
+
+```sql
+-- OK: one table per SELECT
+SELECT id FROM customers WHERE id IN (SELECT customer_id FROM orders);
 ```
 
 #### Non-matching join condition (WARNING)
@@ -98,7 +112,9 @@ Comparisons within the same category are allowed (e.g. integer vs. decimal). Com
 
 ### Aggregation correctness (ERROR)
 
-When aggregate functions (`SUM`, `COUNT`, `AVG`, `MIN`, `MAX`) are used, OBQC checks that all non-aggregated columns in `SELECT` appear in `GROUP BY`.
+When aggregate functions (`SUM`, `COUNT`, `AVG`, `MIN`, `MAX`) are used, OBQC checks that all non-aggregated columns in `SELECT` appear in `GROUP BY`. Grouping by an alias satisfies the check on the column it stands for.
+
+Evaluated per `SELECT`: an aggregate inside a subquery belongs to that subquery, so `SELECT name FROM users WHERE id = (SELECT MAX(user_id) FROM orders)` needs no `GROUP BY` in the outer query.
 
 ```sql
 -- ERROR: Column 'name' in SELECT with aggregation but no GROUP BY
@@ -111,6 +127,8 @@ SELECT status, region, SUM(amount) FROM orders GROUP BY region;
 ### Fan-trap detection (WARNING)
 
 Detects when a query aggregates across two or more one-to-many joins. This is the classic fan-trap pattern where rows multiply silently, producing inflated aggregation results.
+
+Fan-out is judged per join, against the table that join's `ON` condition attaches to -- not by asking whether a table sits on the many side of some relationship elsewhere in the schema. Walking a chain of many-to-one lookups (`sales` -> `clients` -> `countries`) duplicates nothing and is not flagged, however many foreign keys those dimensions carry.
 
 ```sql
 -- WARNING: Potential fan-trap: 2 one-to-many joins with aggregation

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -154,6 +154,10 @@ class OBQCResult:
         default_factory=list
     )
     parsed_joins: list[dict[str, Any]] = field(default_factory=list)
+    # Tables of each SELECT that applies an aggregate, in its own scope. Only
+    # these can be multiplied by that SELECT's joins, so fan-trap rules judge
+    # them rather than every table named anywhere in the query.
+    aggregating_scopes: list[tuple[str, ...]] = field(default_factory=list)
     has_aggregation: bool = False
     has_group_by: bool = False
     fan_trap_risk: bool = False
@@ -739,6 +743,16 @@ class OBQCValidator:
             # inflates a total if the aggregation happens over these joins --
             # an aggregate in some unrelated subquery does not.
             scope_aggregates = self._select_aggregates(select)
+            if scope_aggregates:
+                result.aggregating_scopes.append(
+                    tuple(
+                        dict.fromkeys(
+                            t.name
+                            for t in select.find_all(exp.Table)
+                            if t.name and t.find_ancestor(exp.Select) is select
+                        )
+                    )
+                )
 
             for join in select.args.get("joins") or []:
                 join_info: dict[str, Any] = {
@@ -1372,11 +1386,17 @@ class OBQCValidator:
         if self._schema_cache is None:
             return
 
-        # --- Axiom-grounded path: disjoint sibling facts in the same query ----
-        queried = {t.lower() for t in result.parsed_tables}
-        disjoint_hits: set[frozenset] = {
-            pair for pair in self._disjoint_pairs if pair <= queried
-        }
+        # --- Axiom-grounded path: disjoint sibling facts in one SELECT --------
+        #
+        # Scoped like the heuristic below. Reading the disjoint pair off every
+        # table named in the query flagged a fact that only appears inside a
+        # semi-join filter: "... FROM customers JOIN orders ... WHERE EXISTS
+        # (SELECT 1 FROM returns ...)" aggregates orders alone, and returns
+        # cannot multiply its rows from inside the subquery.
+        disjoint_hits: set[frozenset] = set()
+        for scope in result.aggregating_scopes:
+            queried = {t.lower() for t in scope}
+            disjoint_hits |= {pair for pair in self._disjoint_pairs if pair <= queried}
         if disjoint_hits:
             result.fan_trap_risk = True
             involved = sorted({t for pair in disjoint_hits for t in pair})

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -760,6 +760,9 @@ class OBQCValidator:
                     "table": None,
                     "on_condition": None,
                     "scope_aggregates": scope_aggregates,
+                    # Identifies the owning SELECT so fan-out is counted within
+                    # one query rather than pooled across unrelated ones.
+                    "scope_id": id(select),
                     # Real table names referenced by the ON condition. Fan-trap
                     # detection needs to know which table this join attaches
                     # to, and the ON condition is the only place that says so.
@@ -1433,8 +1436,11 @@ class OBQCValidator:
         # existing: "sales JOIN clients JOIN countries" -- many sales to one
         # client to one country, where no row is ever duplicated -- was warned
         # about because clients happens to reference countries.
-        one_to_many_count = 0
-        involved_tables: list[str] = []
+        # Counted within each aggregating SELECT, not pooled across them. Rows
+        # are multiplied by joins in the same query, so two subqueries that
+        # fan out once each are two safe aggregations -- summing them reported
+        # a fan-trap that exists in neither.
+        fan_outs_by_scope: dict[Any, list[str]] = {}
 
         # Only joins sitting in an aggregating SELECT; a subquery's joins
         # cannot multiply rows the outer query aggregates.
@@ -1454,8 +1460,12 @@ class OBQCValidator:
                 continue
 
             if any(self._join_fans_out(join_table, anchor) for anchor in anchors):
-                one_to_many_count += 1
-                involved_tables.append(join_table)
+                scope_id = join_info.get("scope_id")
+                fan_outs_by_scope.setdefault(scope_id, []).append(join_table)
+
+        worst_scope = max(fan_outs_by_scope.values(), key=len, default=[])
+        one_to_many_count = len(worst_scope)
+        involved_tables = worst_scope
 
         if one_to_many_count >= 2:
             result.fan_trap_risk = True

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -8,7 +8,7 @@ and fan-trap patterns without using LLM.
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import Any, ClassVar
 
 import sqlglot
 from rdflib import Graph, Namespace, URIRef
@@ -163,6 +163,17 @@ class OBQCResult:
     fan_trap_risk: bool = False
     ontology_compatible: bool = True  # Whether ontology has oba: annotations
 
+    # Keys of parsed_joins that belong in a response. Everything else the
+    # extractor records is bookkeeping for the validation rules and must not
+    # reach a caller -- notably scope_id, which identifies a SELECT within one
+    # parse and means nothing outside it.
+    PUBLIC_JOIN_KEYS: ClassVar[tuple[str, ...]] = (
+        "type",
+        "table",
+        "on_condition",
+        "on_tables",
+    )
+
     def to_dict(self) -> dict[str, Any]:
         """Convert result to dictionary for JSON serialization."""
         return {
@@ -181,7 +192,10 @@ class OBQCResult:
             ],
             "parsed_tables": self.parsed_tables,
             "parsed_columns": self.parsed_columns,
-            "parsed_joins": self.parsed_joins,
+            "parsed_joins": [
+                {k: j[k] for k in self.PUBLIC_JOIN_KEYS if k in j}
+                for j in self.parsed_joins
+            ],
             "has_aggregation": self.has_aggregation,
             "has_group_by": self.has_group_by,
             "fan_trap_risk": self.fan_trap_risk,
@@ -737,7 +751,7 @@ class OBQCValidator:
         # EXISTS overwrite the outer "FROM users u", so the outer join's ON
         # condition resolved to order_items and its fan-out was judged against
         # the wrong table -- silently dropping a fan-trap warning.
-        for select in parsed.find_all(exp.Select):
+        for scope_index, select in enumerate(parsed.find_all(exp.Select)):
             alias_map = self._build_alias_map(select)
             # Whether the SELECT owning these joins aggregates. Fan-out only
             # inflates a total if the aggregation happens over these joins --
@@ -761,8 +775,10 @@ class OBQCValidator:
                     "on_condition": None,
                     "scope_aggregates": scope_aggregates,
                     # Identifies the owning SELECT so fan-out is counted within
-                    # one query rather than pooled across unrelated ones.
-                    "scope_id": id(select),
+                    # one query rather than pooled across unrelated ones. A
+                    # traversal index, not id(select): object addresses vary
+                    # per run, and this value must never reach a response.
+                    "scope_id": scope_index,
                     # Real table names referenced by the ON condition. Fan-trap
                     # detection needs to know which table this join attaches
                     # to, and the ON condition is the only place that says so.

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -147,6 +147,10 @@ class OBQCResult:
     # Lower-cased SELECT aliases referenced from ORDER BY / GROUP BY / HAVING.
     # They resolve to select-list output, not to any table's column.
     select_aliases: set[str] = field(default_factory=set)
+    # (column reference, tables it may resolve against) per occurrence. Name
+    # resolution is scoped to the SELECT a column appears in plus its enclosing
+    # ones, so a subquery's tables cannot answer for the outer query.
+    column_scopes: list[tuple[str, tuple[str, ...]]] = field(default_factory=list)
     parsed_joins: list[dict[str, Any]] = field(default_factory=list)
     has_aggregation: bool = False
     has_group_by: bool = False
@@ -504,7 +508,7 @@ class OBQCValidator:
         # Run validation rules
         self._validate_tables(result)
         self._validate_columns(result)
-        self._validate_joins(result)
+        self._validate_joins(parsed, result)
         self._validate_type_compatibility(parsed, result)
         self._validate_aggregation_context(parsed, result)
         self._detect_fan_trap(result)
@@ -552,6 +556,7 @@ class OBQCValidator:
     ) -> None:
         """Extract column references, excluding legal SELECT-alias references."""
         alias_refs = self._select_alias_references(parsed, result, dialect)
+        scope_cache: dict[int, tuple[str, ...]] = {}
 
         for column in parsed.find_all(exp.Column):
             # Alias references resolve to the select list, not to a table, so
@@ -564,8 +569,52 @@ class OBQCValidator:
             col_ref = column.name
             if column.table:
                 col_ref = f"{column.table}.{column.name}"
-            if col_ref and col_ref not in result.parsed_columns:
+            if not col_ref:
+                continue
+            if col_ref not in result.parsed_columns:
                 result.parsed_columns.append(col_ref)
+
+            # Which tables the name could resolve against, which is a property
+            # of where it appears. Resolving against every table in the query
+            # let a subquery's table answer for the outer SELECT: "SELECT
+            # quantity FROM users WHERE id IN (SELECT order_id FROM
+            # order_items)" found quantity in order_items and reported nothing.
+            owner = column.find_ancestor(exp.Select)
+            scope = self._scope_tables(owner, scope_cache) if owner else ()
+            entry = (col_ref, scope)
+            if entry not in result.column_scopes:
+                result.column_scopes.append(entry)
+
+    def _scope_tables(
+        self, select: exp.Select, cache: dict[int, tuple[str, ...]]
+    ) -> tuple[str, ...]:
+        """Tables a name in *select* may resolve against, innermost first.
+
+        Includes the enclosing SELECTs' tables: a correlated subquery legally
+        references them, so omitting them would report those names as missing.
+
+        Args:
+            select: The SELECT a column appears in.
+            cache: Memo keyed by ``id(select)``.
+
+        Returns:
+            Table names in scope, without duplicates.
+        """
+        cached = cache.get(id(select))
+        if cached is not None:
+            return cached
+
+        own = [
+            t.name
+            for t in select.find_all(exp.Table)
+            if t.name and t.find_ancestor(exp.Select) is select
+        ]
+        parent = select.parent_select
+        outer = self._scope_tables(parent, cache) if parent is not None else ()
+
+        tables = tuple(dict.fromkeys([*own, *outer]))
+        cache[id(select)] = tables
+        return tables
 
     def _select_alias_references(
         self, parsed: exp.Expr, result: OBQCResult, dialect: str
@@ -774,7 +823,7 @@ class OBQCValidator:
         if self._schema_cache is None:
             return
 
-        for col_ref in result.parsed_columns:
+        for col_ref, scope in result.column_scopes:
             if "." in col_ref:
                 parts = col_ref.split(".", 1)
                 table_name, col_name = parts[0], parts[1]
@@ -801,8 +850,8 @@ class OBQCValidator:
 
                 found_in_tables: list[str] = []
 
-                # Only check tables that are actually in the query
-                for table_name in result.parsed_tables:
+                # Only tables in this reference's own scope
+                for table_name in scope:
                     table_key = table_name.lower()
                     if (
                         table_key in self._schema_cache.tables
@@ -817,11 +866,9 @@ class OBQCValidator:
                 # table in the query is describable can a missing name be
                 # called missing.
                 describable_tables = [
-                    t for t in result.parsed_tables if t not in result.catalog_tables
+                    t for t in scope if t not in result.catalog_tables
                 ]
-                all_tables_describable = len(describable_tables) == len(
-                    result.parsed_tables
-                )
+                all_tables_describable = len(describable_tables) == len(scope)
 
                 if (
                     len(found_in_tables) == 0
@@ -848,12 +895,39 @@ class OBQCValidator:
                         )
                     )
 
-    def _validate_joins(self, result: OBQCResult) -> None:
-        """Rule: Validate joins use declared FK relationships."""
-        if len(result.parsed_tables) < 2:
-            return  # No joins needed for single table
+    def _flag_cartesian_products(self, parsed: exp.Expr, result: OBQCResult) -> bool:
+        """Report SELECTs that combine tables without any join condition.
 
-        if len(result.parsed_tables) > 1 and len(result.parsed_joins) == 0:
+        Judged per SELECT. Counting tables and joins across the whole query
+        made every subquery look like a cross product: "SELECT id FROM users
+        WHERE id IN (SELECT user_id FROM orders)" has two tables and no joins
+        in total, so it was rejected outright even though each SELECT is
+        perfectly ordinary.
+
+        Args:
+            parsed: Parsed query.
+            result: Result to append issues to.
+
+        Returns:
+            True if a cross product was reported.
+        """
+        found = False
+
+        for select in parsed.find_all(exp.Select):
+            tables = [
+                t
+                for t in select.find_all(exp.Table)
+                if t.name and t.find_ancestor(exp.Select) is select
+            ]
+            if len(tables) < 2:
+                continue
+
+            # Comma-separated FROM items arrive as joins carrying no ON, so a
+            # cross product is a scope whose joins all lack one.
+            joins = select.args.get("joins") or []
+            if joins and any(join.args.get("on") for join in joins):
+                continue
+
             result.issues.append(
                 OBQCIssue(
                     issue_type=OBQCIssueType.MISSING_JOIN_CONDITION,
@@ -863,7 +937,19 @@ class OBQCValidator:
                     suggestion="Add explicit JOIN ... ON conditions",
                 )
             )
+            found = True
+
+        return found
+
+    def _validate_joins(self, parsed: exp.Expr, result: OBQCResult) -> None:
+        """Rule: Validate joins use declared FK relationships."""
+        if self._flag_cartesian_products(parsed, result):
+            # A cross product is reported once per query; the per-join checks
+            # below would restate it as a missing ON condition.
             return
+
+        if len(result.parsed_tables) < 2:
+            return  # No joins needed for single table
 
         for join_info in result.parsed_joins:
             join_table = join_info.get("table")
@@ -1036,6 +1122,23 @@ class OBQCValidator:
         # Same category or unknown are compatible
         return cat1 == cat2 or cat1 == "unknown" or cat2 == "unknown"
 
+    def _select_aggregates(self, select: exp.Select) -> bool:
+        """Whether this SELECT itself applies an aggregate function.
+
+        Aggregates inside a nested subquery belong to that subquery, not here.
+
+        Args:
+            select: The SELECT to inspect.
+
+        Returns:
+            True if an aggregate call sits in this SELECT's own scope.
+        """
+        agg_types = (exp.Sum, exp.Count, exp.Avg, exp.Min, exp.Max)
+        return any(
+            agg.find_ancestor(exp.Select) is select
+            for agg in select.find_all(*agg_types)
+        )
+
     def _validate_aggregation_context(
         self, parsed: exp.Expr, result: OBQCResult
     ) -> None:
@@ -1044,6 +1147,14 @@ class OBQCValidator:
             return
 
         for select in parsed.find_all(exp.Select):
+            # Aggregation is a property of one SELECT. The query-wide flag above
+            # is true if an aggregate appears anywhere, so a subquery's SUM used
+            # to make the outer SELECT look like it aggregates -- and every
+            # plain column in it was reported as missing from a GROUP BY that
+            # the query never needed.
+            if not self._select_aggregates(select):
+                continue
+
             expressions = select.args.get("expressions", [])
 
             # Aliases declared by this select, mapped to the column they stand

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -150,7 +150,9 @@ class OBQCResult:
     # (column reference, tables it may resolve against) per occurrence. Name
     # resolution is scoped to the SELECT a column appears in plus its enclosing
     # ones, so a subquery's tables cannot answer for the outer query.
-    column_scopes: list[tuple[str, tuple[str, ...]]] = field(default_factory=list)
+    column_scopes: list[tuple[str, tuple[tuple[str, ...], ...]]] = field(
+        default_factory=list
+    )
     parsed_joins: list[dict[str, Any]] = field(default_factory=list)
     has_aggregation: bool = False
     has_group_by: bool = False
@@ -556,7 +558,7 @@ class OBQCValidator:
     ) -> None:
         """Extract column references, excluding legal SELECT-alias references."""
         alias_refs = self._select_alias_references(parsed, result, dialect)
-        scope_cache: dict[int, tuple[str, ...]] = {}
+        scope_cache: dict[int, tuple[tuple[str, ...], ...]] = {}
 
         for column in parsed.find_all(exp.Column):
             # Alias references resolve to the select list, not to a table, so
@@ -586,35 +588,43 @@ class OBQCValidator:
                 result.column_scopes.append(entry)
 
     def _scope_tables(
-        self, select: exp.Select, cache: dict[int, tuple[str, ...]]
-    ) -> tuple[str, ...]:
-        """Tables a name in *select* may resolve against, innermost first.
+        self, select: exp.Select, cache: dict[int, tuple[tuple[str, ...], ...]]
+    ) -> tuple[tuple[str, ...], ...]:
+        """Tables a name in *select* may resolve against, innermost level first.
 
-        Includes the enclosing SELECTs' tables: a correlated subquery legally
-        references them, so omitting them would report those names as missing.
+        Returned as levels rather than one flat set because SQL resolves a name
+        in the innermost scope that provides it and stops. Flattening made
+        ``SELECT name FROM users WHERE EXISTS (SELECT 1 FROM orders WHERE id =
+        user_id)`` look ambiguous between orders.id and users.id, when the
+        inner ``id`` is simply orders.id.
+
+        Enclosing levels are still included: a correlated subquery legally
+        references them, so dropping them would report those names as missing.
 
         Args:
             select: The SELECT a column appears in.
             cache: Memo keyed by ``id(select)``.
 
         Returns:
-            Table names in scope, without duplicates.
+            One tuple of table names per scope level, innermost first.
         """
         cached = cache.get(id(select))
         if cached is not None:
             return cached
 
-        own = [
-            t.name
-            for t in select.find_all(exp.Table)
-            if t.name and t.find_ancestor(exp.Select) is select
-        ]
+        own = tuple(
+            dict.fromkeys(
+                t.name
+                for t in select.find_all(exp.Table)
+                if t.name and t.find_ancestor(exp.Select) is select
+            )
+        )
         parent = select.parent_select
         outer = self._scope_tables(parent, cache) if parent is not None else ()
 
-        tables = tuple(dict.fromkeys([*own, *outer]))
-        cache[id(select)] = tables
-        return tables
+        levels = (own, *outer) if own else outer
+        cache[id(select)] = levels
+        return levels
 
     def _select_alias_references(
         self, parsed: exp.Expr, result: OBQCResult, dialect: str
@@ -725,12 +735,17 @@ class OBQCValidator:
         # the wrong table -- silently dropping a fan-trap warning.
         for select in parsed.find_all(exp.Select):
             alias_map = self._build_alias_map(select)
+            # Whether the SELECT owning these joins aggregates. Fan-out only
+            # inflates a total if the aggregation happens over these joins --
+            # an aggregate in some unrelated subquery does not.
+            scope_aggregates = self._select_aggregates(select)
 
             for join in select.args.get("joins") or []:
                 join_info: dict[str, Any] = {
                     "type": join.kind or "INNER",
                     "table": None,
                     "on_condition": None,
+                    "scope_aggregates": scope_aggregates,
                     # Real table names referenced by the ON condition. Fan-trap
                     # detection needs to know which table this join attaches
                     # to, and the ON condition is the only place that says so.
@@ -848,16 +863,24 @@ class OBQCValidator:
                 # Unqualified column - check for ambiguity
                 col_key = col_ref.lower()
 
+                # Innermost level that provides the name wins; SQL stops there,
+                # so tables further out are not candidates and cannot make it
+                # ambiguous.
                 found_in_tables: list[str] = []
 
-                # Only tables in this reference's own scope
-                for table_name in scope:
-                    table_key = table_name.lower()
-                    if (
-                        table_key in self._schema_cache.tables
-                        and col_key in self._schema_cache.tables[table_key].columns
-                    ):
-                        found_in_tables.append(table_name)
+                for level in scope:
+                    matches = [
+                        table_name
+                        for table_name in level
+                        if (
+                            table_name.lower() in self._schema_cache.tables
+                            and col_key
+                            in self._schema_cache.tables[table_name.lower()].columns
+                        )
+                    ]
+                    if matches:
+                        found_in_tables = matches
+                        break
 
                 # Columns of a catalog table cannot be resolved -- the ontology
                 # does not describe them. If the query touches one at all, an
@@ -865,10 +888,13 @@ class OBQCValidator:
                 # its column, so there is nothing to report. Only when every
                 # table in the query is describable can a missing name be
                 # called missing.
+                # Unresolved names are judged against every level, since any of
+                # them could legitimately have provided the name.
+                visible = [t for level in scope for t in level]
                 describable_tables = [
-                    t for t in scope if t not in result.catalog_tables
+                    t for t in visible if t not in result.catalog_tables
                 ]
-                all_tables_describable = len(describable_tables) == len(scope)
+                all_tables_describable = len(describable_tables) == len(visible)
 
                 if (
                     len(found_in_tables) == 0
@@ -1122,6 +1148,22 @@ class OBQCValidator:
         # Same category or unknown are compatible
         return cat1 == cat2 or cat1 == "unknown" or cat2 == "unknown"
 
+    def _own_aggregates(self, select: exp.Select) -> list[Any]:
+        """Aggregate calls belonging to this SELECT's own scope.
+
+        Args:
+            select: The SELECT to inspect.
+
+        Returns:
+            Aggregate expressions whose nearest enclosing SELECT is *select*.
+        """
+        agg_types = (exp.Sum, exp.Count, exp.Avg, exp.Min, exp.Max)
+        return [
+            agg
+            for agg in select.find_all(*agg_types)
+            if agg.find_ancestor(exp.Select) is select
+        ]
+
     def _select_aggregates(self, select: exp.Select) -> bool:
         """Whether this SELECT itself applies an aggregate function.
 
@@ -1133,11 +1175,7 @@ class OBQCValidator:
         Returns:
             True if an aggregate call sits in this SELECT's own scope.
         """
-        agg_types = (exp.Sum, exp.Count, exp.Avg, exp.Min, exp.Max)
-        return any(
-            agg.find_ancestor(exp.Select) is select
-            for agg in select.find_all(*agg_types)
-        )
+        return bool(self._own_aggregates(select))
 
     def _validate_aggregation_context(
         self, parsed: exp.Expr, result: OBQCResult
@@ -1249,10 +1287,13 @@ class OBQCValidator:
                                 )
 
     def _is_inside_aggregate(self, expr: exp.Expression, select: exp.Select) -> bool:
-        """Check if expression is inside an aggregate function."""
-        agg_types = (exp.Sum, exp.Count, exp.Avg, exp.Min, exp.Max)
+        """Check if expression is inside an aggregate function of this SELECT.
 
-        for agg in select.find_all(*agg_types):
+        Aggregates in a nested subquery are that subquery's; counting them here
+        made an outer column look aggregated because some inner aggregate
+        happened to mention the same name.
+        """
+        for agg in self._own_aggregates(select):
             for col in agg.find_all(exp.Column):
                 if (
                     isinstance(expr, exp.Column)
@@ -1315,7 +1356,14 @@ class OBQCValidator:
         ontology agree by construction. Falls back to the relationship heuristic
         when no disjointness axioms are present (e.g. minimal imports).
         """
-        if not result.has_aggregation:
+        # Only joins whose own SELECT aggregates can inflate a total. The
+        # query-wide flag is true if an aggregate appears anywhere, so an
+        # unrelated subquery's COUNT(*) used to raise a fan-trap warning about
+        # outer joins that aggregate nothing.
+        aggregating_joins = [
+            j for j in result.parsed_joins if j.get("scope_aggregates")
+        ]
+        if not aggregating_joins:
             return
 
         if len(result.parsed_tables) < 2:
@@ -1368,7 +1416,9 @@ class OBQCValidator:
         one_to_many_count = 0
         involved_tables: list[str] = []
 
-        for join_info in result.parsed_joins:
+        # Only joins sitting in an aggregating SELECT; a subquery's joins
+        # cannot multiply rows the outer query aggregates.
+        for join_info in aggregating_joins:
             join_table = join_info.get("table")
             if not join_table:
                 continue

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -1,11 +1,18 @@
 """Tests for OBQC (Ontology-Based Query Check) validator."""
 
+import json
 import unittest
 
 from rdflib import Graph, Literal, Namespace
 from rdflib.namespace import OWL, RDF, RDFS, XSD
 
-from src.obqc_validator import OBQCIssue, OBQCIssueType, OBQCSeverity, OBQCValidator
+from src.obqc_validator import (
+    OBQCIssue,
+    OBQCIssueType,
+    OBQCResult,
+    OBQCSeverity,
+    OBQCValidator,
+)
 
 
 def create_sample_ontology_graph() -> tuple[Graph, str]:
@@ -1334,6 +1341,52 @@ class TestOBQCAxiomDrivenFanTrap(unittest.TestCase):
         )
 
         self.assertTrue(result.fan_trap_risk)
+
+
+class TestOBQCResponseShape(unittest.TestCase):
+    """to_dict() is the wire format, so internal bookkeeping must not appear.
+
+    Fan-trap grouping needs to know which SELECT owns a join, but that is a
+    detail of one parse. Leaving it on the join dicts published it through
+    every execute_sql_query response.
+    """
+
+    def setUp(self):
+        self.graph, self.base_uri = create_sample_ontology_graph()
+        self.validator = OBQCValidator()
+        self.validator.load_ontology(self.graph, self.base_uri)
+        self.query = "SELECT u.name FROM users u JOIN orders o ON u.id = o.user_id"
+
+    def test_joins_expose_only_public_keys(self):
+        joins = self.validator.validate(self.query).to_dict()["parsed_joins"]
+
+        self.assertTrue(joins)
+        for join in joins:
+            self.assertEqual(
+                set(join) - set(OBQCResult.PUBLIC_JOIN_KEYS),
+                set(),
+                f"internal keys leaked into the response: {sorted(join)}",
+            )
+
+    def test_response_is_reproducible(self):
+        """An identifier tied to object identity varies between runs."""
+        first = self.validator.validate(self.query).to_dict()
+        second = self.validator.validate(self.query).to_dict()
+
+        self.assertEqual(first["parsed_joins"], second["parsed_joins"])
+
+    def test_response_is_json_serializable(self):
+        payload = self.validator.validate(self.query).to_dict()
+
+        json.dumps(payload)
+
+    def test_useful_join_details_are_still_published(self):
+        """Stripping internals must not strip what callers rely on."""
+        join = self.validator.validate(self.query).to_dict()["parsed_joins"][0]
+
+        self.assertEqual(join["table"], "orders")
+        self.assertEqual(join["on_tables"], ["users", "orders"])
+        self.assertIn("on_condition", join)
 
 
 class TestOBQCDialectParity(unittest.TestCase):

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -1260,6 +1260,49 @@ class TestOBQCAxiomDrivenFanTrap(unittest.TestCase):
         )
         self.assertFalse(result.fan_trap_risk)
 
+    def test_sibling_fact_in_a_semi_join_filter_is_not_flagged(self):
+        """A fact reached only through EXISTS cannot multiply anything.
+
+        The axiom check read its disjoint pair off every table named in the
+        query, so a returns table used purely as a filter flagged an
+        aggregation over orders that it cannot affect.
+        """
+        result = self.validator.validate(
+            "SELECT c.id, SUM(o.amount) FROM customers c "
+            "JOIN orders o ON o.customer_id = c.id "
+            "WHERE EXISTS (SELECT 1 FROM returns r WHERE r.customer_id = c.id) "
+            "GROUP BY c.id"
+        )
+
+        self.assertFalse(
+            result.fan_trap_risk,
+            [i.message for i in result.issues],
+        )
+
+    def test_sibling_fact_in_a_subquery_without_outer_join_is_not_flagged(self):
+        result = self.validator.validate(
+            "SELECT customer_id, SUM(amount) FROM orders "
+            "WHERE EXISTS (SELECT 1 FROM returns "
+            "WHERE returns.customer_id = orders.customer_id) "
+            "GROUP BY customer_id"
+        )
+
+        self.assertFalse(
+            result.fan_trap_risk,
+            [i.message for i in result.issues],
+        )
+
+    def test_both_facts_joined_in_one_select_is_still_flagged(self):
+        """The true positive the axiom path exists for."""
+        result = self.validator.validate(
+            "SELECT c.id, SUM(o.amount), SUM(r.amount) FROM customers c "
+            "JOIN orders o ON o.customer_id = c.id "
+            "JOIN returns r ON r.customer_id = c.id "
+            "GROUP BY c.id"
+        )
+
+        self.assertTrue(result.fan_trap_risk)
+
 
 class TestOBQCDialectParity(unittest.TestCase):
     """Guard that OBQC maps every supported database to a real sqlglot dialect."""

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -703,6 +703,106 @@ class TestOBQCSelectAliases(unittest.TestCase):
         self.assertFalse(result.is_valid)
 
 
+class TestOBQCSubqueryScoping(unittest.TestCase):
+    """Rules apply per SELECT, not across the whole parsed query.
+
+    Tables, columns and aggregation were collected into flat query-wide state,
+    so a subquery's contents were judged as if they belonged to the outer
+    query. Every IN / EXISTS / scalar subquery was rejected outright.
+    """
+
+    def setUp(self):
+        self.graph, self.base_uri = create_sample_ontology_graph()
+        self.validator = OBQCValidator()
+        self.validator.load_ontology(self.graph, self.base_uri)
+
+    def test_in_subquery_is_not_a_cartesian_product(self):
+        """Two tables in total, no joins in total -- but one table per SELECT."""
+        result = self.validator.validate(
+            "SELECT id FROM users WHERE id IN (SELECT user_id FROM orders)"
+        )
+
+        self.assertTrue(result.is_valid, [i.message for i in result.issues])
+
+    def test_exists_subquery_is_not_a_cartesian_product(self):
+        result = self.validator.validate(
+            "SELECT name FROM users u "
+            "WHERE EXISTS (SELECT 1 FROM orders o WHERE o.user_id = u.id)"
+        )
+
+        self.assertTrue(result.is_valid, [i.message for i in result.issues])
+
+    def test_scalar_subquery_in_select_list_is_allowed(self):
+        result = self.validator.validate(
+            "SELECT name, (SELECT COUNT(*) FROM orders) AS n FROM users"
+        )
+
+        self.assertTrue(result.is_valid, [i.message for i in result.issues])
+
+    def test_aggregate_in_subquery_does_not_require_outer_group_by(self):
+        """The outer SELECT aggregates nothing, so it needs no GROUP BY."""
+        result = self.validator.validate(
+            "SELECT name FROM users WHERE id = (SELECT MAX(user_id) FROM orders)"
+        )
+
+        self.assertTrue(result.is_valid, [i.message for i in result.issues])
+
+    def test_subquery_table_cannot_resolve_an_outer_column(self):
+        """quantity belongs to order_items, which the outer SELECT cannot see."""
+        result = self.validator.validate(
+            "SELECT quantity FROM users WHERE id IN (SELECT order_id FROM order_items)"
+        )
+
+        self.assertFalse(result.is_valid)
+
+    def test_no_ambiguity_across_scopes(self):
+        """users.id and orders.id live in different scopes here."""
+        result = self.validator.validate(
+            "SELECT id FROM users WHERE id IN (SELECT user_id FROM orders)"
+        )
+
+        ambiguous = [
+            i for i in result.issues if i.issue_type == OBQCIssueType.AMBIGUOUS_COLUMN
+        ]
+        self.assertEqual(ambiguous, [])
+
+    def test_correlated_subquery_may_use_outer_tables(self):
+        """An enclosing SELECT's tables stay in scope, or this reads as
+        missing."""
+        result = self.validator.validate(
+            "SELECT u.name FROM users u WHERE EXISTS ("
+            "SELECT 1 FROM orders o WHERE o.user_id = u.id AND o.total > 5)"
+        )
+
+        self.assertTrue(result.is_valid, [i.message for i in result.issues])
+
+    def test_real_cartesian_product_still_errors(self):
+        result = self.validator.validate("SELECT * FROM users, orders")
+
+        self.assertFalse(result.is_valid)
+        self.assertTrue(
+            any(
+                i.issue_type == OBQCIssueType.MISSING_JOIN_CONDITION
+                for i in result.issues
+            )
+        )
+
+    def test_real_missing_group_by_still_errors(self):
+        result = self.validator.validate("SELECT name, SUM(id) FROM users")
+
+        self.assertFalse(result.is_valid)
+
+    def test_ambiguity_within_one_scope_still_warns(self):
+        result = self.validator.validate(
+            "SELECT id FROM users JOIN orders ON users.id = orders.user_id"
+        )
+
+        ambiguous = [
+            i for i in result.issues if i.issue_type == OBQCIssueType.AMBIGUOUS_COLUMN
+        ]
+        self.assertEqual(len(ambiguous), 1)
+
+
 class TestOBQCFanTrapDetection(unittest.TestCase):
     """Test suite specifically for fan-trap detection."""
 

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -792,6 +792,60 @@ class TestOBQCSubqueryScoping(unittest.TestCase):
 
         self.assertFalse(result.is_valid)
 
+    def test_nested_aggregate_does_not_excuse_an_outer_column(self):
+        """An aggregate in a subquery cannot aggregate an outer column.
+
+        The per-column check scanned aggregates anywhere under the SELECT, so
+        a nested MAX(id) made the outer bare id look aggregated and a query
+        genuinely missing its GROUP BY passed.
+        """
+        result = self.validator.validate(
+            "SELECT id, SUM(total), (SELECT MAX(id) FROM users) FROM orders"
+        )
+
+        self.assertFalse(result.is_valid)
+
+    def test_subquery_aggregate_does_not_trigger_a_fan_trap(self):
+        """Fan-out only inflates totals the joins are aggregated over."""
+        result = self.validator.validate(
+            "SELECT users.name FROM users "
+            "JOIN orders ON users.id = orders.user_id "
+            "JOIN shipments ON shipments.order_id = orders.id "
+            "WHERE EXISTS (SELECT COUNT(*) FROM order_items)"
+        )
+
+        self.assertFalse(
+            result.fan_trap_risk,
+            [i.message for i in result.issues],
+        )
+
+    def test_real_fan_trap_in_an_aggregating_select_still_warns(self):
+        result = self.validator.validate(
+            "SELECT orders.id, SUM(order_items.quantity), SUM(shipments.cost) "
+            "FROM orders "
+            "JOIN order_items ON orders.id = order_items.order_id "
+            "JOIN shipments ON orders.id = shipments.order_id "
+            "GROUP BY orders.id"
+        )
+
+        self.assertTrue(result.fan_trap_risk)
+
+    def test_inner_name_resolves_in_the_innermost_scope(self):
+        """SQL stops at the innermost scope that provides a name.
+
+        Flattening the scope levels made the inner id look ambiguous between
+        orders.id and users.id, when it is simply orders.id.
+        """
+        result = self.validator.validate(
+            "SELECT name FROM users WHERE EXISTS ("
+            "SELECT 1 FROM orders WHERE id = user_id)"
+        )
+
+        ambiguous = [
+            i for i in result.issues if i.issue_type == OBQCIssueType.AMBIGUOUS_COLUMN
+        ]
+        self.assertEqual(ambiguous, [], [i.message for i in result.issues])
+
     def test_ambiguity_within_one_scope_still_warns(self):
         result = self.validator.validate(
             "SELECT id FROM users JOIN orders ON users.id = orders.user_id"

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -1030,6 +1030,38 @@ class TestOBQCFanTrapDirection(unittest.TestCase):
         self.assertEqual(baseline.parsed_joins[0]["on_tables"], ["users", "orders"])
         self.assertEqual(shadowed.parsed_joins[0]["on_tables"], ["users", "orders"])
 
+    def test_fan_outs_are_counted_per_select_not_pooled(self):
+        """Two subqueries fanning out once each are two safe aggregations.
+
+        Rows are multiplied by joins in the same query. Summing fan-outs
+        across unrelated SELECTs reported a fan-trap that exists in neither.
+        """
+        result = self.validator.validate(
+            "SELECT "
+            "(SELECT SUM(order_items.quantity) FROM orders "
+            " JOIN order_items ON orders.id = order_items.order_id), "
+            "(SELECT SUM(shipments.cost) FROM orders "
+            " JOIN shipments ON orders.id = shipments.order_id) "
+            "FROM users"
+        )
+
+        self.assertFalse(
+            result.fan_trap_risk,
+            [i.message for i in result.issues],
+        )
+
+    def test_fan_trap_inside_a_subquery_is_still_detected(self):
+        """Scoping the count must not switch detection off in subqueries."""
+        result = self.validator.validate(
+            "SELECT name, ("
+            "SELECT SUM(order_items.quantity) + SUM(shipments.cost) FROM orders "
+            "JOIN order_items ON orders.id = order_items.order_id "
+            "JOIN shipments ON orders.id = shipments.order_id) "
+            "FROM users"
+        )
+
+        self.assertTrue(result.fan_trap_risk)
+
     def test_unrelated_join_is_not_counted(self):
         """Tables with no ontology relationship cannot be judged to fan out."""
         result = self.validator.validate(


### PR DESCRIPTION
Found while answering "is there a third place resolving names tree-wide?" after the #85 review. There was — three of them. **All predate this session** (initial commit `d27dfd5`); the merged OBQC PRs only made me look in the right place.

Also includes the new `docs/obqc-overview.md` and README index row, reviewed and corrected.

## The bugs

`OBQCResult` carries `parsed_tables`, `parsed_columns` and `has_aggregation` as flat query-wide state, and every extractor walked the whole tree with `parsed.find_all(...)`. Correct for a single-SELECT query; wrong the moment there are two scopes.

| rule | symptom | severity |
|---|---|---|
| Cartesian product | `SELECT id FROM users WHERE id IN (SELECT user_id FROM orders)` → **rejected**. Two tables, zero joins *in total* | **ERROR** — blocks |
| Aggregation context | `SELECT name FROM users WHERE id = (SELECT MAX(user_id) FROM orders)` → "Column 'name' in SELECT with aggregation but no GROUP BY" | **ERROR** — blocks |
| Column resolution | false ambiguity across scopes, **and** a false negative: `SELECT quantity FROM users WHERE id IN (SELECT order_id FROM order_items)` found `quantity` in `order_items` and passed | WARNING + missed ERROR |

The first meant **every** `IN` / `EXISTS` / scalar subquery was blocked before reaching the database.

## Fixes

- **Cartesian** — judged per SELECT. Comma-separated `FROM` items still raise it, since sqlglot parses them as joins carrying no `ON`.
- **Aggregation** — each SELECT is tested for aggregates in its own scope.
- **Columns** — resolution uses the scope a name appears in *plus enclosing ones*, so a correlated subquery still sees outer tables (`WHERE EXISTS (SELECT 1 FROM orders o WHERE o.user_id = u.id)`) while a subquery's tables cannot answer for the outer query.

## Why it survived since February

The suite had **never contained a subquery** — 102 `SELECT` statements, none nested. The only three on `main` are ones I added during this session's review rounds, and none would have caught it either: two assert `fan_trap_risk` / `on_tables` rather than `is_valid`, and the third reuses `orders` twice so `parsed_tables` deduplicates below the two-table threshold.

## Docs

`docs/obqc-overview.md` is new here. Reviewing it against the code turned up one factual error and two stale claims:

- **Wrong:** "When `validate_sql_syntax()` or `execute_sql_query()` receives SQL, OBQC parses it". `validate_sql_syntax()` is a `DatabaseManager` method doing security and dialect-syntax checks, with no OBQC reference and no MCP tool exposing it. `execute_sql_query()` is the only entry point that runs OBQC.
- **Stale:** "Every referenced table must exist in the ontology" — catalog schemas are exempt since #83.
- **Stale:** "Qualified and unqualified columns must resolve to real columns" — `SELECT` aliases resolve to the select list since #84.

`docs/obqc.md` was still describing pre-#83/#84/#85 behaviour throughout: table existence, column existence, fan-trap direction, and the Cartesian rule. All updated, including the dialect-specific alias visibility and the `mysql`-schema exclusion.

## Tests

10 new (`TestOBQCSubqueryScoping`) covering all three fixes and their negatives — real cross products, real missing `GROUP BY`, and same-scope ambiguity all still fire.

Full suite: **676 passed**, 108 subtests. mypy + ruff clean. All doc links verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)