### PR TITLE
feat(obqc)!: block fan-traps and report them as structured data

### DIFF
--- a/.claude/skills/fan-trap-prevention.md
+++ b/.claude/skills/fan-trap-prevention.md
@@ -53,7 +53,10 @@ Before writing multi-table queries with aggregation:
    - Fan-trap: measure taken from the **one** side across a 1:many join (`SUM(orders.total)` with order_items joined)
    - Fan-trap: multiple 1:many from the same parent
 3. **Conditional aggregates measure the branch, not the test.** `SUM(CASE WHEN orders.total > 100 THEN order_items.quantity ELSE 0 END)` measures `order_items`; the `orders` column only filters. Putting the parent's measure in the branch does still inflate.
-4. **Let `execute_sql_query()` validate** — OBQC runs before execution and a fan-trap is a **blocking error**, not a warning. Read the `obqc_fan_trap` field on the response: `{detected, blocking, findings}`, where each finding names the `measure_table` being inflated and the `fan_out_table` doing it. `evaluated: false` means OBQC never ran (no ontology loaded) — treat that as unknown, not as safe.
+4. **Let `execute_sql_query()` validate** — OBQC runs before execution. Read the `obqc_fan_trap` field on the response: `{evaluated, detected, blocking, findings}`, where each finding names its `kind`, the `measure_table` being inflated and the `fan_out_table` doing it.
+   - `evaluated: false` — OBQC never ran (no ontology loaded, or the request failed before validation). Treat as **unknown**, not safe.
+   - `blocking: true` — this query was refused. A provable fan-trap (a measure read across a 1:many join) blocks.
+   - `blocking: false` with `detected: true` — reported but executed. A `conditional_row_count` warns instead of blocking, because the same shape is a correct star-join idiom; decide from the finding whether your count meant the coarser table.
 5. **Fix the query, don't force it.** Pre-aggregate the fanning table in a CTE, or use UNION ALL. `allow_fan_out=True` exists for the rare case where the multiplied rows are genuinely wanted — it does not make the numbers right.
 6. **Validate results** against source tables
 

--- a/.claude/skills/fan-trap-prevention.md
+++ b/.claude/skills/fan-trap-prevention.md
@@ -52,9 +52,10 @@ Before writing multi-table queries with aggregation:
    - Safe: measure taken from the **many** side (`SUM(order_items.qty)` across orders → order_items)
    - Fan-trap: measure taken from the **one** side across a 1:many join (`SUM(orders.total)` with order_items joined)
    - Fan-trap: multiple 1:many from the same parent
-3. **Let `execute_sql_query()` validate** — OBQC runs before execution and a fan-trap is a **blocking error**, not a warning. Read the `obqc_fan_trap` field on the response: `{detected, blocking, findings}`, where each finding names the `measure_table` being inflated and the `fan_out_table` doing it.
-4. **Fix the query, don't force it.** Pre-aggregate the fanning table in a CTE, or use UNION ALL. `allow_fan_out=True` exists for the rare case where the multiplied rows are genuinely wanted — it does not make the numbers right.
-5. **Validate results** against source tables
+3. **Conditional aggregates measure the branch, not the test.** `SUM(CASE WHEN orders.total > 100 THEN order_items.quantity ELSE 0 END)` measures `order_items`; the `orders` column only filters. Putting the parent's measure in the branch does still inflate.
+4. **Let `execute_sql_query()` validate** — OBQC runs before execution and a fan-trap is a **blocking error**, not a warning. Read the `obqc_fan_trap` field on the response: `{detected, blocking, findings}`, where each finding names the `measure_table` being inflated and the `fan_out_table` doing it. `evaluated: false` means OBQC never ran (no ontology loaded) — treat that as unknown, not as safe.
+5. **Fix the query, don't force it.** Pre-aggregate the fanning table in a CTE, or use UNION ALL. `allow_fan_out=True` exists for the rare case where the multiplied rows are genuinely wanted — it does not make the numbers right.
+6. **Validate results** against source tables
 
 ### Aggregates that survive a fan-out
 

--- a/.claude/skills/fan-trap-prevention.md
+++ b/.claude/skills/fan-trap-prevention.md
@@ -58,7 +58,11 @@ Before writing multi-table queries with aggregation:
 
 ### Aggregates that survive a fan-out
 
-`MIN`, `MAX`, `COUNT(DISTINCT ...)` and `COUNT(*)` are unaffected by repeated rows, so OBQC does not block them. `SUM`, `AVG` and `COUNT(col)` are.
+`MIN`, `MAX` and `COUNT(DISTINCT ...)` read the same answer off repeated rows, so OBQC never blocks a query that aggregates only with those — no join shape makes them wrong.
+
+`SUM`, `AVG` and `COUNT(col)` are corrupted by duplication and are what the checks look for.
+
+`COUNT(*)` sits between the two: counting the joined rows is usually what you meant across a single 1:many join, so it is not blocked there — but across **two** fan-out joins it returns the product of the two children, which is meaningless, and is blocked.
 
 ---
 

--- a/.claude/skills/fan-trap-prevention.md
+++ b/.claude/skills/fan-trap-prevention.md
@@ -4,9 +4,25 @@
 
 ## What is a Fan-Trap?
 
-A fan-trap occurs when a parent table has multiple 1:many relationships and you JOIN them with aggregation, causing data multiplication (Cartesian product).
+A fan-trap occurs when you aggregate a measure across a 1:many join, so each measure row is repeated once per matching child row and the total comes back inflated.
 
-### Example:
+**A single 1:many join is enough.** The classic multi-fact shape is the worst case, not the threshold.
+
+### Example — one join is already wrong:
+```
+sales (1) → shipments (many)
+```
+```sql
+-- ❌ each sale's amount is added once per shipment
+SELECT SUM(public.sales.amount)
+FROM public.sales
+JOIN public.shipments ON public.shipments.sale_id = public.sales.id;
+```
+The inner join also drops sales that never shipped, so the number is wrong in both directions.
+
+Which table you put in `FROM` makes no difference: `FROM shipments JOIN sales` produces the same one-row-per-shipment result.
+
+### Example — the multi-fact shape:
 ```
 orders (1) → order_items (many)
 orders (1) → shipments (many)
@@ -33,10 +49,16 @@ Before writing multi-table queries with aggregation:
 1. **Review foreign_keys** from `discover_schema()` FIRST
 2. **Identify relationship patterns:**
    - Safe: 1:1 relationships (customers → customer_profiles)
-   - Requires care: 1:many (customers → orders)
-   - High risk: Multiple 1:many from same parent (fan-trap potential)
-3. **Let `execute_sql_query()` validate** — it runs OBQC fan-trap checks automatically before executing
-4. **Validate results** against source tables
+   - Safe: measure taken from the **many** side (`SUM(order_items.qty)` across orders → order_items)
+   - Fan-trap: measure taken from the **one** side across a 1:many join (`SUM(orders.total)` with order_items joined)
+   - Fan-trap: multiple 1:many from the same parent
+3. **Let `execute_sql_query()` validate** — OBQC runs before execution and a fan-trap is a **blocking error**, not a warning. Read the `obqc_fan_trap` field on the response: `{detected, blocking, findings}`, where each finding names the `measure_table` being inflated and the `fan_out_table` doing it.
+4. **Fix the query, don't force it.** Pre-aggregate the fanning table in a CTE, or use UNION ALL. `allow_fan_out=True` exists for the rare case where the multiplied rows are genuinely wanted — it does not make the numbers right.
+5. **Validate results** against source tables
+
+### Aggregates that survive a fan-out
+
+`MIN`, `MAX`, `COUNT(DISTINCT ...)` and `COUNT(*)` are unaffected by repeated rows, so OBQC does not block them. `SUM`, `AVG` and `COUNT(col)` are.
 
 ---
 

--- a/.claude/skills/fan-trap-prevention.md
+++ b/.claude/skills/fan-trap-prevention.md
@@ -57,6 +57,12 @@ Before writing multi-table queries with aggregation:
 5. **Fix the query, don't force it.** Pre-aggregate the fanning table in a CTE, or use UNION ALL. `allow_fan_out=True` exists for the rare case where the multiplied rows are genuinely wanted — it does not make the numbers right.
 6. **Validate results** against source tables
 
+### Conditional row counts
+
+`SUM(CASE WHEN <table> … THEN 1 ELSE 0 END)` and `COUNT(*) FILTER (WHERE <table> …)` count *rows*, and a join repeats the rows of whatever the condition names. OBQC **warns without blocking** here, because the SQL cannot say which count you meant — over `orders JOIN order_items` a condition on `orders` counts items, not orders; over `orders JOIN users` a condition on `users` counts orders, which is usually exactly right.
+
+If you meant the coarser count, use `COUNT(DISTINCT <table>.<key>)` or filter with `EXISTS` instead of joining.
+
 ### Aggregates that survive a fan-out
 
 `MIN`, `MAX` and `COUNT(DISTINCT ...)` read the same answer off repeated rows, so OBQC never blocks a query that aggregates only with those — no join shape makes them wrong.

--- a/docs/fan-trap-prevention.md
+++ b/docs/fan-trap-prevention.md
@@ -92,13 +92,13 @@ for measure_table, other in ((anchor, join_table), (join_table, anchor)):
 
 Both ends of every join are checked, so `FROM order_items JOIN orders` summing `orders.total` is caught exactly like `FROM orders JOIN order_items`, and the comma form (`FROM orders o, order_items i WHERE i.order_id = o.id`) is judged the same as the `ON` spelling.
 
-A measure taken from the many side is left alone, as are aggregates duplication cannot change: `MIN`, `MAX` and `COUNT(DISTINCT ...)` are exempt from all three rules. `COUNT(*)` never triggers the measure rule, since it names no table, but it still counts rows -- across two fan-out joins that is the product of the two children, so the weaker rules below still apply to it.
+Only the columns producing an aggregate's value count as measures, so `SUM(CASE WHEN orders.total > 100 THEN order_items.quantity ELSE 0 END)` measures `order_items` and merely filters on `orders`. A measure taken from the many side is left alone, as are aggregates duplication cannot change: `MIN`, `MAX` and `COUNT(DISTINCT ...)` are exempt from all three rules. `COUNT(*)` never triggers the measure rule, since it names no table, but it still counts rows -- across two fan-out joins that is the product of the two children, so the weaker rules below still apply to it.
 
 Two weaker findings follow: sibling facts the ontology declares `owl:disjointWith`, and the older heuristic of two or more one-to-many joins in one aggregating `SELECT`.
 
 The validator knows which relationships are one-to-many because the ontology stores `oba:relationshipType` annotations on every OWL ObjectProperty.
 
-Every response carries an `obqc_fan_trap` object (`{detected, blocking, findings}`) so a caller can read the verdict as data instead of parsing `warnings`. To run a flagged query anyway, pass `allow_fan_out=True` -- the finding is still reported, as a warning.
+Every response carries an `obqc_fan_trap` object (`{evaluated, detected, blocking, findings}`, where `evaluated: false` means the rules never ran and the verdict is unknown rather than clean) so a caller can read the verdict as data instead of parsing `warnings`. To run a flagged query anyway, pass `allow_fan_out=True` -- the finding is still reported, as a warning.
 
 ### Layer 3: GraphRAG Context Retrieval
 

--- a/docs/fan-trap-prevention.md
+++ b/docs/fan-trap-prevention.md
@@ -90,7 +90,9 @@ for measure_table, other in ((anchor, join_table), (join_table, anchor)):
     })
 ```
 
-Both ends of every join are checked, so `FROM order_items JOIN orders` summing `orders.total` is caught exactly like `FROM orders JOIN order_items`. Aggregates that duplication cannot change (`MIN`, `MAX`, `COUNT(DISTINCT ...)`, `COUNT(*)`) are left alone, as is a measure taken from the many side.
+Both ends of every join are checked, so `FROM order_items JOIN orders` summing `orders.total` is caught exactly like `FROM orders JOIN order_items`, and the comma form (`FROM orders o, order_items i WHERE i.order_id = o.id`) is judged the same as the `ON` spelling.
+
+A measure taken from the many side is left alone, as are aggregates duplication cannot change: `MIN`, `MAX` and `COUNT(DISTINCT ...)` are exempt from all three rules. `COUNT(*)` never triggers the measure rule, since it names no table, but it still counts rows -- across two fan-out joins that is the product of the two children, so the weaker rules below still apply to it.
 
 Two weaker findings follow: sibling facts the ontology declares `owl:disjointWith`, and the older heuristic of two or more one-to-many joins in one aggregating `SELECT`.
 

--- a/docs/fan-trap-prevention.md
+++ b/docs/fan-trap-prevention.md
@@ -71,24 +71,32 @@ These warnings appear in the `discover_schema()` output so the LLM (or user) is 
 
 ### Layer 2: OBQC Query Validation (built into `execute_sql_query`)
 
-The Ontology Basic Quality Criteria (OBQC) validator runs automatically inside `execute_sql_query` before the query is run. It parses SQL queries using sqlglot and checks them against the ontology's relationship metadata. It counts how many one-to-many joins a query traverses. If two or more one-to-many joins co-occur with aggregation functions, the validator flags the query:
+The Ontology Basic Quality Criteria (OBQC) validator runs automatically inside `execute_sql_query` before the query is run. It parses SQL queries using sqlglot and checks them against the ontology's relationship metadata. **A detected fan-trap is a blocking error**: the query is refused rather than answered with an inflated number.
+
+The strongest finding needs only a *single* one-to-many join. If an aggregate reads a measure from the "one" side of a join, every one of its rows is repeated:
 
 ```python
-# From src/obqc_validator.py
-if one_to_many_count >= 2:
-    result.fan_trap_risk = True
-    result.issues.append(OBQCIssue(
-        issue_type=OBQCIssueType.FAN_TRAP_DETECTED,
-        severity=OBQCSeverity.WARNING,
-        message=f"Potential fan-trap: {one_to_many_count} "
-                "one-to-many joins with aggregation",
-        suggestion="Use UNION ALL pattern for separate aggregations "
-                   "per fact table, or use CTEs to pre-aggregate "
-                   "before joining",
-    ))
+# From src/obqc_validator.py -- _inflated_measures()
+for measure_table, other in ((anchor, join_table), (join_table, anchor)):
+    if measure_table.lower() not in measures:
+        continue
+    if not self._join_fans_out(other, measure_table):
+        continue
+    findings.append({
+        "kind": "measure_across_fan_out",
+        "measure_table": measure_table,
+        "fan_out_table": other,
+        ...
+    })
 ```
 
+Both ends of every join are checked, so `FROM order_items JOIN orders` summing `orders.total` is caught exactly like `FROM orders JOIN order_items`. Aggregates that duplication cannot change (`MIN`, `MAX`, `COUNT(DISTINCT ...)`, `COUNT(*)`) are left alone, as is a measure taken from the many side.
+
+Two weaker findings follow: sibling facts the ontology declares `owl:disjointWith`, and the older heuristic of two or more one-to-many joins in one aggregating `SELECT`.
+
 The validator knows which relationships are one-to-many because the ontology stores `oba:relationshipType` annotations on every OWL ObjectProperty.
+
+Every response carries an `obqc_fan_trap` object (`{detected, blocking, findings}`) so a caller can read the verdict as data instead of parsing `warnings`. To run a flagged query anyway, pass `allow_fan_out=True` -- the finding is still reported, as a warning.
 
 ### Layer 3: GraphRAG Context Retrieval
 

--- a/docs/fan-trap-prevention.md
+++ b/docs/fan-trap-prevention.md
@@ -92,7 +92,7 @@ for measure_table, other in ((anchor, join_table), (join_table, anchor)):
 
 Both ends of every join are checked, so `FROM order_items JOIN orders` summing `orders.total` is caught exactly like `FROM orders JOIN order_items`, and the comma form (`FROM orders o, order_items i WHERE i.order_id = o.id`) is judged the same as the `ON` spelling.
 
-Only the columns producing an aggregate's value count as measures, so `SUM(CASE WHEN orders.total > 100 THEN order_items.quantity ELSE 0 END)` measures `order_items` and merely filters on `orders`. A measure taken from the many side is left alone, as are aggregates duplication cannot change: `MIN`, `MAX` and `COUNT(DISTINCT ...)` are exempt from all three rules. `COUNT(*)` never triggers the measure rule, since it names no table, but it still counts rows -- across two fan-out joins that is the product of the two children, so the weaker rules below still apply to it.
+Only the columns producing an aggregate's value count as measures, so `SUM(CASE WHEN orders.total > 100 THEN order_items.quantity ELSE 0 END)` measures `order_items` and merely filters on `orders`. A measure taken from the many side is left alone, as are aggregates duplication cannot change: `MIN`, `MAX` and `COUNT(DISTINCT ...)` are exempt from all four rules. `COUNT(*)` never triggers the measure rule, since it names no table, but it still counts rows -- across two fan-out joins that is the product of the two children, so the weaker rules below still apply to it.
 
 Two weaker findings follow: sibling facts the ontology declares `owl:disjointWith`, and the older heuristic of two or more one-to-many joins in one aggregating `SELECT`.
 

--- a/docs/obqc.md
+++ b/docs/obqc.md
@@ -201,22 +201,65 @@ SELECT name, COUNT(*) FROM customers;
 SELECT status, region, SUM(amount) FROM orders GROUP BY region;
 ```
 
-### Fan-trap detection (WARNING)
+### Fan-trap detection (ERROR)
 
-Detects when a query aggregates across two or more one-to-many joins. This is the classic fan-trap pattern where rows multiply silently, producing inflated aggregation results.
+A fan-trap **blocks execution**. A query that aggregates across a one-to-many join returns a silently inflated number, and a wrong answer is worse than no answer -- particularly for a caller that keys off `success` and never reads the prose in `warnings`.
+
+Three findings, strongest first.
+
+**1. A measure multiplied by a fan-out join.** The ontology puts the joined table on the many side of the table a measure is taken from, so each measure row is repeated. **One join is enough** -- no second fact table required:
+
+```sql
+-- ERROR: Fan-trap: aggregating 'sales' across the join to 'shipments', which the
+-- ontology puts on the many side of 'sales'.
+SELECT SUM(s.amount)
+FROM sales s
+JOIN shipments sh ON sh.sale_id = s.id;
+```
+
+Which table sits in `FROM` makes no difference -- `FROM shipments JOIN sales` produces the same one-row-per-shipment result set, so both ends of every join are judged.
+
+A measure taken from the *many* side is fine, because the repeated rows are that measure's own rows:
+
+```sql
+-- OK: each shipment is summed once
+SELECT s.id, SUM(sh.cost) FROM sales s JOIN shipments sh ON sh.sale_id = s.id GROUP BY s.id;
+```
+
+Aggregates that duplication cannot change are left alone: `MIN`, `MAX`, `COUNT(DISTINCT ...)`, and `COUNT(*)` (which names no table -- counting the joined rows is usually the intent).
+
+**2. Disjoint sibling facts**, read from the ontology's own `owl:disjointWith` axioms: two facts at different grains sharing a dimension.
+
+**3. Two or more fan-out joins** in one aggregating `SELECT` -- the heuristic fallback for ontologies carrying no disjointness axioms.
 
 Fan-out is judged per join, against the table that join's `ON` condition attaches to -- not by asking whether a table sits on the many side of some relationship elsewhere in the schema. Walking a chain of many-to-one lookups (`sales` -> `clients` -> `countries`) duplicates nothing and is not flagged, however many foreign keys those dimensions carry.
 
-```sql
--- WARNING: Potential fan-trap: 2 one-to-many joins with aggregation
-SELECT c.name, SUM(o.amount), COUNT(r.id)
-FROM customers c
-JOIN orders o ON c.id = o.customer_id
-JOIN reviews r ON c.id = r.customer_id
-GROUP BY c.name;
+#### The structured verdict
+
+Every `execute_sql_query` response carries `obqc_fan_trap`, whatever the outcome:
+
+```json
+{
+  "detected": true,
+  "blocking": true,
+  "findings": [
+    {
+      "kind": "measure_across_fan_out",
+      "measure_table": "sales",
+      "fan_out_table": "shipments",
+      "tables": ["sales", "shipments"]
+    }
+  ]
+}
 ```
 
-OBQC suggests using `UNION ALL` to aggregate each fact table separately, or CTEs to pre-aggregate before joining. See [Fan-Trap Prevention](fan-trap-prevention.md) for detailed patterns.
+`kind` is one of `measure_across_fan_out`, `disjoint_facts`, or `multiple_fan_out_joins`. A clean query reports `{"detected": false, "blocking": true, "findings": []}` -- so "no fan-trap" is an answer to read rather than the absence of a sentence.
+
+#### Running one anyway
+
+`execute_sql_query(..., allow_fan_out=True)` downgrades the finding to a warning and executes. The finding is still reported and `blocking` becomes `false`. Use it only when the multiplied rows are what you want, or when you know the relationship is 1:1 in practice despite the declared cardinality.
+
+The fix is usually to pre-aggregate the fanning table in a CTE and join the one row per key that produces, or to aggregate each fact separately and combine with `UNION ALL`. See [Fan-Trap Prevention](fan-trap-prevention.md) for the patterns.
 
 ## How the LLM uses OBQC
 
@@ -225,6 +268,7 @@ OBQC results are returned as structured data in the tool response, not displayed
 - `obqc_valid`: overall pass/fail
 - `obqc_issues`: list of issues with type, severity, message, location, and suggestion
 - `fan_trap_risk`: boolean flag
+- `obqc_fan_trap`: `{detected, blocking, findings}` -- the fan-trap verdict as data, present on every response
 - `obqc_error_count` / `obqc_warning_count`: summary counts
 
 When `execute_sql_query` blocks a query, the LLM sees the error details and suggestions, and can revise the SQL and retry -- often without the user ever seeing the failed attempt.

--- a/docs/obqc.md
+++ b/docs/obqc.md
@@ -226,6 +226,18 @@ A measure taken from the *many* side is fine, because the repeated rows are that
 SELECT s.id, SUM(sh.cost) FROM sales s JOIN shipments sh ON sh.sale_id = s.id GROUP BY s.id;
 ```
 
+Within an aggregate, only the columns producing its *value* are read as measures. A column tested in a condition contributes nothing to the total, so a conditional aggregate measures the branch, not the test:
+
+```sql
+-- OK: measures order_items, merely filters on orders
+SELECT o.id, SUM(CASE WHEN o.total > 100 THEN oi.quantity ELSE 0 END)
+FROM orders o JOIN order_items oi ON oi.order_id = o.id GROUP BY o.id;
+
+-- ERROR: the branch itself is the parent's measure, so it still inflates
+SELECT o.id, SUM(CASE WHEN oi.quantity > 1 THEN o.total ELSE 0 END)
+FROM orders o JOIN order_items oi ON oi.order_id = o.id GROUP BY o.id;
+```
+
 Aggregates that duplication cannot change are left alone entirely -- `MIN`, `MAX` and `COUNT(DISTINCT ...)` read the same answer off repeated rows, so no join shape makes them wrong and none of the three rules fires on a query that uses only those.
 
 `COUNT(*)` is a middle case. It names no table, so it never triggers this rule -- counting the joined rows is usually the intent. But it does count rows, so across *two* fan-out joins it returns the product of the two children and rules 2 and 3 below still apply.
@@ -244,6 +256,7 @@ Every `execute_sql_query` response carries `obqc_fan_trap`, whatever the outcome
 
 ```json
 {
+  "evaluated": true,
   "detected": true,
   "blocking": true,
   "findings": [
@@ -257,7 +270,11 @@ Every `execute_sql_query` response carries `obqc_fan_trap`, whatever the outcome
 }
 ```
 
-`kind` is one of `measure_across_fan_out`, `disjoint_facts`, or `multiple_fan_out_joins`. A clean query reports `{"detected": false, "blocking": true, "findings": []}` -- so "no fan-trap" is an answer to read rather than the absence of a sentence.
+`kind` is one of `measure_across_fan_out`, `disjoint_facts`, or `multiple_fan_out_joins`. A clean query reports `detected: false` -- so "no fan-trap" is an answer to read rather than the absence of a sentence.
+
+`evaluated` separates *checked and clean* from *never checked*, which are not the same answer. It is `false` when the rules never ran: no ontology loaded, an ontology without `oba:` annotations, or a request that failed before validation (no connection, bad limit, empty SQL, checklist not confirmed). **A caller must treat `evaluated: false` as "unknown", not as a clean bill of health** -- a query can run and return inflated numbers with `detected: false` when no ontology was loaded to check it against.
+
+The field is present on every `execute_sql_query` response, including those early failures, so reading it needs no special case.
 
 #### Running one anyway
 
@@ -272,7 +289,7 @@ OBQC results are returned as structured data in the tool response, not displayed
 - `obqc_valid`: overall pass/fail
 - `obqc_issues`: list of issues with type, severity, message, location, and suggestion
 - `fan_trap_risk`: boolean flag
-- `obqc_fan_trap`: `{detected, blocking, findings}` -- the fan-trap verdict as data, present on every response
+- `obqc_fan_trap`: `{evaluated, detected, blocking, findings}` -- the fan-trap verdict as data, present on every response
 - `obqc_error_count` / `obqc_warning_count`: summary counts
 
 When `execute_sql_query` blocks a query, the LLM sees the error details and suggestions, and can revise the SQL and retry -- often without the user ever seeing the failed attempt.

--- a/docs/obqc.md
+++ b/docs/obqc.md
@@ -201,11 +201,11 @@ SELECT name, COUNT(*) FROM customers;
 SELECT status, region, SUM(amount) FROM orders GROUP BY region;
 ```
 
-### Fan-trap detection (ERROR)
+### Fan-trap detection (ERROR / WARNING)
 
-A **provable** fan-trap blocks execution: a query that aggregates a measure across a one-to-many join returns a silently inflated number, and a wrong answer is worse than no answer -- particularly for a caller that keys off `success` and never reads the prose in `warnings`. One finding below (rule 1b) is reported without blocking, because the SQL does not say whether it is wrong; `blocking` on the verdict tells you which happened.
+A **provable** fan-trap blocks execution: a query that aggregates a measure across a one-to-many join returns a silently inflated number, and a wrong answer is worse than no answer -- particularly for a caller that keys off `success` and never reads the prose in `warnings`. One finding below (rule 4) is reported without blocking, because the SQL does not say whether it is wrong; `blocking` on the verdict tells you which happened.
 
-Three findings, strongest first.
+Four findings, strongest first. The first three block; the fourth is reported without blocking.
 
 **1. A measure multiplied by a fan-out join.** The ontology puts the joined table on the many side of the table a measure is taken from, so each measure row is repeated. **One join is enough** -- no second fact table required:
 
@@ -238,13 +238,17 @@ SELECT o.id, SUM(CASE WHEN oi.quantity > 1 THEN o.total ELSE 0 END)
 FROM orders o JOIN order_items oi ON oi.order_id = o.id GROUP BY o.id;
 ```
 
-Aggregates that duplication cannot change are left alone entirely -- `MIN`, `MAX` and `COUNT(DISTINCT ...)` read the same answer off repeated rows, so no join shape makes them wrong and none of the three rules fires on a query that uses only those.
+Aggregates that duplication cannot change are left alone entirely -- `MIN`, `MAX` and `COUNT(DISTINCT ...)` read the same answer off repeated rows, so no join shape makes them wrong and none of the rules fires on a query that uses only those.
 
 `COUNT(*)` is a middle case. It names no table, so it never triggers this rule -- counting the joined rows is usually the intent. But it does count rows, so across *two* fan-out joins it returns the product of the two children and rules 2 and 3 below still apply.
 
 The comma form is judged identically: `FROM orders o, order_items i WHERE i.order_id = o.id` states the same join as the `ON` spelling and inflates the same way.
 
-**1b. A conditional row count over a repeated table (WARNING, never blocks).** A constant-valued conditional aggregate -- `SUM(CASE WHEN … THEN 1 ELSE 0 END)`, or the same thing as `COUNT(*) FILTER (WHERE …)` -- has no measure column, but the join still repeats what it counts:
+**2. Disjoint sibling facts**, read from the ontology's own `owl:disjointWith` axioms: two facts at different grains sharing a dimension.
+
+**3. Two or more fan-out joins** in one aggregating `SELECT` -- the heuristic fallback for ontologies carrying no disjointness axioms.
+
+**4. A conditional row count over a repeated table (WARNING, never blocks).** A constant-valued conditional aggregate -- `SUM(CASE WHEN … THEN 1 ELSE 0 END)`, or the same thing as `COUNT(*) FILTER (WHERE …)` -- has no measure column, but the join still repeats what it counts:
 
 ```sql
 -- WARNING: counts order_items rows matching an orders condition, not orders rows
@@ -255,10 +259,6 @@ FROM orders o JOIN order_items i ON i.order_id = o.id;
 This one is **reported without blocking**, because the SQL does not say which count was meant. The identical shape is a ubiquitous correct idiom in a star join -- `SUM(CASE WHEN u.segment = 'SMB' THEN 1 ELSE 0 END)` over `orders JOIN users` counts orders, which is exactly right, and reads as an inflated count of users only if that is what you wanted. Blocking it would reject ordinary analytics SQL, so OBQC states the ambiguity and leaves the call to you.
 
 Only conditions naming a single table qualify. One that also names the child counts at the child's grain, which no join corrupts, and an unconditional `COUNT(*)` names nothing at all. Unqualified condition columns resolve the same way value columns do -- against the tables in scope, and only when exactly one of them declares the name.
-
-**2. Disjoint sibling facts**, read from the ontology's own `owl:disjointWith` axioms: two facts at different grains sharing a dimension.
-
-**3. Two or more fan-out joins** in one aggregating `SELECT` -- the heuristic fallback for ontologies carrying no disjointness axioms.
 
 Fan-out is judged per join, against the table that join's `ON` condition attaches to -- not by asking whether a table sits on the many side of some relationship elsewhere in the schema. Walking a chain of many-to-one lookups (`sales` -> `clients` -> `countries`) duplicates nothing and is not flagged, however many foreign keys those dimensions carry.
 

--- a/docs/obqc.md
+++ b/docs/obqc.md
@@ -203,7 +203,7 @@ SELECT status, region, SUM(amount) FROM orders GROUP BY region;
 
 ### Fan-trap detection (ERROR)
 
-A fan-trap **blocks execution**. A query that aggregates across a one-to-many join returns a silently inflated number, and a wrong answer is worse than no answer -- particularly for a caller that keys off `success` and never reads the prose in `warnings`.
+A **provable** fan-trap blocks execution: a query that aggregates a measure across a one-to-many join returns a silently inflated number, and a wrong answer is worse than no answer -- particularly for a caller that keys off `success` and never reads the prose in `warnings`. One finding below (rule 1b) is reported without blocking, because the SQL does not say whether it is wrong; `blocking` on the verdict tells you which happened.
 
 Three findings, strongest first.
 

--- a/docs/obqc.md
+++ b/docs/obqc.md
@@ -284,7 +284,7 @@ Every `execute_sql_query` response carries `obqc_fan_trap`, whatever the outcome
 
 `kind` is one of `measure_across_fan_out`, `conditional_row_count`, `disjoint_facts`, or `multiple_fan_out_joins`.
 
-`blocking` says whether this verdict actually stopped the query, not what the caller asked for: it is `false` for a clean query, `false` when `allow_fan_out` was passed, and `false` for a `conditional_row_count`, which reports without blocking even under the default policy. A clean query reports `detected: false` -- so "no fan-trap" is an answer to read rather than the absence of a sentence.
+`blocking` says whether this verdict actually stopped the query, not what the caller asked for: it is `false` for a clean query, `false` when `allow_fan_out` was passed, `false` for a `conditional_row_count`, which reports without blocking even under the default policy, and `false` whenever `evaluated` is `false`, since a run that never checked blocked nothing. A clean query reports `detected: false` -- so "no fan-trap" is an answer to read rather than the absence of a sentence.
 
 `evaluated` separates *checked and clean* from *never checked*, which are not the same answer. It is `false` when the rules never ran: no ontology loaded, an ontology without `oba:` annotations, or a request that failed before validation (no connection, bad limit, empty SQL, checklist not confirmed). **A caller must treat `evaluated: false` as "unknown", not as a clean bill of health** -- a query can run and return inflated numbers with `detected: false` when no ontology was loaded to check it against.
 

--- a/docs/obqc.md
+++ b/docs/obqc.md
@@ -244,6 +244,18 @@ Aggregates that duplication cannot change are left alone entirely -- `MIN`, `MAX
 
 The comma form is judged identically: `FROM orders o, order_items i WHERE i.order_id = o.id` states the same join as the `ON` spelling and inflates the same way.
 
+**1b. A conditional row count over a repeated table (WARNING, never blocks).** A constant-valued conditional aggregate -- `SUM(CASE WHEN … THEN 1 ELSE 0 END)`, or the same thing as `COUNT(*) FILTER (WHERE …)` -- has no measure column, but the join still repeats what it counts:
+
+```sql
+-- WARNING: counts order_items rows matching an orders condition, not orders rows
+SELECT SUM(CASE WHEN o.total > 100 THEN 1 ELSE 0 END)
+FROM orders o JOIN order_items i ON i.order_id = o.id;
+```
+
+This one is **reported without blocking**, because the SQL does not say which count was meant. The identical shape is a ubiquitous correct idiom in a star join -- `SUM(CASE WHEN u.segment = 'SMB' THEN 1 ELSE 0 END)` over `orders JOIN users` counts orders, which is exactly right, and reads as an inflated count of users only if that is what you wanted. Blocking it would reject ordinary analytics SQL, so OBQC states the ambiguity and leaves the call to you.
+
+Only conditions naming a single table qualify. One that also names the child counts at the child's grain, which no join corrupts, and an unconditional `COUNT(*)` names nothing at all.
+
 **2. Disjoint sibling facts**, read from the ontology's own `owl:disjointWith` axioms: two facts at different grains sharing a dimension.
 
 **3. Two or more fan-out joins** in one aggregating `SELECT` -- the heuristic fallback for ontologies carrying no disjointness axioms.
@@ -270,7 +282,9 @@ Every `execute_sql_query` response carries `obqc_fan_trap`, whatever the outcome
 }
 ```
 
-`kind` is one of `measure_across_fan_out`, `disjoint_facts`, or `multiple_fan_out_joins`. A clean query reports `detected: false` -- so "no fan-trap" is an answer to read rather than the absence of a sentence.
+`kind` is one of `measure_across_fan_out`, `conditional_row_count`, `disjoint_facts`, or `multiple_fan_out_joins`.
+
+`blocking` says whether this verdict actually stopped the query, not what the caller asked for: it is `false` for a clean query, `false` when `allow_fan_out` was passed, and `false` for a `conditional_row_count`, which reports without blocking even under the default policy. A clean query reports `detected: false` -- so "no fan-trap" is an answer to read rather than the absence of a sentence.
 
 `evaluated` separates *checked and clean* from *never checked*, which are not the same answer. It is `false` when the rules never ran: no ontology loaded, an ontology without `oba:` annotations, or a request that failed before validation (no connection, bad limit, empty SQL, checklist not confirmed). **A caller must treat `evaluated: false` as "unknown", not as a clean bill of health** -- a query can run and return inflated numbers with `detected: false` when no ontology was loaded to check it against.
 

--- a/docs/obqc.md
+++ b/docs/obqc.md
@@ -226,7 +226,11 @@ A measure taken from the *many* side is fine, because the repeated rows are that
 SELECT s.id, SUM(sh.cost) FROM sales s JOIN shipments sh ON sh.sale_id = s.id GROUP BY s.id;
 ```
 
-Aggregates that duplication cannot change are left alone: `MIN`, `MAX`, `COUNT(DISTINCT ...)`, and `COUNT(*)` (which names no table -- counting the joined rows is usually the intent).
+Aggregates that duplication cannot change are left alone entirely -- `MIN`, `MAX` and `COUNT(DISTINCT ...)` read the same answer off repeated rows, so no join shape makes them wrong and none of the three rules fires on a query that uses only those.
+
+`COUNT(*)` is a middle case. It names no table, so it never triggers this rule -- counting the joined rows is usually the intent. But it does count rows, so across *two* fan-out joins it returns the product of the two children and rules 2 and 3 below still apply.
+
+The comma form is judged identically: `FROM orders o, order_items i WHERE i.order_id = o.id` states the same join as the `ON` spelling and inflates the same way.
 
 **2. Disjoint sibling facts**, read from the ontology's own `owl:disjointWith` axioms: two facts at different grains sharing a dimension.
 

--- a/docs/obqc.md
+++ b/docs/obqc.md
@@ -254,7 +254,7 @@ FROM orders o JOIN order_items i ON i.order_id = o.id;
 
 This one is **reported without blocking**, because the SQL does not say which count was meant. The identical shape is a ubiquitous correct idiom in a star join -- `SUM(CASE WHEN u.segment = 'SMB' THEN 1 ELSE 0 END)` over `orders JOIN users` counts orders, which is exactly right, and reads as an inflated count of users only if that is what you wanted. Blocking it would reject ordinary analytics SQL, so OBQC states the ambiguity and leaves the call to you.
 
-Only conditions naming a single table qualify. One that also names the child counts at the child's grain, which no join corrupts, and an unconditional `COUNT(*)` names nothing at all.
+Only conditions naming a single table qualify. One that also names the child counts at the child's grain, which no join corrupts, and an unconditional `COUNT(*)` names nothing at all. Unqualified condition columns resolve the same way value columns do -- against the tables in scope, and only when exactly one of them declares the name.
 
 **2. Disjoint sibling facts**, read from the ontology's own `owl:disjointWith` axioms: two facts at different grains sharing a dimension.
 

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -365,6 +365,7 @@ Execute a SQL query with built-in validation, fan-trap protection, and automatic
 | `limit` | integer | No | `1000` | Maximum rows to return (max: 5,000) |
 | `checklist_completed` | boolean | No | `false` | Confirmation that the pre-execution checklist has been completed |
 | `query_intent` | string | No | Auto-extracted | Natural language description of what the query aims to retrieve |
+| `allow_fan_out` | boolean | No | `false` | Execute even when OBQC detects a fan-trap. The finding is still reported, as a warning rather than a blocking error. |
 
 **Returns:** Dictionary containing:
 - `success` -- boolean execution result
@@ -372,6 +373,7 @@ Execute a SQL query with built-in validation, fan-trap protection, and automatic
 - `rows` -- array of result rows
 - `row_count` -- number of rows returned
 - `execution_time_ms` -- query execution time in milliseconds
+- `obqc_fan_trap` -- `{detected, blocking, findings}`, present on every response
 - `next_tool` -- suggests `generate_chart` when results contain data
 
 **Key Features:**
@@ -382,7 +384,7 @@ Execute a SQL query with built-in validation, fan-trap protection, and automatic
 - Query timeout protection
 - Result size capped at 5,000 rows
 - Automatically retrieves GraphRAG context for relevant tables when available
-- Fan-trap detection warns about data multiplication in multi-table joins
+- Fan-trap detection **blocks** queries whose aggregates read across a 1:many join (a single such join is enough); `allow_fan_out: true` runs one anyway
 - `query_intent` enables better GraphRAG context retrieval; if omitted, intent is auto-extracted from the SQL
 
 ---

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -373,7 +373,7 @@ Execute a SQL query with built-in validation, fan-trap protection, and automatic
 - `rows` -- array of result rows
 - `row_count` -- number of rows returned
 - `execution_time_ms` -- query execution time in milliseconds
-- `obqc_fan_trap` -- `{detected, blocking, findings}`, present on every response
+- `obqc_fan_trap` -- `{evaluated, detected, blocking, findings}`, present on every response. `evaluated: false` means the rules never ran (no ontology loaded, or the request failed before validation) -- treat that as unknown, not as clean.
 - `next_tool` -- suggests `generate_chart` when results contain data
 
 **Key Features:**

--- a/src/handlers/query.py
+++ b/src/handlers/query.py
@@ -240,7 +240,8 @@ async def execute_sql_query(
         fan_trap_report: dict[str, Any] = {
             "evaluated": False,
             "detected": False,
-            "blocking": not allow_fan_out,
+            # Nothing was checked, so nothing blocked on this account.
+            "blocking": False,
             "findings": [],
         }
 
@@ -402,7 +403,7 @@ async def execute_sql_query(
         err["obqc_fan_trap"] = {
             "evaluated": False,
             "detected": False,
-            "blocking": not allow_fan_out,
+            "blocking": False,
             "findings": [],
         }
         return err

--- a/src/handlers/query.py
+++ b/src/handlers/query.py
@@ -208,6 +208,7 @@ async def execute_sql_query(
     checklist_completed: bool | str,
     query_intent: str | None,
     services: "HandlerContext",
+    allow_fan_out: bool | str = False,
 ) -> dict[str, Any]:
     """Execute SQL query with built-in validation and fan-trap protection.
 
@@ -217,6 +218,8 @@ async def execute_sql_query(
         limit: Maximum rows to return
         checklist_completed: Pre-execution checklist confirmation
         query_intent: Natural language query description
+        allow_fan_out: Run the query even if OBQC finds a fan-trap. The finding
+            is still reported, as a warning rather than a blocking error.
         get_session_data: Function to get session data
         get_session_db_manager: Function to get session db manager
         get_session_obqc_validator: Function to get OBQC validator
@@ -225,6 +228,8 @@ async def execute_sql_query(
     try:
         if isinstance(checklist_completed, str):
             checklist_completed = checklist_completed.lower() in ("true", "1", "yes")
+        if isinstance(allow_fan_out, str):
+            allow_fan_out = allow_fan_out.lower() in ("true", "1", "yes")
 
         db_manager = services.get_session_db_manager(ctx)
 
@@ -254,10 +259,22 @@ async def execute_sql_query(
 
         # OBQC validation (fan-trap detection, ontology-aware checks)
         obqc_warnings = []
+        # Structured fan-trap verdict, carried onto the response whatever the
+        # outcome. A consumer that keys off fields rather than reading prose
+        # must be able to see a corrupted aggregate, and the success path used
+        # to say nothing at all.
+        fan_trap_report: dict[str, Any] = {
+            "detected": False,
+            "blocking": not allow_fan_out,
+            "findings": [],
+        }
         obqc_validator = services.get_session_obqc_validator(ctx)
         if obqc_validator:
             db_type = db_manager.connection_info.get("type", "postgresql")
-            obqc_result = obqc_validator.validate(sql_query.strip(), dialect=db_type)
+            obqc_result = obqc_validator.validate(
+                sql_query.strip(), dialect=db_type, allow_fan_out=allow_fan_out
+            )
+            fan_trap_report = obqc_result.to_dict()["obqc_fan_trap"]
 
             if not obqc_result.is_valid:
                 error_details = []
@@ -276,6 +293,7 @@ async def execute_sql_query(
                     "error_type": "obqc_error",
                     "obqc_issues": error_details,
                     "fan_trap_risk": obqc_result.fan_trap_risk,
+                    "obqc_fan_trap": fan_trap_report,
                     "warnings": [],
                     "query_plan": None,
                     "limit_applied": False,
@@ -289,9 +307,12 @@ async def execute_sql_query(
                     obqc_warnings.append(msg)
 
             if obqc_result.fan_trap_risk:
+                # Only reachable with allow_fan_out: otherwise a fan-trap is an
+                # error and the query never got here.
                 obqc_warnings.append(
-                    "[OBQC] FAN-TRAP RISK: Query aggregates across multiple "
-                    "1:many relationships. Consider UNION ALL pattern."
+                    "[OBQC] FAN-TRAP RISK accepted via allow_fan_out: aggregates "
+                    "read across a 1:many join and are inflated. See "
+                    "obqc_fan_trap for the tables involved."
                 )
 
             logger.debug(
@@ -328,6 +349,10 @@ async def execute_sql_query(
         if obqc_warnings:
             existing_warnings = result.get("warnings", [])
             result["warnings"] = existing_warnings + obqc_warnings
+
+        # Always present, so "no fan-trap" is an answer the caller can read
+        # rather than the absence of a sentence in warnings.
+        result["obqc_fan_trap"] = fan_trap_report
 
         if result.get("success"):
             logger.info(

--- a/src/handlers/query.py
+++ b/src/handlers/query.py
@@ -323,9 +323,11 @@ async def execute_sql_query(
                         msg += f" — {issue.suggestion}"
                     obqc_warnings.append(msg)
 
-            if obqc_result.fan_trap_risk:
-                # Only reachable with allow_fan_out: otherwise a fan-trap is an
-                # error and the query never got here.
+            if obqc_result.fan_trap_overridden:
+                # Only when allow_fan_out actually downgraded a blocking
+                # finding. Keyed off fan_trap_risk, this also fired for
+                # findings that never block, telling a caller who passed
+                # nothing that they had accepted a risk.
                 obqc_warnings.append(
                     "[OBQC] FAN-TRAP RISK accepted via allow_fan_out: aggregates "
                     "read across a 1:many join and are inflated. See "

--- a/src/handlers/query.py
+++ b/src/handlers/query.py
@@ -231,43 +231,59 @@ async def execute_sql_query(
         if isinstance(allow_fan_out, str):
             allow_fan_out = allow_fan_out.lower() in ("true", "1", "yes")
 
-        db_manager = services.get_session_db_manager(ctx)
-
-        if not db_manager.has_engine():
-            return ConnectionError(
-                "No database connection established. Please use connect_database tool first to establish a connection to PostgreSQL, Snowflake, or Dremio.",
-                details="Available connection methods: connect_database('postgresql'), connect_database('snowflake'), connect_database('dremio')",
-            ).to_response()
-
-        if limit <= 0 or limit > 5000:
-            return ParameterError(
-                f"Invalid limit value '{limit}'. Must be between 1 and 5000.",
-                details="Use a reasonable limit to prevent memory exhaustion while allowing comprehensive analysis.",
-            ).to_response()
-
-        if not sql_query or not sql_query.strip():
-            return ParameterError(
-                "SQL query cannot be empty.",
-                details="Provide a valid SELECT statement or schema introspection query.",
-            ).to_response()
-
-        if not checklist_completed:
-            return ValidationError(
-                "ERROR: PRE-EXECUTION CHECKLIST NOT COMPLETED.\nSee tool description for required steps.",
-                details="You must complete the pre-execution checklist before executing SQL queries. Review the tool documentation for required steps.",
-            ).to_response()
-
-        # OBQC validation (fan-trap detection, ontology-aware checks)
-        obqc_warnings = []
-        # Structured fan-trap verdict, carried onto the response whatever the
-        # outcome. A consumer that keys off fields rather than reading prose
-        # must be able to see a corrupted aggregate, and the success path used
-        # to say nothing at all.
+        # Structured fan-trap verdict, carried onto every response this tool
+        # returns, so a caller reading fields never needs a special case for
+        # the paths that bail out early. "evaluated" separates "checked and
+        # clean" from "never checked" -- without it, a query run with no
+        # ontology loaded reported detected=false and read as a clean bill of
+        # health.
         fan_trap_report: dict[str, Any] = {
+            "evaluated": False,
             "detected": False,
             "blocking": not allow_fan_out,
             "findings": [],
         }
+
+        def _with_verdict(response: dict[str, Any]) -> dict[str, Any]:
+            response["obqc_fan_trap"] = fan_trap_report
+            return response
+
+        db_manager = services.get_session_db_manager(ctx)
+
+        if not db_manager.has_engine():
+            return _with_verdict(
+                ConnectionError(
+                    "No database connection established. Please use connect_database tool first to establish a connection to PostgreSQL, Snowflake, or Dremio.",
+                    details="Available connection methods: connect_database('postgresql'), connect_database('snowflake'), connect_database('dremio')",
+                ).to_response()
+            )
+
+        if limit <= 0 or limit > 5000:
+            return _with_verdict(
+                ParameterError(
+                    f"Invalid limit value '{limit}'. Must be between 1 and 5000.",
+                    details="Use a reasonable limit to prevent memory exhaustion while allowing comprehensive analysis.",
+                ).to_response()
+            )
+
+        if not sql_query or not sql_query.strip():
+            return _with_verdict(
+                ParameterError(
+                    "SQL query cannot be empty.",
+                    details="Provide a valid SELECT statement or schema introspection query.",
+                ).to_response()
+            )
+
+        if not checklist_completed:
+            return _with_verdict(
+                ValidationError(
+                    "ERROR: PRE-EXECUTION CHECKLIST NOT COMPLETED.\nSee tool description for required steps.",
+                    details="You must complete the pre-execution checklist before executing SQL queries. Review the tool documentation for required steps.",
+                ).to_response()
+            )
+
+        # OBQC validation (fan-trap detection, ontology-aware checks)
+        obqc_warnings = []
         obqc_validator = services.get_session_obqc_validator(ctx)
         if obqc_validator:
             db_type = db_manager.connection_info.get("type", "postgresql")
@@ -381,4 +397,12 @@ async def execute_sql_query(
             "internal_error",
             "This may indicate a system-level issue. Please check server logs and try again.",
         )
+        # The failure may have happened before, during or after validation, so
+        # the honest verdict here is "not evaluated".
+        err["obqc_fan_trap"] = {
+            "evaluated": False,
+            "detected": False,
+            "blocking": not allow_fan_out,
+            "findings": [],
+        }
         return err

--- a/src/main.py
+++ b/src/main.py
@@ -468,6 +468,7 @@ async def execute_sql_query(
     limit: int = 1000,
     checklist_completed: bool = False,
     query_intent: _ShortText | None = None,
+    allow_fan_out: bool = False,
 ) -> dict[str, Any]:
     """Execute SQL query with built-in syntax validation, security checks, OBQC
     validation, and fan-trap protection.
@@ -481,6 +482,13 @@ async def execute_sql_query(
     is loaded, OBQC checks (fan-trap detection, semantic validation) run too — errors
     block execution, warnings are included in the result.
 
+    A detected fan-trap blocks execution: aggregating across a 1:many join returns
+    a silently inflated number, so the query is refused rather than answered wrongly.
+    Every response carries `obqc_fan_trap` ({detected, blocking, findings}) so the
+    verdict is readable as data. Pre-aggregate in a CTE or use the UNION ALL
+    Composite Fact Layer to fix the query; pass allow_fan_out=True only to run it
+    anyway.
+
     REQUIRES: connect_database must be called first.
 
     Args:
@@ -488,6 +496,11 @@ async def execute_sql_query(
         limit: Maximum rows to return (default: 1000, max: 5,000)
         checklist_completed: Confirmation that pre-execution checklist is complete
         query_intent: Optional natural language description of query intent
+        allow_fan_out: Execute even when OBQC finds a fan-trap. Aggregates read
+            across a 1:many join are inflated, so only set this when the
+            multiplied rows are what you want (or you have verified the join is
+            1:1 in practice). The finding is still reported, as a warning
+            instead of a blocking error, and `obqc_fan_trap` names the tables.
     """
     return await _h_query.execute_sql_query(
         ctx,
@@ -496,6 +509,7 @@ async def execute_sql_query(
         checklist_completed,
         query_intent,
         services=_services(),
+        allow_fan_out=allow_fan_out,
     )
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -482,12 +482,18 @@ async def execute_sql_query(
     is loaded, OBQC checks (fan-trap detection, semantic validation) run too — errors
     block execution, warnings are included in the result.
 
-    A detected fan-trap blocks execution: aggregating across a 1:many join returns
-    a silently inflated number, so the query is refused rather than answered wrongly.
-    Every response carries `obqc_fan_trap` ({detected, blocking, findings}) so the
-    verdict is readable as data. Pre-aggregate in a CTE or use the UNION ALL
-    Composite Fact Layer to fix the query; pass allow_fan_out=True only to run it
-    anyway.
+    Aggregating across a 1:many join returns a silently inflated number, so a
+    provable fan-trap blocks execution rather than answering wrongly. Fix it by
+    pre-aggregating in a CTE or using the UNION ALL Composite Fact Layer; pass
+    allow_fan_out=True only to run it anyway.
+
+    Every response carries `obqc_fan_trap`: {evaluated, detected, blocking,
+    findings}. Read `evaluated` first -- false means the rules never ran (no
+    ontology loaded, or the request failed before validation), which is "unknown",
+    not "clean". `blocking` says whether the verdict actually stopped this query.
+    Not every finding blocks: a `conditional_row_count` (SUM(CASE WHEN ... THEN 1
+    END) over a join that repeats what it counts) is reported as a warning,
+    because the same shape is a correct star-join idiom.
 
     REQUIRES: connect_database must be called first.
 

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -185,6 +185,13 @@ class OBQCResult:
     has_aggregation: bool = False
     has_group_by: bool = False
     fan_trap_risk: bool = False
+    # One entry per fan-trap finding, as data rather than prose: a consumer
+    # that keys off fields (an agent reading "success") must be able to see a
+    # corrupted aggregate without parsing an English sentence out of warnings.
+    fan_trap_findings: list[dict[str, Any]] = field(default_factory=list)
+    # Whether a fan-trap finding blocks execution. False when the caller opted
+    # in with allow_fan_out.
+    fan_trap_blocking: bool = True
     ontology_compatible: bool = True  # Whether ontology has oba: annotations
 
     # Keys of parsed_joins that belong in a response. Everything else the
@@ -223,6 +230,11 @@ class OBQCResult:
             "has_aggregation": self.has_aggregation,
             "has_group_by": self.has_group_by,
             "fan_trap_risk": self.fan_trap_risk,
+            "obqc_fan_trap": {
+                "detected": self.fan_trap_risk,
+                "blocking": self.fan_trap_blocking,
+                "findings": self.fan_trap_findings,
+            },
             "obqc_error_count": sum(
                 1 for i in self.issues if i.severity == OBQCSeverity.ERROR
             ),
@@ -491,17 +503,26 @@ class OBQCValidator:
             return default
         return val.lower() in ("true", "1", "yes")
 
-    def validate(self, sql_query: str, dialect: str = "postgresql") -> OBQCResult:
+    def validate(
+        self,
+        sql_query: str,
+        dialect: str = "postgresql",
+        allow_fan_out: bool = False,
+    ) -> OBQCResult:
         """Validate SQL query against loaded ontology.
 
         Args:
             sql_query: The SQL query to validate
             dialect: Database dialect ("postgresql", "snowflake", "dremio")
+            allow_fan_out: Downgrade fan-trap findings from blocking errors to
+                warnings. For a caller that has judged the fan-out harmless or
+                wants the multiplied rows on purpose; the finding is still
+                reported either way.
 
         Returns:
             OBQCResult with validation findings
         """
-        result = OBQCResult(is_valid=True)
+        result = OBQCResult(is_valid=True, fan_trap_blocking=not allow_fan_out)
         self._cte_references = set()
 
         if not self._schema_cache:
@@ -561,7 +582,7 @@ class OBQCValidator:
         self._validate_joins(parsed, result)
         self._validate_type_compatibility(parsed, result)
         self._validate_aggregation_context(parsed, result)
-        self._detect_fan_trap(result)
+        self._detect_fan_trap(result, blocking=not allow_fan_out)
 
         # Set overall validity
         result.is_valid = not any(
@@ -960,6 +981,10 @@ class OBQCValidator:
             # may carry no ON and still be conditioned.
             where_joins = self._where_joins_tables(select)
 
+            # Tables whose columns this SELECT adds up. A join can only report
+            # a wrong number if it multiplies rows a measure is taken from.
+            measure_tables = self._measure_tables(select, alias_map)
+
             for join in select.args.get("joins") or []:
                 join_info: dict[str, Any] = {
                     "type": join.kind or "INNER",
@@ -975,6 +1000,8 @@ class OBQCValidator:
                     # detection needs to know which table this join attaches
                     # to, and the ON condition is the only place that says so.
                     "on_tables": [],
+                    # Tables this SELECT sums or averages over, lower-cased.
+                    "measure_tables": measure_tables,
                 }
 
                 # How to name this join in a message. A joined subquery has
@@ -1023,6 +1050,77 @@ class OBQCValidator:
                     join_info["on_tables"] = on_tables
 
                 result.parsed_joins.append(join_info)
+
+    def _measure_tables(
+        self, select: exp.Select, alias_map: dict[str, str]
+    ) -> set[str]:
+        """Tables whose columns this SELECT aggregates in a duplication-sensitive way.
+
+        A fan-out join only produces a wrong number when a measure is taken
+        from the side it multiplies. ``SUM(sales.amount)`` over a join that
+        repeats each sale is wrong; ``SUM(shipments.weight)`` over the same
+        join is right, because the repeated rows *are* the shipments.
+
+        Only aggregates that duplication changes are counted. MIN and MAX are
+        indifferent to repeated rows, and so is COUNT(DISTINCT ...); SUM, AVG
+        and a plain COUNT of a column are not. ``COUNT(*)`` names no table and
+        so attributes to none -- counting joined rows is usually the intent.
+
+        Args:
+            select: The SELECT to inspect.
+            alias_map: This scope's alias -> table name map.
+
+        Returns:
+            Lower-cased table names whose columns are summed or averaged.
+        """
+        sensitive = (exp.Sum, exp.Avg, exp.Count)
+        tables: set[str] = set()
+
+        for agg in self._own_aggregates(select):
+            if not isinstance(agg, sensitive):
+                continue
+            # sqlglot models DISTINCT as a node wrapping the argument, not as a
+            # flag on the call: COUNT(DISTINCT id) is Count(this=Distinct(...)).
+            if isinstance(agg.this, exp.Distinct):
+                continue
+
+            for column in agg.find_all(exp.Column):
+                if column.table:
+                    resolved = alias_map.get(column.table.lower())
+                    if resolved:
+                        tables.add(resolved.lower())
+                    continue
+
+                # Unqualified: attribute it only when exactly one table in
+                # scope declares the name. Spreading an ambiguous name over
+                # every candidate would blame tables the measure may not come
+                # from, and a fan-trap finding blocks the query.
+                owners = self._tables_declaring(column.name, alias_map)
+                if len(owners) == 1:
+                    tables.add(owners[0])
+
+        return tables
+
+    def _tables_declaring(self, column: str, alias_map: dict[str, str]) -> list[str]:
+        """In-scope tables that declare *column*, lower-cased.
+
+        Args:
+            column: Unqualified column name.
+            alias_map: This scope's alias -> table name map.
+
+        Returns:
+            Distinct lower-cased table names owning the column.
+        """
+        if self._schema_cache is None:
+            return []
+
+        key = column.lower()
+        owners = set()
+        for table in alias_map.values():
+            schema = self._schema_cache.tables.get(table.lower())
+            if schema and key in schema.columns:
+                owners.add(table.lower())
+        return sorted(owners)
 
     def _resolve_qualifier(
         self, select: exp.Select | None, qualifier: str
@@ -1962,14 +2060,98 @@ class OBQCValidator:
 
         return False
 
-    def _detect_fan_trap(self, result: OBQCResult) -> None:
-        """Rule: Detect potential fan-trap patterns.
+    def _inflated_measures(self, result: OBQCResult) -> list[dict[str, Any]]:
+        """Joins that repeat rows a measure in the same SELECT is taken from.
 
-        Prefers the ontology's own ``owl:disjointWith`` axioms (sibling facts
-        sharing a dimension — the canonical fan-trap shape) so OBQC and the
-        ontology agree by construction. Falls back to the relationship heuristic
-        when no disjointness axioms are present (e.g. minimal imports).
+        The single-child fan trap: ``FROM sales JOIN shipments ON
+        shipments.sale_id = sales.id`` with ``SUM(sales.amount)`` returns a
+        total inflated by every sale that shipped more than once, and an inner
+        join silently drops the ones that never shipped. One fan-out join is
+        enough to corrupt the number, so no count threshold applies.
+
+        A measure taken from the *many* side is fine -- ``SUM(shipments.cost)``
+        over the same join sums each shipment once -- so what matters is the
+        direction between the measure's table and the one joined to it, not
+        which table the query happened to put in FROM. ``FROM order_items JOIN
+        orders`` summing ``orders.total`` inflates exactly as ``FROM orders
+        JOIN order_items`` does: both produce one row per item. Each join is
+        therefore judged from both ends.
+
+        Args:
+            result: Result carrying the extracted joins.
+
+        Returns:
+            One finding per (measure table, fan-out table) pair, deduplicated.
         """
+        findings: list[dict[str, Any]] = []
+        seen: set[tuple[str, str]] = set()
+
+        for join_info in result.parsed_joins:
+            if not join_info.get("scope_aggregates"):
+                continue
+
+            join_table = join_info.get("table")
+            measures = join_info.get("measure_tables") or set()
+            if not join_table or not measures:
+                continue
+
+            anchors = [
+                t
+                for t in join_info.get("on_tables", [])
+                if t.lower() != join_table.lower()
+            ]
+
+            for anchor in anchors:
+                # Both ends of the edge: whichever side holds the measure, the
+                # other one inflates it if the ontology puts it on the many
+                # side.
+                for measure_table, other in (
+                    (anchor, join_table),
+                    (join_table, anchor),
+                ):
+                    if measure_table.lower() not in measures:
+                        continue
+                    if not self._join_fans_out(other, measure_table):
+                        continue
+
+                    key = (measure_table.lower(), other.lower())
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    findings.append(
+                        {
+                            "kind": "measure_across_fan_out",
+                            "measure_table": measure_table,
+                            "fan_out_table": other,
+                            "tables": sorted({measure_table, other}),
+                        }
+                    )
+
+        return findings
+
+    def _detect_fan_trap(self, result: OBQCResult, blocking: bool = True) -> None:
+        """Rule: Detect fan-trap patterns.
+
+        Three findings, strongest first:
+
+        1. **Measure across a fan-out join.** The ontology says the joined
+           table is on the "many" side of the table a measure is taken from,
+           so every row of that measure is repeated and the total is inflated.
+           This holds for a *single* join -- ``sales JOIN shipments`` summing
+           ``sales.amount`` reports a wrong number with no second fact table in
+           sight, and used to pass in silence because the count heuristic below
+           needed two fan-outs before it said anything.
+        2. **Disjoint sibling facts**, from the ontology's own
+           ``owl:disjointWith`` axioms: the canonical fan-trap shape.
+        3. **Two or more fan-out joins** in one aggregating SELECT, the
+           heuristic fallback for ontologies with no disjointness axioms.
+
+        Args:
+            result: Result to record findings on.
+            blocking: Whether a finding blocks the query (ERROR) or merely
+                annotates it (WARNING).
+        """
+        severity = OBQCSeverity.ERROR if blocking else OBQCSeverity.WARNING
         # Only joins whose own SELECT aggregates can inflate a total. The
         # query-wide flag is true if an aggregate appears anywhere, so an
         # unrelated subquery's COUNT(*) used to raise a fan-trap warning about
@@ -1986,6 +2168,39 @@ class OBQCValidator:
         if self._schema_cache is None:
             return
 
+        # --- Measure multiplied by a fan-out join ----------------------------
+        #
+        # The most direct evidence there is: a table is summed, and a join in
+        # the same SELECT repeats its rows. One such join is enough.
+        inflated = self._inflated_measures(result)
+        if inflated:
+            result.fan_trap_risk = True
+            result.fan_trap_findings.extend(inflated)
+            for finding in inflated:
+                measure = anchor = finding["measure_table"]
+                fanning = finding["fan_out_table"]
+                result.issues.append(
+                    OBQCIssue(
+                        issue_type=OBQCIssueType.FAN_TRAP_DETECTED,
+                        severity=severity,
+                        message=(
+                            f"Fan-trap: aggregating '{measure}' across the join to "
+                            f"'{fanning}', which the ontology puts on the many side of "
+                            f"'{anchor}'. Each {anchor} row is repeated once per "
+                            f"matching {fanning} row, so the total is inflated."
+                        ),
+                        location="Query structure",
+                        suggestion=(
+                            f"Pre-aggregate {fanning} in a CTE and join the one row per "
+                            f"{anchor} that produces, or aggregate each fact separately "
+                            "and combine with UNION ALL (Composite Fact Layer). "
+                            "COUNT(DISTINCT ...) also reads correctly across a fan-out."
+                        ),
+                        related_entities=sorted({measure, fanning, anchor}),
+                    )
+                )
+            return
+
         # --- Axiom-grounded path: disjoint sibling facts in one SELECT --------
         #
         # Scoped like the heuristic below. Reading the disjoint pair off every
@@ -2000,10 +2215,16 @@ class OBQCValidator:
         if disjoint_hits:
             result.fan_trap_risk = True
             involved = sorted({t for pair in disjoint_hits for t in pair})
+            result.fan_trap_findings.append(
+                {
+                    "kind": "disjoint_facts",
+                    "tables": involved,
+                }
+            )
             result.issues.append(
                 OBQCIssue(
                     issue_type=OBQCIssueType.FAN_TRAP_DETECTED,
-                    severity=OBQCSeverity.WARNING,
+                    severity=severity,
                     message=(
                         "Potential fan-trap: query aggregates across tables the ontology "
                         f"declares disjoint (sibling facts sharing a dimension): "
@@ -2066,10 +2287,17 @@ class OBQCValidator:
 
         if one_to_many_count >= 2:
             result.fan_trap_risk = True
+            result.fan_trap_findings.append(
+                {
+                    "kind": "multiple_fan_out_joins",
+                    "tables": sorted(set(involved_tables)),
+                    "join_count": one_to_many_count,
+                }
+            )
             result.issues.append(
                 OBQCIssue(
                     issue_type=OBQCIssueType.FAN_TRAP_DETECTED,
-                    severity=OBQCSeverity.WARNING,
+                    severity=severity,
                     message=f"Potential fan-trap: {one_to_many_count} one-to-many joins with aggregation",
                     location="Query structure",
                     suggestion=(

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -197,6 +197,11 @@ class OBQCResult:
     # with no ontology loaded reported detected=false and read as a clean bill
     # of health.
     fan_trap_evaluated: bool = False
+    # Whether allow_fan_out actually downgraded a finding that would otherwise
+    # have blocked. Distinct from fan_trap_risk, which is also true for
+    # findings that never block, so a caller who passed nothing is not told
+    # they accepted a risk.
+    fan_trap_overridden: bool = False
     ontology_compatible: bool = True  # Whether ontology has oba: annotations
 
     # Keys of parsed_joins that belong in a response. Everything else the
@@ -1271,15 +1276,24 @@ class OBQCValidator:
         for agg in self._duplication_sensitive_aggregates(select):
             if self._value_columns(agg):
                 continue
-            condition_tables = {
-                resolved
-                for column in self._condition_columns(agg)
-                if column.table
-                for resolved in [alias_map.get(column.table.lower())]
-                if resolved
-            }
+            condition_tables: set[str] = set()
+            for column in self._condition_columns(agg):
+                if column.table:
+                    resolved = alias_map.get(column.table.lower())
+                    if resolved:
+                        condition_tables.add(resolved.lower())
+                    continue
+
+                # Unqualified, exactly as the value side handles it: attribute
+                # only when a single table in scope declares the name. Reading
+                # qualified names alone missed the same risky query written
+                # without the prefix.
+                owners = self._tables_declaring(column.name, alias_map)
+                if len(owners) == 1:
+                    condition_tables.add(owners[0])
+
             if len(condition_tables) == 1:
-                counted.add(next(iter(condition_tables)).lower())
+                counted.add(next(iter(condition_tables)))
 
         return counted
 
@@ -2393,6 +2407,14 @@ class OBQCValidator:
                 annotates it (WARNING).
         """
         severity = OBQCSeverity.ERROR if blocking else OBQCSeverity.WARNING
+
+        def record(finding: dict[str, Any]) -> None:
+            """Note a finding of a kind that blocks unless allow_fan_out was set."""
+            result.fan_trap_risk = True
+            result.fan_trap_findings.append(finding)
+            if not blocking:
+                result.fan_trap_overridden = True
+
         # Only joins whose own SELECT aggregates can inflate a total. The
         # query-wide flag is true if an aggregate appears anywhere, so an
         # unrelated subquery's COUNT(*) used to raise a fan-trap warning about
@@ -2418,9 +2440,8 @@ class OBQCValidator:
         # the same SELECT repeats its rows. One such join is enough.
         inflated = self._inflated_measures(result)
         if inflated:
-            result.fan_trap_risk = True
-            result.fan_trap_findings.extend(inflated)
             for finding in inflated:
+                record(finding)
                 measure = anchor = finding["measure_table"]
                 fanning = finding["fan_out_table"]
                 result.issues.append(
@@ -2457,14 +2478,8 @@ class OBQCValidator:
             queried = {t.lower() for t in scope}
             disjoint_hits |= {pair for pair in self._disjoint_pairs if pair <= queried}
         if disjoint_hits:
-            result.fan_trap_risk = True
             involved = sorted({t for pair in disjoint_hits for t in pair})
-            result.fan_trap_findings.append(
-                {
-                    "kind": "disjoint_facts",
-                    "tables": involved,
-                }
-            )
+            record({"kind": "disjoint_facts", "tables": involved})
             result.issues.append(
                 OBQCIssue(
                     issue_type=OBQCIssueType.FAN_TRAP_DETECTED,
@@ -2558,8 +2573,7 @@ class OBQCValidator:
         involved_tables = worst_scope
 
         if one_to_many_count >= 2:
-            result.fan_trap_risk = True
-            result.fan_trap_findings.append(
+            record(
                 {
                     "kind": "multiple_fan_out_joins",
                     "tables": sorted(set(involved_tables)),

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -192,6 +192,11 @@ class OBQCResult:
     # Whether a fan-trap finding blocks execution. False when the caller opted
     # in with allow_fan_out.
     fan_trap_blocking: bool = True
+    # Whether the fan-trap rules actually ran. False means "not checked", which
+    # is not the same answer as "nothing found" -- without it, a query validated
+    # with no ontology loaded reported detected=false and read as a clean bill
+    # of health.
+    fan_trap_evaluated: bool = False
     ontology_compatible: bool = True  # Whether ontology has oba: annotations
 
     # Keys of parsed_joins that belong in a response. Everything else the
@@ -231,6 +236,7 @@ class OBQCResult:
             "has_group_by": self.has_group_by,
             "fan_trap_risk": self.fan_trap_risk,
             "obqc_fan_trap": {
+                "evaluated": self.fan_trap_evaluated,
                 "detected": self.fan_trap_risk,
                 "blocking": self.fan_trap_blocking,
                 "findings": self.fan_trap_findings,
@@ -567,6 +573,10 @@ class OBQCValidator:
                 )
             )
             return result
+
+        # Past the guards: the rules below really run, so a "not detected"
+        # verdict from here on means the query was checked and came back clean.
+        result.fan_trap_evaluated = True
 
         # Extract query components. CTE names first: the rules below need to
         # know which references name a WITH alias rather than a real table.
@@ -1149,6 +1159,47 @@ class OBQCValidator:
             and not isinstance(agg.this, exp.Distinct)
         ]
 
+    @classmethod
+    def _value_columns(cls, expr: exp.Expr | None) -> list[exp.Column]:
+        """Columns that contribute to *expr*'s value, not to a condition in it.
+
+        A conditional aggregate reads its measure from the branches, never from
+        the test: in ``CASE WHEN a.flag THEN b.amount ELSE 0 END`` the value is
+        ``b.amount`` and ``a.flag`` only decides whether it is taken. Treating
+        both alike attributed the measure to the wrong table.
+
+        Args:
+            expr: Expression to walk, or None.
+
+        Returns:
+            The value-producing column references, in source order.
+        """
+        if expr is None:
+            return []
+
+        if isinstance(expr, exp.Column):
+            return [expr]
+
+        if isinstance(expr, exp.Case):
+            # CASE <operand> WHEN ... : the operand is half of a comparison,
+            # so it is a condition like the WHEN tests are.
+            columns: list[exp.Column] = []
+            for branch in expr.args.get("ifs") or []:
+                columns += cls._value_columns(branch.args.get("true"))
+            return columns + cls._value_columns(expr.args.get("default"))
+
+        if isinstance(expr, exp.If):
+            return cls._value_columns(expr.args.get("true")) + cls._value_columns(
+                expr.args.get("false")
+            )
+
+        columns = []
+        for value in expr.args.values():
+            for item in value if isinstance(value, list) else [value]:
+                if isinstance(item, exp.Expression):
+                    columns += cls._value_columns(item)
+        return columns
+
     def _measure_tables(
         self, select: exp.Select, alias_map: dict[str, str]
     ) -> set[str]:
@@ -1164,6 +1215,14 @@ class OBQCValidator:
         and a plain COUNT of a column are not. ``COUNT(*)`` names no table and
         so attributes to none -- counting joined rows is usually the intent.
 
+        Within an aggregate, only the columns that produce its *value* count.
+        A column tested in a condition contributes nothing to the total, so
+        ``SUM(CASE WHEN orders.total > 100 THEN order_items.quantity ELSE 0
+        END)`` measures order_items and merely filters on orders -- reading
+        every column under the aggregate blamed orders and blocked a safe
+        conditional aggregate, which is the shape the fan-trap guidance itself
+        recommends.
+
         Args:
             select: The SELECT to inspect.
             alias_map: This scope's alias -> table name map.
@@ -1174,7 +1233,7 @@ class OBQCValidator:
         tables: set[str] = set()
 
         for agg in self._duplication_sensitive_aggregates(select):
-            for column in agg.find_all(exp.Column):
+            for column in self._value_columns(agg):
                 if column.table:
                     resolved = alias_map.get(column.table.lower())
                     if resolved:

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -189,9 +189,11 @@ class OBQCResult:
     # that keys off fields (an agent reading "success") must be able to see a
     # corrupted aggregate without parsing an English sentence out of warnings.
     fan_trap_findings: list[dict[str, Any]] = field(default_factory=list)
-    # Whether a fan-trap finding blocks execution. False when the caller opted
-    # in with allow_fan_out.
-    fan_trap_blocking: bool = True
+    # Whether the fan-trap verdict actually stopped the query. Computed from
+    # the issues that were raised, so it starts false: a run that returns
+    # before the rules execute blocked nothing, and saying otherwise
+    # contradicted the field's own meaning.
+    fan_trap_blocking: bool = False
     # Whether the fan-trap rules actually ran. False means "not checked", which
     # is not the same answer as "nothing found" -- without it, a query validated
     # with no ontology loaded reported detected=false and read as a clean bill
@@ -533,7 +535,7 @@ class OBQCValidator:
         Returns:
             OBQCResult with validation findings
         """
-        result = OBQCResult(is_valid=True, fan_trap_blocking=not allow_fan_out)
+        result = OBQCResult(is_valid=True)
         self._cte_references = set()
 
         if not self._schema_cache:

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -966,7 +966,12 @@ class OBQCValidator:
             # inflates a total if the aggregation happens over these joins --
             # an aggregate in some unrelated subquery does not.
             scope_aggregates = self._select_aggregates(select)
-            if scope_aggregates:
+            # Whether any of them is one duplication would corrupt. MAX and
+            # COUNT(DISTINCT ...) read the same answer off multiplied rows, so
+            # a query using only those is safe across any join shape -- and was
+            # being blocked outright by the rules below.
+            scope_sensitive = bool(self._duplication_sensitive_aggregates(select))
+            if scope_sensitive:
                 result.aggregating_scopes.append(
                     tuple(
                         dict.fromkeys(
@@ -991,6 +996,8 @@ class OBQCValidator:
                     "table": None,
                     "on_condition": None,
                     "scope_aggregates": scope_aggregates,
+                    # Whether this scope's aggregates can be corrupted at all.
+                    "scope_sensitive": scope_sensitive,
                     # Identifies the owning SELECT so fan-out is counted within
                     # one query rather than pooled across unrelated ones. A
                     # traversal index, not id(select): object addresses vary
@@ -1038,18 +1045,109 @@ class OBQCValidator:
                 on_clause = join.args.get("on")
                 if on_clause is not None:
                     join_info["on_condition"] = on_clause.sql()
-                    on_tables: list[str] = []
-                    for column in on_clause.find_all(exp.Column):
-                        if not column.table:
-                            continue
-                        # Columns are qualified by alias far more often than by
-                        # table name, so resolve through the alias map.
-                        resolved = alias_map.get(column.table.lower(), column.table)
-                        if resolved not in on_tables:
-                            on_tables.append(resolved)
-                    join_info["on_tables"] = on_tables
+                    join_info["on_tables"] = self._condition_tables(
+                        on_clause, alias_map
+                    )
+                elif join_info["table"]:
+                    # A comma join states the same relationship in WHERE.
+                    # Reading anchors only from ON let the identical query
+                    # escape fan-trap detection by being written the older way:
+                    # "FROM orders o, order_items i WHERE i.order_id = o.id"
+                    # inflates SUM(o.total) exactly as the JOIN ... ON spelling
+                    # does, and returned fan_trap_risk=False.
+                    join_info["on_tables"] = self._where_anchors(
+                        select, join.this, alias_map
+                    )
 
                 result.parsed_joins.append(join_info)
+
+    @staticmethod
+    def _condition_tables(condition: exp.Expr, alias_map: dict[str, str]) -> list[str]:
+        """Real table names a join condition refers to.
+
+        Args:
+            condition: An ON clause, or a WHERE predicate acting as one.
+            alias_map: The owning scope's alias -> table name map.
+
+        Returns:
+            Distinct table names, in the order the condition names them.
+        """
+        tables: list[str] = []
+        for column in condition.find_all(exp.Column):
+            if not column.table:
+                continue
+            # Columns are qualified by alias far more often than by table
+            # name, so resolve through the alias map.
+            resolved = alias_map.get(column.table.lower(), column.table)
+            if resolved not in tables:
+                tables.append(resolved)
+        return tables
+
+    def _where_anchors(
+        self, select: exp.Select, joined: exp.Expr, alias_map: dict[str, str]
+    ) -> list[str]:
+        """Tables that *joined* is tied to by an equality in this SELECT's WHERE.
+
+        The comma form's counterpart to reading anchors off an ON clause.
+
+        Args:
+            select: The SELECT owning the join and the WHERE.
+            joined: The table introduced by the comma join.
+            alias_map: The scope's alias -> table name map.
+
+        Returns:
+            Table names the join attaches to, including the joined table
+            itself, matching what an ON clause would have yielded.
+        """
+        if not isinstance(joined, exp.Table):
+            return []
+
+        where = select.args.get("where")
+        if where is None:
+            return []
+
+        key = (joined.alias or joined.name).lower()
+        anchors: list[str] = []
+
+        for eq in where.find_all(exp.EQ):
+            # An equality inside a nested subquery belongs to that scope.
+            if eq.find_ancestor(exp.Select) is not select:
+                continue
+            left, right = eq.this, eq.expression
+            if not (isinstance(left, exp.Column) and isinstance(right, exp.Column)):
+                continue
+            qualifiers = {side.table.lower() for side in (left, right) if side.table}
+            if key not in qualifiers or len(qualifiers) < 2:
+                continue
+            for name in self._condition_tables(eq, alias_map):
+                if name not in anchors:
+                    anchors.append(name)
+
+        return anchors
+
+    def _duplication_sensitive_aggregates(self, select: exp.Select) -> list[Any]:
+        """This SELECT's aggregates whose value repeated rows would change.
+
+        MIN and MAX read the same answer off a duplicated set, and so does
+        COUNT(DISTINCT ...). SUM, AVG and a plain COUNT do not. ``COUNT(*)``
+        counts rows, so it belongs here even though it names no table -- across
+        two fan-out joins it returns the product of the two children.
+
+        Args:
+            select: The SELECT to inspect.
+
+        Returns:
+            Aggregate expressions of this scope that duplication corrupts.
+        """
+        sensitive = (exp.Sum, exp.Avg, exp.Count)
+        return [
+            agg
+            for agg in self._own_aggregates(select)
+            if isinstance(agg, sensitive)
+            # sqlglot models DISTINCT as a node wrapping the argument, not as a
+            # flag on the call: COUNT(DISTINCT id) is Count(this=Distinct(...)).
+            and not isinstance(agg.this, exp.Distinct)
+        ]
 
     def _measure_tables(
         self, select: exp.Select, alias_map: dict[str, str]
@@ -1073,17 +1171,9 @@ class OBQCValidator:
         Returns:
             Lower-cased table names whose columns are summed or averaged.
         """
-        sensitive = (exp.Sum, exp.Avg, exp.Count)
         tables: set[str] = set()
 
-        for agg in self._own_aggregates(select):
-            if not isinstance(agg, sensitive):
-                continue
-            # sqlglot models DISTINCT as a node wrapping the argument, not as a
-            # flag on the call: COUNT(DISTINCT id) is Count(this=Distinct(...)).
-            if isinstance(agg.this, exp.Distinct):
-                continue
-
+        for agg in self._duplication_sensitive_aggregates(select):
             for column in agg.find_all(exp.Column):
                 if column.table:
                     resolved = alias_map.get(column.table.lower())
@@ -2156,9 +2246,12 @@ class OBQCValidator:
         # query-wide flag is true if an aggregate appears anywhere, so an
         # unrelated subquery's COUNT(*) used to raise a fan-trap warning about
         # outer joins that aggregate nothing.
-        aggregating_joins = [
-            j for j in result.parsed_joins if j.get("scope_aggregates")
-        ]
+        # Only joins in a SELECT whose aggregates duplication can corrupt. A
+        # scope aggregating solely with MAX, MIN or COUNT(DISTINCT ...) reads
+        # the same answer however many times its rows are repeated, so no join
+        # shape makes it wrong -- and blocking it contradicted the rule that
+        # those aggregates survive a fan-out.
+        aggregating_joins = [j for j in result.parsed_joins if j.get("scope_sensitive")]
         if not aggregating_joins:
             return
 

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -599,6 +599,15 @@ class OBQCValidator:
             issue.severity == OBQCSeverity.ERROR for issue in result.issues
         )
 
+        # Whether the fan-trap verdict actually stopped the query, rather than
+        # just what the caller asked for: an ambiguous conditional count is
+        # reported without blocking even when blocking is on.
+        result.fan_trap_blocking = any(
+            issue.issue_type == OBQCIssueType.FAN_TRAP_DETECTED
+            and issue.severity == OBQCSeverity.ERROR
+            for issue in result.issues
+        )
+
         return result
 
     def _extract_ctes(self, parsed: exp.Expr, result: OBQCResult) -> None:
@@ -999,6 +1008,9 @@ class OBQCValidator:
             # Tables whose columns this SELECT adds up. A join can only report
             # a wrong number if it multiplies rows a measure is taken from.
             measure_tables = self._measure_tables(select, alias_map)
+            # Tables a constant-valued conditional aggregate counts by. Judged
+            # separately: those are ambiguous rather than provably wrong.
+            counted_tables = self._counted_tables(select, alias_map)
 
             for join in select.args.get("joins") or []:
                 join_info: dict[str, Any] = {
@@ -1019,6 +1031,7 @@ class OBQCValidator:
                     "on_tables": [],
                     # Tables this SELECT sums or averages over, lower-cased.
                     "measure_tables": measure_tables,
+                    "counted_tables": counted_tables,
                 }
 
                 # How to name this join in a message. A joined subquery has
@@ -1199,6 +1212,76 @@ class OBQCValidator:
                 if isinstance(item, exp.Expression):
                     columns += cls._value_columns(item)
         return columns
+
+    @classmethod
+    def _condition_columns(cls, agg: exp.Expr) -> list[exp.Column]:
+        """Columns an aggregate only tests, rather than reads a value from.
+
+        Includes a trailing ``FILTER (WHERE ...)``, which lives on the parent
+        node and is the same construct as a CASE test written another way.
+
+        Args:
+            agg: The aggregate call.
+
+        Returns:
+            Its condition-only column references.
+        """
+        value_ids = {id(column) for column in cls._value_columns(agg)}
+        columns = [c for c in agg.find_all(exp.Column) if id(c) not in value_ids]
+
+        parent = agg.parent
+        if isinstance(parent, exp.Filter):
+            where = parent.args.get("expression")
+            if isinstance(where, exp.Expression):
+                columns += list(where.find_all(exp.Column))
+
+        return columns
+
+    def _counted_tables(
+        self, select: exp.Select, alias_map: dict[str, str]
+    ) -> set[str]:
+        """Tables a constant-valued conditional aggregate counts rows by.
+
+        ``SUM(CASE WHEN orders.total > 100 THEN 1 ELSE 0 END)`` is COUNT(*)
+        over the rows where that holds. It has no measure column, so the
+        measure rule cannot see it, yet a join that repeats orders repeats the
+        count too -- three for a single qualifying order.
+
+        What it *should* count is not decidable from the SQL. The same shape is
+        a ubiquitous correct idiom in a star join: over ``orders JOIN users``,
+        ``SUM(CASE WHEN users.segment = 'SMB' THEN 1 ELSE 0 END)`` counts
+        orders, which is exactly right, and reads as an inflated count of users
+        only if that is what you meant. Both are "count the fine-grained rows
+        matching a coarse predicate", so callers get a warning rather than a
+        block.
+
+        Only conditions naming a single table qualify. One that also names the
+        child counts at the child's grain, which no join corrupts, and an
+        unconditional COUNT(*) names nothing at all.
+
+        Args:
+            select: The SELECT to inspect.
+            alias_map: This scope's alias -> table name map.
+
+        Returns:
+            Lower-cased table names such counts are conditioned on.
+        """
+        counted: set[str] = set()
+
+        for agg in self._duplication_sensitive_aggregates(select):
+            if self._value_columns(agg):
+                continue
+            condition_tables = {
+                resolved
+                for column in self._condition_columns(agg)
+                if column.table
+                for resolved in [alias_map.get(column.table.lower())]
+                if resolved
+            }
+            if len(condition_tables) == 1:
+                counted.add(next(iter(condition_tables)).lower())
+
+        return counted
 
     def _measure_tables(
         self, select: exp.Select, alias_map: dict[str, str]
@@ -2209,7 +2292,12 @@ class OBQCValidator:
 
         return False
 
-    def _inflated_measures(self, result: OBQCResult) -> list[dict[str, Any]]:
+    def _inflated_measures(
+        self,
+        result: OBQCResult,
+        key: str = "measure_tables",
+        kind: str = "measure_across_fan_out",
+    ) -> list[dict[str, Any]]:
         """Joins that repeat rows a measure in the same SELECT is taken from.
 
         The single-child fan trap: ``FROM sales JOIN shipments ON
@@ -2228,6 +2316,10 @@ class OBQCValidator:
 
         Args:
             result: Result carrying the extracted joins.
+            key: Which per-scope table set to read -- the measures an
+                aggregate takes its value from, or the tables a constant-valued
+                conditional aggregate counts by.
+            kind: Value for the finding's ``kind`` field.
 
         Returns:
             One finding per (measure table, fan-out table) pair, deduplicated.
@@ -2240,7 +2332,7 @@ class OBQCValidator:
                 continue
 
             join_table = join_info.get("table")
-            measures = join_info.get("measure_tables") or set()
+            measures = join_info.get(key) or set()
             if not join_table or not measures:
                 continue
 
@@ -2263,13 +2355,13 @@ class OBQCValidator:
                     if not self._join_fans_out(other, measure_table):
                         continue
 
-                    key = (measure_table.lower(), other.lower())
-                    if key in seen:
+                    pair = (measure_table.lower(), other.lower())
+                    if pair in seen:
                         continue
-                    seen.add(key)
+                    seen.add(pair)
                     findings.append(
                         {
-                            "kind": "measure_across_fan_out",
+                            "kind": kind,
                             "measure_table": measure_table,
                             "fan_out_table": other,
                             "tables": sorted({measure_table, other}),
@@ -2432,6 +2524,34 @@ class OBQCValidator:
             if any(self._join_fans_out(join_table, anchor) for anchor in anchors):
                 scope_id = join_info.get("scope_id")
                 fan_outs_by_scope.setdefault(scope_id, []).append(join_table)
+
+        # Ambiguous counts, reported but never blocking -- see _counted_tables
+        # for why the same shape is both a bug and a common correct idiom.
+        counts = self._inflated_measures(
+            result, key="counted_tables", kind="conditional_row_count"
+        )
+        for finding in counts:
+            result.fan_trap_risk = True
+            result.fan_trap_findings.append(finding)
+            counted, fanning = finding["measure_table"], finding["fan_out_table"]
+            result.issues.append(
+                OBQCIssue(
+                    issue_type=OBQCIssueType.FAN_TRAP_DETECTED,
+                    severity=OBQCSeverity.WARNING,
+                    message=(
+                        f"Conditional count over '{counted}', whose rows the join to "
+                        f"'{fanning}' repeats. This counts {fanning} rows matching a "
+                        f"{counted} condition, not {counted} rows -- correct if that "
+                        "is what you meant, inflated if it is not."
+                    ),
+                    location="Query structure",
+                    suggestion=(
+                        f"To count {counted} rows, use COUNT(DISTINCT {counted}.<key>) "
+                        f"or filter with EXISTS instead of joining {fanning}."
+                    ),
+                    related_entities=sorted({counted, fanning}),
+                )
+            )
 
         worst_scope = max(fan_outs_by_scope.values(), key=len, default=[])
         one_to_many_count = len(worst_scope)

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -129,6 +129,21 @@ TEMPORAL_LITERAL = re.compile(
     r"^\d{4}-\d{2}-\d{2}([ T]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?$"
 )
 
+# The fan-trap findings OBQC can report, strongest first. Named here so the
+# rules, the response and the documentation cannot drift apart -- each has gone
+# stale separately while this was built.
+KIND_MEASURE_ACROSS_FAN_OUT = "measure_across_fan_out"
+KIND_DISJOINT_FACTS = "disjoint_facts"
+KIND_MULTIPLE_FAN_OUT_JOINS = "multiple_fan_out_joins"
+KIND_CONDITIONAL_ROW_COUNT = "conditional_row_count"
+
+FAN_TRAP_KINDS = (
+    KIND_MEASURE_ACROSS_FAN_OUT,
+    KIND_DISJOINT_FACTS,
+    KIND_MULTIPLE_FAN_OUT_JOINS,
+    KIND_CONDITIONAL_ROW_COUNT,
+)
+
 # Comparison operators that can relate two tables. A join condition is not
 # always an equality: "ON a.starts < b.ends" is an ordinary theta join.
 COMPARISON_TYPES = (exp.EQ, exp.NEQ, exp.GT, exp.GTE, exp.LT, exp.LTE)
@@ -2481,7 +2496,7 @@ class OBQCValidator:
             disjoint_hits |= {pair for pair in self._disjoint_pairs if pair <= queried}
         if disjoint_hits:
             involved = sorted({t for pair in disjoint_hits for t in pair})
-            record({"kind": "disjoint_facts", "tables": involved})
+            record({"kind": KIND_DISJOINT_FACTS, "tables": involved})
             result.issues.append(
                 OBQCIssue(
                     issue_type=OBQCIssueType.FAN_TRAP_DETECTED,
@@ -2545,7 +2560,7 @@ class OBQCValidator:
         # Ambiguous counts, reported but never blocking -- see _counted_tables
         # for why the same shape is both a bug and a common correct idiom.
         counts = self._inflated_measures(
-            result, key="counted_tables", kind="conditional_row_count"
+            result, key="counted_tables", kind=KIND_CONDITIONAL_ROW_COUNT
         )
         for finding in counts:
             result.fan_trap_risk = True
@@ -2577,7 +2592,7 @@ class OBQCValidator:
         if one_to_many_count >= 2:
             record(
                 {
-                    "kind": "multiple_fan_out_joins",
+                    "kind": KIND_MULTIPLE_FAN_OUT_JOINS,
                     "tables": sorted(set(involved_tables)),
                     "join_count": one_to_many_count,
                 }

--- a/tests/test_fan_trap_contract_docs.py
+++ b/tests/test_fan_trap_contract_docs.py
@@ -1,0 +1,100 @@
+"""Keep the documented fan-trap contract in step with the code.
+
+The verdict's shape and severity rules changed several times while this was
+built, and each change left one description behind -- the tool docstring, then
+the skill file, each caught only in review. The skill in particular is served
+to agents over ``skill://``, so a stale copy is not a docs nit: it is what the
+model reads before deciding how to call the tool.
+
+These tests assert the properties that actually went wrong, not prose.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+from src.obqc_validator import OBQCResult
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Every file that describes the verdict to a human or to a model.
+CONTRACT_DOCS = (
+    ROOT / "docs" / "obqc.md",
+    ROOT / "docs" / "tools-reference.md",
+    ROOT / "docs" / "fan-trap-prevention.md",
+    ROOT / ".claude" / "skills" / "fan-trap-prevention.md",
+    ROOT / "src" / "main.py",
+)
+
+VERDICT_KEYS = ("evaluated", "detected", "blocking", "findings")
+
+
+class TestFanTrapContractIsDocumentedAccurately(unittest.TestCase):
+    def test_every_written_shape_lists_the_whole_verdict(self):
+        """A partial key list is how each stale description read.
+
+        Checked against the braces actually written, not against the file as a
+        whole: the stale skill listed ``{detected, blocking, findings}`` and
+        then mentioned ``evaluated`` in the next breath, so a file-wide search
+        for the word found it and proved nothing.
+        """
+        # The prose form -- "{evaluated, detected, blocking, findings}" -- is
+        # what went stale each time. A worked JSON example is skipped: its
+        # nested braces defeat a flat match, and it is not where the key list
+        # gets summarised.
+        shape = re.compile(r"\{([a-z_, ]*\b(?:detected|findings)\b[a-z_, ]*)\}")
+
+        for path in CONTRACT_DOCS:
+            text = path.read_text()
+            if "obqc_fan_trap" not in text:
+                continue
+
+            # Wrapped across lines in the tool docstring, so compare on one.
+            written = [
+                group
+                for group in shape.findall(re.sub(r"\s+", " ", text))
+                if sum(key in group for key in VERDICT_KEYS) >= 2
+            ]
+            with self.subTest(doc=path.relative_to(ROOT)):
+                self.assertTrue(
+                    written,
+                    f"{path.relative_to(ROOT)} describes obqc_fan_trap but "
+                    "never writes out its shape",
+                )
+                for group in written:
+                    missing = [key for key in VERDICT_KEYS if key not in group]
+                    self.assertEqual(
+                        missing,
+                        [],
+                        f"{path.relative_to(ROOT)} writes the verdict as "
+                        f"'{{{group}}}', missing {missing}",
+                    )
+
+    def test_no_description_claims_every_fan_trap_blocks(self):
+        """A conditional_row_count is reported without blocking.
+
+        Saying otherwise teaches a caller to treat a successful response as
+        proof that no fan-trap was found.
+        """
+        overbroad = re.compile(
+            r"fan-trap is a \*\*blocking error\*\*|every (detected )?fan-trap blocks",
+            re.IGNORECASE,
+        )
+        for path in CONTRACT_DOCS:
+            with self.subTest(doc=path.relative_to(ROOT)):
+                self.assertIsNone(
+                    overbroad.search(path.read_text()),
+                    f"{path.relative_to(ROOT)} says all fan-traps block, but "
+                    "conditional_row_count findings do not",
+                )
+
+    def test_documented_keys_match_the_result_object(self):
+        """The list above is only useful while it mirrors the code."""
+        self.assertEqual(
+            set(OBQCResult(is_valid=True).to_dict()["obqc_fan_trap"]),
+            set(VERDICT_KEYS),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fan_trap_contract_docs.py
+++ b/tests/test_fan_trap_contract_docs.py
@@ -13,7 +13,7 @@ import re
 import unittest
 from pathlib import Path
 
-from src.obqc_validator import OBQCResult
+from src.obqc_validator import FAN_TRAP_KINDS, KIND_CONDITIONAL_ROW_COUNT, OBQCResult
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -94,6 +94,55 @@ class TestFanTrapContractIsDocumentedAccurately(unittest.TestCase):
             set(OBQCResult(is_valid=True).to_dict()["obqc_fan_trap"]),
             set(VERDICT_KEYS),
         )
+
+    def test_every_finding_kind_is_documented(self):
+        """A kind the code can emit but no page explains is undocumented.
+
+        Adding the fourth kind left the reference describing three.
+        """
+        reference = (ROOT / "docs" / "obqc.md").read_text()
+        for kind in FAN_TRAP_KINDS:
+            with self.subTest(kind=kind):
+                self.assertIn(kind, reference)
+
+    def test_stated_counts_match_the_number_of_kinds(self):
+        """Prose that counts the rules has to count them correctly.
+
+        "Three findings, strongest first" outlived the third revision of this
+        list, and a reader has no way to tell it is stale.
+        """
+        words = {2: "two", 3: "three", 4: "four", 5: "five", 6: "six"}
+        expected = words[len(FAN_TRAP_KINDS)]
+        # Plural only: "One finding below is reported without blocking" counts
+        # a single rule, not the set.
+        counted = re.compile(
+            r"\b(two|three|four|five|six)\s+(findings|rules)\b", re.IGNORECASE
+        )
+
+        for path in CONTRACT_DOCS:
+            with self.subTest(doc=path.relative_to(ROOT)):
+                for word, noun in counted.findall(path.read_text()):
+                    self.assertEqual(
+                        word.lower(),
+                        expected,
+                        f"{path.relative_to(ROOT)} says '{word} {noun}' but "
+                        f"there are {len(FAN_TRAP_KINDS)} fan-trap findings",
+                    )
+
+    def test_the_fan_trap_section_is_not_labelled_error_only(self):
+        """One kind never blocks, so a bare (ERROR) heading misdescribes it."""
+        heading = re.compile(r"^#+ Fan-trap detection \((.+)\)\s*$", re.MULTILINE)
+
+        for path in CONTRACT_DOCS:
+            for severities in heading.findall(path.read_text()):
+                with self.subTest(doc=path.relative_to(ROOT)):
+                    self.assertIn(
+                        "WARNING",
+                        severities,
+                        f"{path.relative_to(ROOT)} labels fan-trap detection "
+                        f"'({severities})', but {KIND_CONDITIONAL_ROW_COUNT} "
+                        "is warning-only",
+                    )
 
 
 if __name__ == "__main__":

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -1918,6 +1918,30 @@ class TestSingleFanOutMeasure(unittest.TestCase):
         )
         self.assertFalse(result.to_dict()["obqc_fan_trap"]["blocking"])
 
+    def test_a_run_that_never_checked_did_not_block(self):
+        """blocking says the verdict stopped the query, so it starts false.
+
+        Initialising it from the caller's flag made an ontology without oba:
+        annotations -- where the rules never run -- report blocking: true on a
+        query that executed fine.
+        """
+        from rdflib import Graph
+
+        bare = OBQCValidator()
+        bare.load_ontology(Graph(), "http://example.com/")
+
+        for label, validator in (
+            ("no ontology", OBQCValidator()),
+            ("ontology without oba: annotations", bare),
+        ):
+            with self.subTest(case=label):
+                report = validator.validate("SELECT id FROM orders").to_dict()[
+                    "obqc_fan_trap"
+                ]
+
+                self.assertFalse(report["evaluated"])
+                self.assertFalse(report["blocking"])
+
     def test_clean_query_reports_no_fan_trap(self):
         """The verdict is a field even when the answer is no."""
         report = self.validator.validate("SELECT users.name FROM users").to_dict()[

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -987,6 +987,43 @@ class TestOBQCFanTrapDirection(unittest.TestCase):
             [("orders", "order_items")],
         )
 
+    def test_duplication_proof_aggregates_survive_two_fan_outs(self):
+        """MAX reads the same answer however often its rows are repeated.
+
+        The count heuristic fired on any aggregate at all, so it blocked
+        queries the measure rule deliberately leaves alone -- and once
+        fan-traps became errors, that stopped them running.
+        """
+        for aggregate in (
+            "MAX(orders.total)",
+            "MIN(orders.total)",
+            "COUNT(DISTINCT orders.id)",
+        ):
+            with self.subTest(aggregate=aggregate):
+                result = self.validator.validate(
+                    f"SELECT orders.id, {aggregate} "
+                    "FROM orders "
+                    "JOIN order_items ON orders.id = order_items.order_id "
+                    "JOIN shipments ON orders.id = shipments.order_id "
+                    "GROUP BY orders.id"
+                )
+
+                self.assertFalse(
+                    result.fan_trap_risk, [i.message for i in result.issues]
+                )
+
+    def test_count_star_across_two_fan_outs_is_still_a_fan_trap(self):
+        """COUNT(*) names no table, but it counts rows -- here, their product."""
+        result = self.validator.validate(
+            "SELECT orders.id, COUNT(*) "
+            "FROM orders "
+            "JOIN order_items ON orders.id = order_items.order_id "
+            "JOIN shipments ON orders.id = shipments.order_id "
+            "GROUP BY orders.id"
+        )
+
+        self.assertTrue(result.fan_trap_risk)
+
     def test_two_facts_on_one_dimension_is_still_a_fan_trap(self):
         """The true positive must survive: orders fans out twice."""
         result = self.validator.validate(
@@ -1651,6 +1688,35 @@ class TestSingleFanOutMeasure(unittest.TestCase):
             "SELECT users.name, SUM(orders.total) "
             "FROM orders JOIN users ON orders.user_id = users.id "
             "GROUP BY users.name"
+        )
+
+        self.assertFalse(result.fan_trap_risk, [i.message for i in result.issues])
+
+    def test_comma_join_spelling_is_caught_too(self):
+        """The older syntax states the same join and inflates identically.
+
+        Anchors were read only from ON, so writing the join the pre-SQL-92 way
+        skipped fan-trap detection entirely.
+        """
+        result = self.validator.validate(
+            "SELECT SUM(o.total) FROM orders o, order_items i "
+            "WHERE i.order_id = o.id"
+        )
+
+        self.assertTrue(result.fan_trap_risk)
+        self.assertFalse(result.is_valid)
+        self.assertEqual(
+            [
+                (f["measure_table"], f["fan_out_table"])
+                for f in result.fan_trap_findings
+            ],
+            [("orders", "order_items")],
+        )
+
+    def test_comma_join_measure_from_the_many_side_is_fine(self):
+        result = self.validator.validate(
+            "SELECT SUM(i.quantity) FROM orders o, order_items i "
+            "WHERE i.order_id = o.id"
         )
 
         self.assertFalse(result.fan_trap_risk, [i.message for i in result.issues])

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -1721,6 +1721,48 @@ class TestSingleFanOutMeasure(unittest.TestCase):
 
         self.assertFalse(result.fan_trap_risk, [i.message for i in result.issues])
 
+    def test_a_column_only_tested_in_a_condition_is_not_a_measure(self):
+        """A CASE test decides whether the value is taken, it is not the value.
+
+        Reading every column under the aggregate blamed the table named in the
+        WHEN clause, blocking a safe conditional aggregate -- the shape the
+        fan-trap guidance itself recommends.
+        """
+        result = self.validator.validate(
+            "SELECT orders.id, "
+            "SUM(CASE WHEN orders.total > 100 THEN order_items.quantity ELSE 0 END) "
+            "FROM orders JOIN order_items ON order_items.order_id = orders.id "
+            "GROUP BY orders.id"
+        )
+
+        self.assertFalse(result.fan_trap_risk, [i.message for i in result.issues])
+
+    def test_a_measure_inside_a_case_is_still_a_measure(self):
+        """Both branches produce the value, so both are read."""
+        for branch in (
+            "CASE WHEN order_items.quantity > 1 THEN orders.total ELSE 0 END",
+            "CASE WHEN order_items.quantity > 1 THEN 0 ELSE orders.total END",
+            "IF(order_items.quantity > 1, orders.total, 0)",
+        ):
+            with self.subTest(branch=branch):
+                result = self.validator.validate(
+                    f"SELECT orders.id, SUM({branch}) "
+                    "FROM orders JOIN order_items ON order_items.order_id = orders.id "
+                    "GROUP BY orders.id"
+                )
+
+                self.assertTrue(result.fan_trap_risk)
+
+    def test_arithmetic_on_a_one_side_column_is_a_measure(self):
+        """Multiplying by a repeated column inflates just as summing it does."""
+        result = self.validator.validate(
+            "SELECT orders.id, SUM(order_items.quantity * orders.total) "
+            "FROM orders JOIN order_items ON order_items.order_id = orders.id "
+            "GROUP BY orders.id"
+        )
+
+        self.assertTrue(result.fan_trap_risk)
+
     def test_finding_is_structured_not_prose(self):
         result = self.validator.validate(
             "SELECT SUM(orders.total) FROM orders "
@@ -1728,6 +1770,7 @@ class TestSingleFanOutMeasure(unittest.TestCase):
         )
 
         report = result.to_dict()["obqc_fan_trap"]
+        self.assertTrue(report["evaluated"])
         self.assertTrue(report["detected"])
         self.assertTrue(report["blocking"])
         self.assertEqual(
@@ -1768,7 +1811,15 @@ class TestSingleFanOutMeasure(unittest.TestCase):
             "obqc_fan_trap"
         ]
 
-        self.assertEqual(report, {"detected": False, "blocking": True, "findings": []})
+        self.assertEqual(
+            report,
+            {
+                "evaluated": True,
+                "detected": False,
+                "blocking": True,
+                "findings": [],
+            },
+        )
 
 
 class TestWindowFunctions(unittest.TestCase):

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -1813,6 +1813,55 @@ class TestSingleFanOutMeasure(unittest.TestCase):
                     result.fan_trap_risk, [i.message for i in result.issues]
                 )
 
+    def test_unqualified_condition_column_is_attributed(self):
+        """The same risky count written without the table prefix.
+
+        Reading qualified names only missed it, while the qualified spelling
+        was reported -- the value side already resolved unqualified names this
+        way.
+        """
+        result = self.validator.validate(
+            "SELECT SUM(CASE WHEN total > 100 THEN 1 ELSE 0 END) "
+            "FROM orders o JOIN order_items i ON i.order_id = o.id"
+        )
+
+        self.assertTrue(result.fan_trap_risk)
+        self.assertEqual(
+            [f["measure_table"] for f in result.fan_trap_findings], ["orders"]
+        )
+
+    def test_an_ambiguous_unqualified_condition_is_left_alone(self):
+        """order_id is declared by both tables, so it names neither grain."""
+        result = self.validator.validate(
+            "SELECT SUM(CASE WHEN order_id > 1 THEN 1 ELSE 0 END) "
+            "FROM orders o JOIN order_items i ON i.order_id = o.id"
+        )
+
+        self.assertFalse(result.fan_trap_risk, [i.message for i in result.issues])
+
+    def test_a_warning_only_finding_is_not_an_override(self):
+        """Nothing was downgraded, so the caller accepted nothing.
+
+        Keyed off fan_trap_risk, the response told a caller who passed no
+        allow_fan_out that they had accepted the risk with it.
+        """
+        result = self.validator.validate(
+            "SELECT SUM(CASE WHEN o.total > 100 THEN 1 ELSE 0 END) "
+            "FROM orders o JOIN order_items i ON i.order_id = o.id"
+        )
+
+        self.assertTrue(result.fan_trap_risk)
+        self.assertFalse(result.fan_trap_overridden)
+
+    def test_allow_fan_out_on_a_blocking_finding_is_an_override(self):
+        result = self.validator.validate(
+            "SELECT SUM(o.total) FROM orders o "
+            "JOIN order_items i ON i.order_id = o.id",
+            allow_fan_out=True,
+        )
+
+        self.assertTrue(result.fan_trap_overridden)
+
     def test_star_join_conditional_count_is_not_blocked(self):
         """The ubiquitous idiom: count facts matching a dimension predicate.
 

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -1763,6 +1763,70 @@ class TestSingleFanOutMeasure(unittest.TestCase):
 
         self.assertTrue(result.fan_trap_risk)
 
+    def test_conditional_row_count_is_reported_but_not_blocked(self):
+        """A constant-valued conditional aggregate is a filtered row count.
+
+        It has no measure column, so the measure rule cannot see it, yet the
+        join repeats what it counts. Whether that is wrong is not decidable
+        from the SQL -- the same shape is a correct star-join idiom -- so it is
+        reported without blocking. Checked against DuckDB: 3 for a single
+        qualifying order.
+        """
+        result = self.validator.validate(
+            "SELECT SUM(CASE WHEN o.total > 100 THEN 1 ELSE 0 END) "
+            "FROM orders o JOIN order_items i ON i.order_id = o.id"
+        )
+
+        self.assertTrue(result.fan_trap_risk)
+        self.assertTrue(result.is_valid)
+        self.assertEqual(
+            [f["kind"] for f in result.fan_trap_findings], ["conditional_row_count"]
+        )
+        self.assertFalse(result.to_dict()["obqc_fan_trap"]["blocking"])
+
+    def test_count_star_filter_is_the_same_construct(self):
+        """FILTER (WHERE ...) is a CASE test written another way."""
+        result = self.validator.validate(
+            "SELECT COUNT(*) FILTER (WHERE o.total > 100) "
+            "FROM orders o JOIN order_items i ON i.order_id = o.id"
+        )
+
+        self.assertTrue(result.fan_trap_risk)
+        self.assertTrue(result.is_valid)
+
+    def test_a_count_conditioned_on_the_child_is_clean(self):
+        """Counting at the child's grain is what the join already produces."""
+        for aggregate in (
+            "SUM(CASE WHEN i.quantity > 1 THEN 1 ELSE 0 END)",
+            "COUNT(*) FILTER (WHERE i.quantity > 1)",
+            # Naming both sides counts child rows too.
+            "SUM(CASE WHEN o.total > 100 AND i.quantity > 1 THEN 1 ELSE 0 END)",
+            "COUNT(*)",
+        ):
+            with self.subTest(aggregate=aggregate):
+                result = self.validator.validate(
+                    f"SELECT {aggregate} "
+                    "FROM orders o JOIN order_items i ON i.order_id = o.id"
+                )
+
+                self.assertFalse(
+                    result.fan_trap_risk, [i.message for i in result.issues]
+                )
+
+    def test_star_join_conditional_count_is_not_blocked(self):
+        """The ubiquitous idiom: count facts matching a dimension predicate.
+
+        Structurally identical to the case above -- the dimension's rows are
+        repeated by the fact join -- but here the repeated reading is the one
+        nobody means. Blocking it would reject ordinary analytics SQL.
+        """
+        result = self.validator.validate(
+            "SELECT SUM(CASE WHEN u.name = 'x' THEN 1 ELSE 0 END) "
+            "FROM orders o JOIN users u ON o.user_id = u.id"
+        )
+
+        self.assertTrue(result.is_valid)
+
     def test_finding_is_structured_not_prose(self):
         result = self.validator.validate(
             "SELECT SUM(orders.total) FROM orders "
@@ -1816,7 +1880,7 @@ class TestSingleFanOutMeasure(unittest.TestCase):
             {
                 "evaluated": True,
                 "detected": False,
-                "blocking": True,
+                "blocking": False,
                 "findings": [],
             },
         )

--- a/tests/test_obqc_validator.py
+++ b/tests/test_obqc_validator.py
@@ -929,9 +929,13 @@ class TestOBQCFanTrapDirection(unittest.TestCase):
         self.validator.load_ontology(self.graph, self.base_uri)
 
     def test_many_to_one_chain_is_not_a_fan_trap(self):
-        """order_items -> orders -> users: every hop is a lookup."""
+        """order_items -> orders -> users: every hop is a lookup.
+
+        The measure is taken at the finest grain in the query, so walking up to
+        the dimensions repeats nothing.
+        """
         result = self.validator.validate(
-            "SELECT users.name, SUM(orders.total) "
+            "SELECT users.name, SUM(order_items.quantity) "
             "FROM order_items "
             "JOIN orders ON order_items.order_id = orders.id "
             "JOIN users ON orders.user_id = users.id "
@@ -946,16 +950,41 @@ class TestOBQCFanTrapDirection(unittest.TestCase):
     def test_many_to_one_chain_with_aliases_is_not_a_fan_trap(self):
         """ON conditions are qualified by alias, so aliases must resolve."""
         result = self.validator.validate(
-            "SELECT u.name, COUNT(*) AS n, SUM(o.total) AS lifetime_value "
+            "SELECT u.name, SUM(oi.quantity) AS units "
             "FROM public.order_items oi "
             "JOIN public.orders o ON oi.order_id = o.id "
             "JOIN public.users u ON o.user_id = u.id "
-            "GROUP BY u.name ORDER BY SUM(o.total) DESC"
+            "GROUP BY u.name ORDER BY SUM(oi.quantity) DESC"
         )
 
         self.assertFalse(
             result.fan_trap_risk,
             [i.message for i in result.issues],
+        )
+
+    def test_parent_measure_at_child_grain_is_a_fan_trap(self):
+        """The same chain, but summing the parent's measure, does inflate.
+
+        ``FROM order_items JOIN orders`` yields one row per item, so each
+        order's total is added once per item it contains. Checked against
+        DuckDB: two orders totalling 150 come back as 250 when order 1 has two
+        items. Which table sits in FROM makes no difference to that.
+        """
+        result = self.validator.validate(
+            "SELECT users.name, SUM(orders.total) "
+            "FROM order_items "
+            "JOIN orders ON order_items.order_id = orders.id "
+            "JOIN users ON orders.user_id = users.id "
+            "GROUP BY users.name"
+        )
+
+        self.assertTrue(result.fan_trap_risk)
+        self.assertEqual(
+            [
+                (f["measure_table"], f["fan_out_table"])
+                for f in result.fan_trap_findings
+            ],
+            [("orders", "order_items")],
         )
 
     def test_two_facts_on_one_dimension_is_still_a_fan_trap(self):
@@ -1069,19 +1098,21 @@ class TestOBQCFanTrapDirection(unittest.TestCase):
 
         self.assertTrue(result.fan_trap_risk)
 
-    def test_unrelated_join_is_not_counted(self):
-        """Tables with no ontology relationship cannot be judged to fan out."""
+    def test_only_the_fanning_join_is_blamed(self):
+        """A lookup joined alongside a fan-out must not be named as the cause.
+
+        shipments multiplies orders; users is a many-to-one lookup and
+        multiplies nothing. The finding must say so.
+        """
         result = self.validator.validate(
             "SELECT SUM(orders.total) FROM orders "
             "JOIN users ON orders.user_id = users.id "
             "JOIN shipments ON shipments.order_id = orders.id"
         )
 
-        # shipments fans out from orders; users does not. One fan-out only.
-        self.assertFalse(
-            result.fan_trap_risk,
-            [i.message for i in result.issues],
-        )
+        self.assertTrue(result.fan_trap_risk)
+        blamed = {f["fan_out_table"] for f in result.fan_trap_findings}
+        self.assertEqual(blamed, {"shipments"})
 
 
 class TestOBQCFanTrapDimensionWithOwnKeys(unittest.TestCase):
@@ -1540,6 +1571,138 @@ class TestIncompatibleOntology(unittest.TestCase):
 
         self.assertIn("obqc_ontology_compatible", result_dict)
         self.assertTrue(result_dict["obqc_ontology_compatible"])
+
+
+class TestSingleFanOutMeasure(unittest.TestCase):
+    """One 1:many join is enough to inflate a measure taken from the one side.
+
+    The count heuristic needed two fan-out joins before it said anything, so
+    ``orders JOIN order_items`` summing ``orders.total`` -- which repeats each
+    order's total once per item -- passed in silence.
+    """
+
+    def setUp(self):
+        self.graph, self.base_uri = create_sample_ontology_graph()
+        self.validator = OBQCValidator()
+        self.validator.load_ontology(self.graph, self.base_uri)
+
+    def test_measure_from_the_one_side_is_blocked(self):
+        result = self.validator.validate(
+            "SELECT users.name, SUM(orders.total) "
+            "FROM orders "
+            "JOIN order_items ON order_items.order_id = orders.id "
+            "JOIN users ON orders.user_id = users.id "
+            "GROUP BY users.name"
+        )
+
+        self.assertTrue(result.fan_trap_risk)
+        self.assertFalse(result.is_valid)
+        self.assertEqual(
+            [
+                i.severity
+                for i in result.issues
+                if i.issue_type == OBQCIssueType.FAN_TRAP_DETECTED
+            ],
+            [OBQCSeverity.ERROR],
+        )
+
+    def test_measure_from_the_many_side_is_fine(self):
+        """The repeated rows *are* the measure's rows, so nothing is doubled."""
+        result = self.validator.validate(
+            "SELECT orders.id, SUM(order_items.quantity) "
+            "FROM orders JOIN order_items ON order_items.order_id = orders.id "
+            "GROUP BY orders.id"
+        )
+
+        self.assertFalse(result.fan_trap_risk, [i.message for i in result.issues])
+
+    def test_count_star_is_not_attributed_to_any_table(self):
+        """Counting the joined rows is usually the intent, so it is left alone."""
+        result = self.validator.validate(
+            "SELECT orders.id, COUNT(*) "
+            "FROM orders JOIN order_items ON order_items.order_id = orders.id "
+            "GROUP BY orders.id"
+        )
+
+        self.assertFalse(result.fan_trap_risk, [i.message for i in result.issues])
+
+    def test_min_and_max_survive_duplication(self):
+        result = self.validator.validate(
+            "SELECT orders.id, MAX(orders.total) "
+            "FROM orders JOIN order_items ON order_items.order_id = orders.id "
+            "GROUP BY orders.id"
+        )
+
+        self.assertFalse(result.fan_trap_risk, [i.message for i in result.issues])
+
+    def test_count_distinct_survives_duplication(self):
+        result = self.validator.validate(
+            "SELECT users.name, COUNT(DISTINCT orders.id) "
+            "FROM orders "
+            "JOIN order_items ON order_items.order_id = orders.id "
+            "JOIN users ON orders.user_id = users.id "
+            "GROUP BY users.name"
+        )
+
+        self.assertFalse(result.fan_trap_risk, [i.message for i in result.issues])
+
+    def test_dimension_lookup_never_fans_out(self):
+        result = self.validator.validate(
+            "SELECT users.name, SUM(orders.total) "
+            "FROM orders JOIN users ON orders.user_id = users.id "
+            "GROUP BY users.name"
+        )
+
+        self.assertFalse(result.fan_trap_risk, [i.message for i in result.issues])
+
+    def test_finding_is_structured_not_prose(self):
+        result = self.validator.validate(
+            "SELECT SUM(orders.total) FROM orders "
+            "JOIN order_items ON order_items.order_id = orders.id"
+        )
+
+        report = result.to_dict()["obqc_fan_trap"]
+        self.assertTrue(report["detected"])
+        self.assertTrue(report["blocking"])
+        self.assertEqual(
+            report["findings"],
+            [
+                {
+                    "kind": "measure_across_fan_out",
+                    "measure_table": "orders",
+                    "fan_out_table": "order_items",
+                    "tables": ["order_items", "orders"],
+                }
+            ],
+        )
+
+    def test_allow_fan_out_downgrades_to_a_warning(self):
+        sql = (
+            "SELECT SUM(orders.total) FROM orders "
+            "JOIN order_items ON order_items.order_id = orders.id"
+        )
+
+        result = self.validator.validate(sql, allow_fan_out=True)
+
+        self.assertTrue(result.is_valid)
+        self.assertTrue(result.fan_trap_risk)
+        self.assertEqual(
+            [
+                i.severity
+                for i in result.issues
+                if i.issue_type == OBQCIssueType.FAN_TRAP_DETECTED
+            ],
+            [OBQCSeverity.WARNING],
+        )
+        self.assertFalse(result.to_dict()["obqc_fan_trap"]["blocking"])
+
+    def test_clean_query_reports_no_fan_trap(self):
+        """The verdict is a field even when the answer is no."""
+        report = self.validator.validate("SELECT users.name FROM users").to_dict()[
+            "obqc_fan_trap"
+        ]
+
+        self.assertEqual(report, {"detected": False, "blocking": True, "findings": []})
 
 
 class TestWindowFunctions(unittest.TestCase):

--- a/tests/test_query_fan_trap_response.py
+++ b/tests/test_query_fan_trap_response.py
@@ -93,8 +93,68 @@ class TestFanTrapResponseField(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result["success"])
         self.assertEqual(
             result["obqc_fan_trap"],
-            {"detected": False, "blocking": True, "findings": []},
+            {
+                "evaluated": True,
+                "detected": False,
+                "blocking": True,
+                "findings": [],
+            },
         )
+
+    async def test_early_failures_still_carry_the_verdict(self):
+        """Every response has the field, so a caller needs no special case.
+
+        These paths returned before it was attached, so a client reading
+        `obqc_fan_trap` had to guard against its absence.
+        """
+        no_connection = MagicMock()
+        no_connection.has_engine.return_value = False
+        services = HandlerContext(get_session_db_manager=lambda ctx: no_connection)
+
+        cases = {
+            "no connection": (CLEAN_SQL, 100, True),
+            "bad limit": (CLEAN_SQL, 0, True),
+            "empty sql": ("   ", 100, True),
+            "checklist not completed": (CLEAN_SQL, 100, False),
+        }
+        for label, (sql, limit, checklist) in cases.items():
+            with self.subTest(case=label):
+                connected = MagicMock()
+                connected.has_engine.return_value = label != "no connection"
+                result = await execute_sql_query(
+                    self.ctx,
+                    sql,
+                    limit,
+                    checklist,
+                    None,
+                    (
+                        HandlerContext(get_session_db_manager=lambda ctx: connected)
+                        if label != "no connection"
+                        else services
+                    ),
+                )
+
+                self.assertFalse(result["success"])
+                self.assertIn("obqc_fan_trap", result)
+                self.assertFalse(result["obqc_fan_trap"]["evaluated"])
+
+    async def test_no_ontology_reports_not_evaluated(self):
+        """ "Not checked" must not read as "checked and clean".
+
+        Without an ontology OBQC never runs, but the query still executes and
+        succeeds -- exactly the case where a caller keying off the field would
+        otherwise be told there is no fan-trap.
+        """
+        services, db_manager = _services(None)
+
+        result = await execute_sql_query(
+            self.ctx, FAN_TRAP_SQL, 100, True, None, services
+        )
+
+        self.assertTrue(result["success"])
+        db_manager.execute_sql_query.assert_called_once()
+        self.assertFalse(result["obqc_fan_trap"]["evaluated"])
+        self.assertFalse(result["obqc_fan_trap"]["detected"])
 
     async def test_string_allow_fan_out_is_coerced(self):
         """MCP clients sometimes send booleans as strings."""

--- a/tests/test_query_fan_trap_response.py
+++ b/tests/test_query_fan_trap_response.py
@@ -156,6 +156,35 @@ class TestFanTrapResponseField(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(result["obqc_fan_trap"]["evaluated"])
         self.assertFalse(result["obqc_fan_trap"]["detected"])
 
+    async def test_warning_only_finding_claims_no_override(self):
+        """The response must not say a risk was accepted via allow_fan_out.
+
+        A conditional row count warns without blocking and without the caller
+        passing anything, so the generic acceptance line does not belong.
+        """
+        services, _ = _services(self.validator)
+
+        result = await execute_sql_query(
+            self.ctx,
+            "SELECT SUM(CASE WHEN o.total > 100 THEN 1 ELSE 0 END) "
+            "FROM orders o JOIN order_items i ON i.order_id = o.id",
+            100,
+            True,
+            None,
+            services,
+        )
+
+        self.assertTrue(result["success"])
+        self.assertTrue(result["obqc_fan_trap"]["detected"])
+        self.assertFalse(result["obqc_fan_trap"]["blocking"])
+        self.assertFalse(
+            any("allow_fan_out" in w for w in result["warnings"]), result["warnings"]
+        )
+        self.assertTrue(
+            any("Conditional count" in w for w in result["warnings"]),
+            result["warnings"],
+        )
+
     async def test_string_allow_fan_out_is_coerced(self):
         """MCP clients sometimes send booleans as strings."""
         services, db_manager = _services(self.validator)

--- a/tests/test_query_fan_trap_response.py
+++ b/tests/test_query_fan_trap_response.py
@@ -96,7 +96,7 @@ class TestFanTrapResponseField(unittest.IsolatedAsyncioTestCase):
             {
                 "evaluated": True,
                 "detected": False,
-                "blocking": True,
+                "blocking": False,
                 "findings": [],
             },
         )

--- a/tests/test_query_fan_trap_response.py
+++ b/tests/test_query_fan_trap_response.py
@@ -1,0 +1,112 @@
+"""The fan-trap verdict must reach the caller as a field, not as prose.
+
+An agent keys off ``success``. When a query silently returned inflated numbers,
+the only signal was an English sentence in ``warnings`` -- and on the success
+path not even that, since ``fan_trap_risk`` was set only on the failure branch.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from src.handler_context import HandlerContext
+from src.handlers.query import execute_sql_query
+from src.obqc_validator import OBQCValidator
+from tests.test_obqc_validator import create_sample_ontology_graph
+
+FAN_TRAP_SQL = (
+    "SELECT SUM(orders.total) FROM orders "
+    "JOIN order_items ON order_items.order_id = orders.id"
+)
+CLEAN_SQL = "SELECT users.name FROM users"
+
+
+def _services(validator):
+    """A HandlerContext whose db always succeeds, so only OBQC decides."""
+    db_manager = MagicMock()
+    db_manager.has_engine.return_value = True
+    db_manager.connection_info = {"type": "postgresql"}
+    db_manager.execute_sql_query.return_value = {
+        "success": True,
+        "data": [{"sum": 1}],
+        "columns": ["sum"],
+        "row_count": 1,
+        "execution_time_ms": 1,
+    }
+
+    return (
+        HandlerContext(
+            get_session_db_manager=lambda ctx: db_manager,
+            get_session_obqc_validator=lambda ctx: validator,
+            get_session_data=lambda ctx: SimpleNamespace(
+                graphrag_initialized=False, graphrag_manager=None
+            ),
+        ),
+        db_manager,
+    )
+
+
+class TestFanTrapResponseField(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        graph, base_uri = create_sample_ontology_graph()
+        self.validator = OBQCValidator()
+        self.validator.load_ontology(graph, base_uri)
+        self.ctx = MagicMock()
+        self.ctx.info = AsyncMock()
+
+    async def test_fan_trap_blocks_and_reports_structurally(self):
+        services, db_manager = _services(self.validator)
+
+        result = await execute_sql_query(
+            self.ctx, FAN_TRAP_SQL, 100, True, None, services
+        )
+
+        self.assertFalse(result["success"])
+        self.assertTrue(result["obqc_fan_trap"]["detected"])
+        self.assertTrue(result["obqc_fan_trap"]["blocking"])
+        self.assertEqual(
+            result["obqc_fan_trap"]["findings"][0]["fan_out_table"], "order_items"
+        )
+        db_manager.execute_sql_query.assert_not_called()
+
+    async def test_allow_fan_out_executes_and_still_reports(self):
+        services, db_manager = _services(self.validator)
+
+        result = await execute_sql_query(
+            self.ctx, FAN_TRAP_SQL, 100, True, None, services, allow_fan_out=True
+        )
+
+        self.assertTrue(result["success"])
+        db_manager.execute_sql_query.assert_called_once()
+        self.assertTrue(result["obqc_fan_trap"]["detected"])
+        self.assertFalse(result["obqc_fan_trap"]["blocking"])
+        self.assertTrue(
+            any("FAN-TRAP" in w for w in result["warnings"]), result["warnings"]
+        )
+
+    async def test_clean_query_carries_a_negative_verdict(self):
+        """ "No fan-trap" must be readable, not merely the absence of a warning."""
+        services, _ = _services(self.validator)
+
+        result = await execute_sql_query(self.ctx, CLEAN_SQL, 100, True, None, services)
+
+        self.assertTrue(result["success"])
+        self.assertEqual(
+            result["obqc_fan_trap"],
+            {"detected": False, "blocking": True, "findings": []},
+        )
+
+    async def test_string_allow_fan_out_is_coerced(self):
+        """MCP clients sometimes send booleans as strings."""
+        services, db_manager = _services(self.validator)
+
+        result = await execute_sql_query(
+            self.ctx, FAN_TRAP_SQL, 100, "true", None, services, allow_fan_out="true"
+        )
+
+        self.assertTrue(result["success"])
+        db_manager.execute_sql_query.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Stacked on #87.** Base is `fix/obqc-false-positives`; retarget to `main` once that merges. Review the delta only — GitHub shows just this branch's commit.

**BREAKING CHANGE:** a detected fan-trap now returns `success: false` instead of executing with a warning attached. `execute_sql_query(..., allow_fan_out=true)` runs one anyway.

Two problems, both letting wrong numbers reach a caller.

## 1. The single-child trap was invisible

The rule counted fan-out joins and said nothing below two. So this passed silently:

```sql
SELECT SUM(sales.amount)
FROM sales JOIN shipments ON shipments.sale_id = sales.id;
```

Each sale's amount is added once per shipment, and the inner join drops sales that never shipped — wrong in both directions, with no second fact table in sight. In the session that found this, €11,008 was returned against a true €13,962, with zero warnings.

Detection now works from the **measure**: a finding needs an aggregate whose column comes from the table the join multiplies. That distinguishes `SUM(sales.amount)` (inflated) from `SUM(shipments.cost)` over the same join (correct — the repeated rows are the shipments' own).

**Both ends of every join are judged.** `FROM order_items JOIN orders` summing `orders.total` produces the same one-row-per-item result set as the reverse spelling. Verified against DuckDB: two orders totalling 150 come back as 250 when one has two items.

Aggregates that duplication cannot change — `MIN`, `MAX`, `COUNT(DISTINCT …)`, and `COUNT(*)` (which names no table; counting joined rows is usually the intent) — are left alone. The disjoint-facts axiom path and the two-or-more-joins heuristic remain as weaker findings.

## 2. The verdict was prose

Fan-trap risk surfaced as an English sentence in `warnings`, and on the success path there was no `fan_trap` field at all — `fan_trap_risk` was set only on the failure branch. An agent keying off `success: true` had no way to see that its numbers were inflated.

Every response now carries:

```json
{
  "detected": true,
  "blocking": true,
  "findings": [
    {
      "kind": "measure_across_fan_out",
      "measure_table": "sales",
      "fan_out_table": "shipments",
      "tables": ["sales", "shipments"]
    }
  ]
}
```

`kind` is one of `measure_across_fan_out`, `disjoint_facts`, `multiple_fan_out_joins`. A clean query reports `{"detected": false, "blocking": true, "findings": []}` — so "no fan-trap" is an answer to read, not the absence of a sentence.

## Escape hatch

`allow_fan_out` (snake_case, matching `checklist_completed` and the rest of the tool API) downgrades the finding to a warning and executes. The finding is still reported and `blocking` becomes `false`. String values are coerced, as MCP clients sometimes send booleans as strings.

## Three existing tests changed — please check this

`TestOBQCFanTrapDirection` had three tests whose queries were themselves inflating: they summed a parent measure at child grain. Their **intent** is preserved:

- `test_many_to_one_chain_is_not_a_fan_trap` and its alias twin now take the measure at the finest grain in the query, which is what "every hop is a lookup" was meant to demonstrate.
- `test_unrelated_join_is_not_counted` → `test_only_the_fanning_join_is_blamed`: it now asserts the finding names `shipments` and never `users`, which is the property it was actually guarding.
- `test_parent_measure_at_child_grain_is_a_fan_trap` covers the case they had been asserting was safe.

## Testing

734 tests pass (+14 over #87, incl. a new `tests/test_query_fan_trap_response.py` covering the handler response shape and the `allow_fan_out` path end to end). `black`, `isort`, `ruff`, `mypy --strict` clean; `bandit` unchanged at 70 pre-existing findings.

Docs updated: `docs/obqc.md`, `docs/fan-trap-prevention.md`, `docs/tools-reference.md`, and the `fan-trap-prevention` skill the LLM reads at query-writing time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)