### PR TITLE
docs(changelog): correct the 1.8.0 tool count to 26 → 28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ Feature release centred on OBQC correctness and GraphRAG schema search. **OBQC
 now blocks fan-traps instead of warning about them** — see Breaking Changes.
 Six OBQC false positives that blocked valid SQL are fixed, schema search moved
 from TF-IDF to semantic embeddings, and the per-version retention mechanism
-records the data it was always meant to clean up. Tool surface grows from 28 to
-30 tools (`add_semantic_context`, `cleanup_old_versions`).
+records the data it was always meant to clean up. Tool surface grows from 26 to
+28 tools (`add_semantic_context`, `cleanup_old_versions`).
 
 ### Breaking Changes
 - **A detected fan-trap now fails the query.** `execute_sql_query` returns


### PR DESCRIPTION
The 1.8.0 CHANGELOG entry claimed the tool surface grew **28 → 30**. Both numbers were wrong; it is **26 → 28**.

The bad numbers came from `grep -c "@mcp.tool()" src/main.py`, which returns 30 — but two of those hits are prose, not decorators: the module docstring ("exposes one ``@mcp.tool()`` wrapper per tool") and the registration-section comment ("The @mcp.tool() decorators MUST stay here"). Counting only decorators actually followed by an `async def` gives 28 now and 26 at `v1.7.2`, which also matches the 1.7.1/1.7.2 entries that both say "still 26 tools".

Verified empirically against the published image rather than by grep — `tools/list` over a real MCP session on `ralforion/orionbelt-analytics:1.8.0` returns 28 tools, including the two new ones:

```
tools/list: 28 tools
1.8.0 new tools present: ['add_semantic_context', 'cleanup_old_versions']
```

The GitHub release notes for v1.8.0 have already been edited with the same correction. The `v1.8.0` tag and the PyPI sdist keep the original text — the count is not referenced anywhere in source or on the PyPI page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)