### PR TITLE
feat(ontology): model views as oba:View, typed apart from tables

### DIFF
--- a/ontology/oba-shacl.ttl
+++ b/ontology/oba-shacl.ttl
@@ -492,3 +492,141 @@ oba:OntologyShape a sh:NodeShape ;
         sh:name "ontology comment" ;
         sh:message "The ontology must have at least one rdfs:comment."
     ] .
+
+# -----------------------------------------------------------------------------
+# View Shape --- validates oba:View instances representing database views
+# -----------------------------------------------------------------------------
+#
+# Targets oba:View, not owl:Class.  Views are typed apart precisely so that
+# TableShape (which targets owl:Class and requires oba:tableName) does not
+# apply to them, and so table consumers cannot mistake one for a base table.
+
+oba:ViewShape a sh:NodeShape ;
+    sh:targetClass oba:View ;
+    rdfs:label "OBA View Shape" ;
+    rdfs:comment "Validates entities annotated as database views." ;
+
+    # Required properties
+    sh:property [
+        sh:path oba:viewName ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "view name" ;
+        sh:message "Every view must have exactly one oba:viewName (xsd:string)."
+    ] ;
+    sh:property [
+        sh:path oba:schemaName ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "schema name" ;
+        sh:message "Every view must have exactly one oba:schemaName (xsd:string)."
+    ] ;
+    sh:property [
+        sh:path rdfs:label ;
+        sh:minCount 1 ;
+        sh:name "label" ;
+        sh:message "Every view must have at least one rdfs:label."
+    ] ;
+
+    # A view must never carry oba:tableName: that is what table extraction
+    # keys on, and carrying it would defeat the separation entirely.
+    sh:property [
+        sh:path oba:tableName ;
+        sh:maxCount 0 ;
+        sh:name "table name" ;
+        sh:message "A view must not carry oba:tableName -- use oba:viewName. Table consumers key on oba:tableName and would treat the view as a base table."
+    ] ;
+
+    # A view must never declare a primary key or foreign keys: it has none,
+    # and asserting one invites the join validation that cannot apply to it.
+    sh:property [
+        sh:path oba:primaryKey ;
+        sh:maxCount 0 ;
+        sh:name "primary key" ;
+        sh:message "A view must not declare oba:primaryKey -- a view has no key, and a join to it cannot be validated."
+    ] ;
+
+    # Optional properties with type constraints
+    sh:property [
+        sh:path oba:viewDefinition ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "view definition"
+    ] ;
+    sh:property [
+        sh:path oba:viewColumnCount ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:integer ;
+        sh:name "view column count"
+    ] ;
+    sh:property [
+        sh:path oba:derivedFrom ;
+        sh:nodeKind sh:IRI ;
+        sh:name "derived from" ;
+        sh:message "oba:derivedFrom must point at the IRI of a source table class."
+    ] ;
+    sh:property [
+        sh:path oba:semanticName ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "semantic name"
+    ] ;
+    sh:property [
+        sh:path oba:usageNotes ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "usage notes"
+    ] .
+
+# -----------------------------------------------------------------------------
+# View Column Shape --- validates oba:ViewColumn instances
+# -----------------------------------------------------------------------------
+
+oba:ViewColumnShape a sh:NodeShape ;
+    sh:targetClass oba:ViewColumn ;
+    rdfs:label "OBA View Column Shape" ;
+    rdfs:comment "Validates entities annotated as columns exposed by a view." ;
+
+    sh:property [
+        sh:path oba:columnName ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "column name" ;
+        sh:message "Every view column must have exactly one oba:columnName (xsd:string)."
+    ] ;
+    sh:property [
+        sh:path oba:viewName ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "view name" ;
+        sh:message "Every view column must name its owning view with exactly one oba:viewName."
+    ] ;
+    sh:property [
+        sh:path oba:tableName ;
+        sh:maxCount 0 ;
+        sh:name "table name" ;
+        sh:message "A view column must not carry oba:tableName -- use oba:viewName."
+    ] ;
+    sh:property [
+        sh:path oba:sqlDataType ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "SQL data type"
+    ] ;
+    sh:property [
+        sh:path oba:isNullable ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "is nullable"
+    ] ;
+    sh:property [
+        sh:path rdfs:domain ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:name "domain" ;
+        sh:message "A view column's rdfs:domain must be the IRI of its view."
+    ] .

--- a/ontology/oba.ttl
+++ b/ontology/oba.ttl
@@ -226,3 +226,52 @@ oba:businessRule a owl:AnnotationProperty ;
     rdfs:label "business rule" ;
     rdfs:comment "LLM-generated business rule governing this relationship." ;
     rdfs:range xsd:string .
+
+# =============================================================================
+# 8. VIEW MODELLING (oba:View / oba:ViewColumn instances)
+# =============================================================================
+#
+# Views are typed oba:View rather than owl:Class, and their columns
+# oba:ViewColumn rather than owl:DatatypeProperty.  This is deliberate and
+# load-bearing: every consumer that reads tables looks for owl:Class carrying
+# oba:tableName, so a view modelled as an ordinary class would be picked up as
+# a base table by each of them and would have to be excluded again, rule by
+# rule, forever.  Distinct types make the separation structural -- a view is
+# invisible to table extraction by construction, and is found only by code
+# that asks for views on purpose.
+#
+# The same reasoning gives views oba:viewName instead of oba:tableName.
+#
+# What a view is NOT: joinable.  It has already applied its own joins and
+# grain, and carries no primary key, no foreign keys and no declared
+# cardinality, so a join to one cannot be validated.  oba:derivedFrom records
+# provenance for lineage and impact analysis, NOT a join path.
+
+oba:View a owl:Class ;
+    rdfs:label "database view" ;
+    rdfs:comment "A database view: a named query whose joins and grain are already fixed.  Typed apart from owl:Class so table consumers never mistake one for a base table." .
+
+oba:ViewColumn a owl:Class ;
+    rdfs:label "view column" ;
+    rdfs:comment "A column exposed by a view.  Typed apart from owl:DatatypeProperty for the same reason oba:View is typed apart from owl:Class." .
+
+oba:viewName a owl:AnnotationProperty ;
+    rdfs:label "view name" ;
+    rdfs:comment "Exact SQL view name as it appears in the database catalog.  Reused on oba:ViewColumn to name its owning view, mirroring how oba:tableName is reused on columns." ;
+    rdfs:range xsd:string .
+
+oba:viewDefinition a owl:AnnotationProperty ;
+    rdfs:label "view definition" ;
+    rdfs:comment "The SQL body defining the view, as returned by the database catalog.  Absent when the backend withholds it (commonly a permissions matter)." ;
+    rdfs:range xsd:string .
+
+oba:derivedFrom a owl:ObjectProperty ;
+    rdfs:label "derived from" ;
+    rdfs:comment "A base table this view reads.  Repeating property --- one triple per source table.  Provenance only: it records lineage for impact analysis and must never be read as a join path, because a view's own joins are already applied.  Asserted only when the source is known with certainty; omitted entirely rather than guessed." ;
+    rdfs:domain oba:View ;
+    rdfs:range owl:Class .
+
+oba:viewColumnCount a owl:AnnotationProperty ;
+    rdfs:label "view column count" ;
+    rdfs:comment "Number of columns the view exposes." ;
+    rdfs:range xsd:integer .

--- a/src/database_manager.py
+++ b/src/database_manager.py
@@ -11,7 +11,7 @@ import re
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, cast
 
 from sqlalchemy import text
@@ -67,6 +67,15 @@ class ViewInfo:
     schema: str
     definition: str | None = None
     comment: str | None = None
+    # Columns as the catalog reports them. Authoritative where a parsed
+    # definition is not: information_schema knows the output of "SELECT *"
+    # and of an explicit "CREATE VIEW v (a, b)" header, both of which reading
+    # the SQL gets wrong or gives up on.
+    columns: list[ColumnInfo] = field(default_factory=list)
+    # Base tables the view reads. Empty when lineage could not be established
+    # with certainty -- a guess here would be consumed as fact by anything
+    # reasoning over provenance.
+    source_tables: list[str] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "ViewInfo":
@@ -74,15 +83,25 @@ class ViewInfo:
 
         Args:
             data: Dict with keys matching ViewInfo fields.
+                  Columns may be dicts or ColumnInfo instances.
 
         Returns:
             ViewInfo instance
         """
+        columns = []
+        for col in data.get("columns", []):
+            if isinstance(col, ColumnInfo):
+                columns.append(col)
+            elif isinstance(col, dict):
+                columns.append(ColumnInfo(**col))
+
         return cls(
             name=data["name"],
             schema=data.get("schema", ""),
             definition=data.get("definition"),
             comment=data.get("comment"),
+            columns=columns,
+            source_tables=data.get("source_tables", []),
         )
 
 
@@ -1007,6 +1026,24 @@ class DatabaseManager:
             ViewInfo(name=name, schema=schema_name or "", definition=definition)
             for name, definition in raw.items()
         ]
+
+        # Columns come from the catalog, never from reading the definition.
+        # information_schema knows the output of "SELECT *" and of an explicit
+        # "CREATE VIEW v (a, b)" header; parsing the SQL gets the second wrong
+        # and gives up on the first. A view whose columns cannot be read is
+        # still returned -- it stays searchable, and its columns stay
+        # unchecked rather than guessed.
+        for view in views:
+            try:
+                info = self._driver.analyze_table(view.name, schema_name)
+                if info and info.columns:
+                    view.columns = info.columns
+            except Exception as e:
+                logger.debug(
+                    f"Could not read columns of view '{view.name}' ({e}); "
+                    "its columns stay unchecked."
+                )
+
         self._store_in_cache(cache_key, views)
         return views
 

--- a/src/graphrag/manager.py
+++ b/src/graphrag/manager.py
@@ -38,6 +38,7 @@ except ImportError:
 
 def _annotate_view_sources(
     views_info: list[dict[str, Any]] | None,
+    dialect: str | None = None,
 ) -> list[dict[str, Any]]:
     """Fill in each view's ``referenced_tables`` by parsing its definition.
 
@@ -51,8 +52,16 @@ def _annotate_view_sources(
     forms, and a view that cannot be parsed is still worth indexing by name
     and raw text. Such a view simply keeps an empty source list.
 
+    The dialect matters more than the SQL does. Measured across real view
+    bodies, sqlglot parses semi-structured Snowflake, BigQuery structs,
+    ClickHouse aggregates and LATERAL joins without complaint -- and fails on
+    a Snowflake body read as PostgreSQL. Passing the connection's dialect is
+    what makes the difference between lineage and silence.
+
     Args:
         views_info: View metadata, or None.
+        dialect: sqlglot dialect name. None uses sqlglot's permissive
+            default, which is right only when the backend is unknown.
 
     Returns:
         The same list with ``referenced_tables`` populated where derivable.
@@ -74,14 +83,23 @@ def _annotate_view_sources(
             continue
 
         try:
-            parsed = sqlglot.parse_one(definition)
+            parsed = sqlglot.parse_one(definition, dialect=dialect)
             # CTE names are defined by the view itself, so they are not
             # sources; excluding them keeps the list to real base tables.
-            cte_names = {cte.alias_or_name.lower() for cte in parsed.find_all(exp.CTE)}
+            excluded = {cte.alias_or_name.lower() for cte in parsed.find_all(exp.CTE)}
+            # Nor is the view itself. DuckDB returns the whole CREATE VIEW
+            # statement, whose target parses as a Table like any other, so the
+            # view listed itself among its own sources.
+            if isinstance(parsed, exp.Create):
+                for target in parsed.this.find_all(exp.Table):
+                    if target.name:
+                        excluded.add(target.name.lower())
+            excluded.add(str(view.get("name", "")).lower())
+
             sources = {
                 table.name
                 for table in parsed.find_all(exp.Table)
-                if table.name and table.name.lower() not in cte_names
+                if table.name and table.name.lower() not in excluded
             }
             view["referenced_tables"] = sorted(sources)
         except Exception as e:

--- a/src/handlers/graphrag.py
+++ b/src/handlers/graphrag.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import time
+from functools import partial
 from typing import Any, cast
 
 from fastmcp import Context
@@ -130,8 +131,14 @@ async def _auto_generate_ontology_background(
         base_uri = config.ontology_base_uri
 
         ontology_generator = OntologyGenerator(base_uri=base_uri)
+        from .ontology_generation import _views_for_ontology
+
         ontology_ttl = await asyncio.to_thread(
-            ontology_generator.generate_from_schema, tables_info
+            partial(
+                ontology_generator.generate_from_schema,
+                tables_info,
+                views_info=_views_for_ontology(session, schema_name),
+            )
         )
 
         conn_dir = (

--- a/src/handlers/ontology_generation.py
+++ b/src/handlers/ontology_generation.py
@@ -4,11 +4,14 @@ import asyncio
 import json
 import logging
 import os
-from typing import Any
+from functools import partial
+from typing import Any, cast
 
 from fastmcp import Context
 
+from ..constants import DB_SQLGLOT_DIALECTS
 from ..database_manager import ColumnInfo, TableInfo
+from ..graphrag.manager import _annotate_view_sources
 from ..handler_context import HandlerContext
 from ..lifecycle.artifacts import artifact_family_lock, prune_superseded_artifacts
 from ..lifecycle.metadata import (
@@ -24,6 +27,52 @@ from ..paths import OUTPUT_DIR, ensure_output_dir, get_connection_dir
 from ..utils import utc_now, write_text_file
 
 logger = logging.getLogger(__name__)
+
+
+def _views_for_ontology(session: Any, schema_name: str | None) -> list[Any]:
+    """Discovered views for *schema_name*, with their lineage resolved.
+
+    Lineage is filled in here rather than at discovery because it is only the
+    ontology that consumes it, and it is parsed with the connection's own
+    dialect: a Snowflake body read as PostgreSQL fails to parse, and the view
+    then silently carries no sources at all.
+
+    Views are an enrichment, not a prerequisite: an ontology describing the
+    tables is useful, and one that fails to generate is not. So anything that
+    goes wrong resolving them degrades to "no views" rather than propagating.
+
+    Args:
+        session: The session holding the discovery cache.
+        schema_name: Schema being generated, or None for the default.
+
+    Returns:
+        ViewInfo objects, empty when nothing was discovered or resolution
+        failed.
+    """
+    try:
+        views = session.get_cached_views(schema_name or "")
+        if not views:
+            return []
+
+        dialect = None
+        if getattr(session, "db_manager", None) is not None:
+            db_type = session.db_manager.connection_info.get("type")
+            dialect = DB_SQLGLOT_DIALECTS.get(db_type) if db_type else None
+
+        annotated = _annotate_view_sources(
+            [{"name": v.name, "definition": v.definition} for v in views],
+            dialect=dialect,
+        )
+        for view, entry in zip(views, annotated, strict=False):
+            view.source_tables = entry.get("referenced_tables", [])
+
+        return cast(list[Any], views)
+    except Exception as e:
+        logger.warning(
+            f"Could not resolve views for the ontology ({e}); "
+            "generating it without them."
+        )
+        return []
 
 
 def _build_minimal_graph_summary(ontology_ttl: str) -> str:
@@ -263,9 +312,12 @@ async def generate_ontology(
             logger.warning(f"Failed to read active version: {e}")
 
     generator = services.server_state.get_ontology_generator(base_uri=base_uri)
+    views_info = _views_for_ontology(session, schema_name)
     # rdflib work is CPU-bound (~876 ms per 2.65 MB of Turtle); off the loop
     # so it does not freeze every concurrent session.
-    ontology_ttl = await asyncio.to_thread(generator.generate_from_schema, tables_info)
+    ontology_ttl = await asyncio.to_thread(
+        partial(generator.generate_from_schema, tables_info, views_info=views_info)
+    )
 
     # Optional SHACL conformance check (Phase 4). Default on, gated by setting;
     # never hard-fails generation — surfaces violations as a warning only.

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -470,6 +470,48 @@ class OBQCValidator:
         )
         self._view_signature = signature
 
+    def _extract_views_from_ontology(self) -> None:
+        """Register views the ontology declares as oba:View.
+
+        Preferred over the definitions path: these columns came from the
+        database catalog, which knows the output of ``SELECT *`` and of an
+        explicit ``CREATE VIEW v (a, b)`` header -- both of which reading the
+        SQL gets wrong or abandons.
+
+        Views are found by asking for oba:View specifically. They are not
+        owl:Class and carry oba:viewName rather than oba:tableName, so
+        _extract_schema_from_ontology cannot see them at all: no rule that
+        reasons about tables has to remember to exclude them.
+
+        An ontology with no views leaves any previously registered set alone,
+        so loading a table-only ontology does not silently drop views the
+        session discovered.
+        """
+        if self._graph is None or self._oba_ns is None:
+            return
+
+        views: dict[str, set[str]] = {}
+        for subject in self._graph.subjects(RDF.type, self._oba_ns.View):
+            view_name = self._get_literal(subject, self._oba_ns.viewName)
+            if view_name:
+                views[view_name.lower()] = set()
+
+        if not views:
+            return
+
+        for subject in self._graph.subjects(RDF.type, self._oba_ns.ViewColumn):
+            column_name = self._get_literal(subject, self._oba_ns.columnName)
+            view_name = self._get_literal(subject, self._oba_ns.viewName)
+            if column_name and view_name and view_name.lower() in views:
+                views[view_name.lower()].add(column_name.lower())
+
+        self._known_views = views
+        # The ontology is authoritative, so a later definitions-based
+        # registration must not quietly overwrite it with parsed guesses
+        # unless the view set genuinely changed.
+        self._view_signature = None
+        logger.debug(f"OBQC registered {len(views)} views from the ontology")
+
     def _view_columns_unknown(self, table_key: str) -> bool:
         """True when *table_key* is a view whose columns could not be derived."""
         return table_key in self._known_views and not self._known_views[table_key]
@@ -495,6 +537,7 @@ class OBQCValidator:
         self._oba_ns = Namespace(OBA_NAMESPACE)
         self._schema_cache = self._extract_schema_from_ontology()
         self._disjoint_pairs = self._extract_disjoint_pairs()
+        self._extract_views_from_ontology()
 
         # Check if ontology has required oba: annotations for OBQC
         self._is_compatible = self._check_ontology_compatibility()

--- a/src/ontology_generator.py
+++ b/src/ontology_generator.py
@@ -202,6 +202,7 @@ class OntologyGenerator:
         tables_info: list[TableInfo],
         include_inferred_relationships: bool = True,
         annotate_denormalized: bool = True,
+        views_info: list[Any] | None = None,
     ) -> str:
         """Generate an ontology from a list of table information with quality enhancements.
 
@@ -209,6 +210,11 @@ class OntologyGenerator:
             tables_info: List of table information from schema analysis
             include_inferred_relationships: Whether to add relationships inferred from naming patterns
             annotate_denormalized: Whether to annotate detected denormalized fields
+            views_info: Optional database views. Emitted as oba:View, typed
+                apart from owl:Class so table consumers never see them, and
+                excluded from every table-driven step below (relationship
+                inference, denormalization, disjointness, property chains) --
+                a view has no keys for any of those to reason about.
 
         Returns:
             Serialized ontology in Turtle format
@@ -228,6 +234,15 @@ class OntologyGenerator:
         # Add all tables and their columns/relationships
         for table_info in tables_info:
             self._add_table_to_ontology(table_info)
+
+        # Views are added after the tables so oba:derivedFrom can point at
+        # classes that already exist, and before nothing else: every step
+        # below this reasons about keys and relationships, which a view has
+        # none of, so views are excluded from all of them by simply not being
+        # in tables_info.
+        known_tables = {t.name.lower(): t.name for t in tables_info}
+        for view_info in views_info or []:
+            self._add_view_to_ontology(view_info, known_tables)
 
         # Infer implicit relationships from naming patterns
         if include_inferred_relationships:
@@ -282,6 +297,111 @@ class OntologyGenerator:
             Quality report or None if no generation has occurred
         """
         return self.quality_report
+
+    def _add_view_to_ontology(
+        self, view_info: Any, known_tables: dict[str, str]
+    ) -> None:
+        """Add a database view to the ontology as an oba:View.
+
+        Typed oba:View rather than owl:Class, and annotated oba:viewName
+        rather than oba:tableName, so every consumer that reads tables --
+        OBQC's schema extraction, the SHACL TableShape, the relationship and
+        fan-trap reasoning -- cannot see it. Excluding views rule by rule
+        would work only until the next rule is written; this makes the
+        separation structural.
+
+        No primary key and no foreign keys are emitted, because a view has
+        neither. oba:derivedFrom records provenance only, and is asserted
+        solely for sources that resolve to a table already in the ontology --
+        a guessed lineage would be consumed as fact by anything reasoning
+        over it, so an unknown source is omitted instead.
+
+        Args:
+            view_info: A ViewInfo (or compatible object) to add.
+            known_tables: Lower-cased name -> real name for tables already in
+                the ontology, used to resolve oba:derivedFrom targets.
+        """
+        view_uri = self.base_uri[self._clean_name(view_info.name)]
+
+        self.graph.add((view_uri, RDF.type, self.oba_ns.View))
+        self.graph.add((view_uri, RDFS.label, Literal(view_info.name)))
+        self.graph.add((view_uri, self.oba_ns.viewName, Literal(view_info.name)))
+        self.graph.add(
+            (view_uri, self.oba_ns.schemaName, Literal(view_info.schema or "public"))
+        )
+
+        definition = getattr(view_info, "definition", None)
+        if definition:
+            self.graph.add((view_uri, self.oba_ns.viewDefinition, Literal(definition)))
+
+        comment = getattr(view_info, "comment", None)
+        if comment:
+            self.graph.add((view_uri, RDFS.comment, Literal(comment)))
+
+        columns = getattr(view_info, "columns", None) or []
+        for column in columns:
+            self._add_view_column_to_ontology(view_uri, column, view_info.name)
+        if columns:
+            self.graph.add(
+                (view_uri, self.oba_ns.viewColumnCount, Literal(len(columns)))
+            )
+
+        for source in getattr(view_info, "source_tables", None) or []:
+            real_name = known_tables.get(str(source).lower())
+            if real_name is None:
+                # The view reads something this ontology does not describe
+                # (another schema, a nested view). Asserting a dangling link
+                # would be worse than asserting nothing.
+                logger.debug(
+                    f"View '{view_info.name}' reads unknown source '{source}'; "
+                    "omitting oba:derivedFrom for it."
+                )
+                continue
+            self.graph.add(
+                (
+                    view_uri,
+                    self.oba_ns.derivedFrom,
+                    self.base_uri[self._clean_name(real_name)],
+                )
+            )
+
+    def _add_view_column_to_ontology(
+        self, view_uri: URIRef, column: Any, view_name: str
+    ) -> None:
+        """Add a single view column as an oba:ViewColumn.
+
+        Typed apart from owl:DatatypeProperty for the same reason the view is
+        typed apart from owl:Class: column extraction keys on that type plus
+        oba:tableName, and a view column must not answer to either.
+
+        Args:
+            view_uri: URI of the owning view.
+            column: A ColumnInfo (or compatible object).
+            view_name: Name of the owning view.
+        """
+        prop_uri = self.base_uri[
+            f"{self._clean_name(view_name)}_{self._clean_name(column.name)}"
+        ]
+
+        self.graph.add((prop_uri, RDF.type, self.oba_ns.ViewColumn))
+        self.graph.add((prop_uri, RDFS.label, Literal(column.name)))
+        self.graph.add((prop_uri, self.oba_ns.columnName, Literal(column.name)))
+        self.graph.add((prop_uri, self.oba_ns.viewName, Literal(view_name)))
+        self.graph.add((prop_uri, RDFS.domain, view_uri))
+
+        data_type = getattr(column, "data_type", None)
+        if data_type:
+            self.graph.add((prop_uri, self.oba_ns.sqlDataType, Literal(data_type)))
+
+        is_nullable = getattr(column, "is_nullable", None)
+        if is_nullable is not None:
+            self.graph.add(
+                (
+                    prop_uri,
+                    self.oba_ns.isNullable,
+                    Literal("true" if is_nullable else "false"),
+                )
+            )
 
     def _add_table_to_ontology(self, table_info: TableInfo) -> None:
         """Add a single table and its columns to the ontology with comprehensive database annotations."""

--- a/tests/test_ontology_views.py
+++ b/tests/test_ontology_views.py
@@ -1,0 +1,223 @@
+"""Tests for modelling database views in the ontology.
+
+Views are emitted as oba:View, not owl:Class, and their columns as
+oba:ViewColumn, not owl:DatatypeProperty. That typing is load-bearing rather
+than cosmetic: every consumer that reads tables looks for owl:Class carrying
+oba:tableName, so a view modelled as an ordinary class would be picked up as
+a base table by each of them and would have to be excluded again, rule by
+rule, forever. These tests pin the separation at both ends -- what is emitted,
+and what OBQC sees.
+"""
+
+import unittest
+
+from rdflib import Graph, Namespace
+from rdflib.namespace import OWL, RDF, RDFS
+
+from src.constants import OBA_NAMESPACE
+from src.database_manager import ColumnInfo, TableInfo, ViewInfo
+from src.graphrag.manager import _annotate_view_sources
+from src.obqc_validator import OBQCSeverity, OBQCValidator
+from src.ontology_generator import OntologyGenerator
+
+BASE_URI = "http://test.com/ontology/"
+OBA = Namespace(OBA_NAMESPACE)
+NS = Namespace(BASE_URI)
+
+
+def _col(name, data_type="INTEGER", **kw):
+    return ColumnInfo(
+        name=name,
+        data_type=data_type,
+        is_nullable=kw.get("is_nullable", True),
+        is_primary_key=kw.get("is_primary_key", False),
+        is_foreign_key=kw.get("is_foreign_key", False),
+    )
+
+
+TABLES = [
+    TableInfo(
+        name="sales",
+        schema="public",
+        columns=[_col("id"), _col("clientid"), _col("amount", "DECIMAL")],
+        primary_keys=["id"],
+        foreign_keys=[],
+    ),
+    TableInfo(
+        name="clients",
+        schema="public",
+        columns=[_col("clientid"), _col("name", "TEXT")],
+        primary_keys=["clientid"],
+        foreign_keys=[],
+    ),
+]
+
+VIEW = ViewInfo(
+    name="v_revenue",
+    schema="public",
+    definition="SELECT c.name, SUM(s.amount) AS total_revenue FROM sales s "
+    "JOIN clients c ON s.clientid = c.clientid GROUP BY c.name",
+    columns=[_col("name", "TEXT"), _col("total_revenue", "DECIMAL")],
+    source_tables=["sales", "clients"],
+)
+
+
+def _generate(views=None):
+    ttl = OntologyGenerator(BASE_URI).generate_from_schema(
+        TABLES, views_info=views if views is not None else [VIEW]
+    )
+    graph = Graph()
+    graph.parse(data=ttl, format="turtle")
+    return ttl, graph
+
+
+class TestViewTyping(unittest.TestCase):
+    """The separation is structural: views are simply not classes."""
+
+    def setUp(self):
+        self.ttl, self.g = _generate()
+        self.view_uri = NS["v_revenue"]
+
+    def test_view_is_typed_oba_view(self):
+        self.assertIn((self.view_uri, RDF.type, OBA.View), self.g)
+
+    def test_view_is_not_an_owl_class(self):
+        """An owl:Class would be picked up by every table consumer."""
+        self.assertNotIn((self.view_uri, RDF.type, OWL.Class), self.g)
+
+    def test_view_carries_view_name_not_table_name(self):
+        self.assertEqual(str(self.g.value(self.view_uri, OBA.viewName)), "v_revenue")
+        self.assertIsNone(self.g.value(self.view_uri, OBA.tableName))
+
+    def test_view_columns_are_typed_oba_view_column(self):
+        cols = set(self.g.subjects(RDF.type, OBA.ViewColumn))
+        self.assertEqual(len(cols), 2)
+        for col in cols:
+            self.assertNotIn((col, RDF.type, OWL.DatatypeProperty), self.g)
+            self.assertIsNone(self.g.value(col, OBA.tableName))
+            self.assertEqual(str(self.g.value(col, OBA.viewName)), "v_revenue")
+
+    def test_view_declares_no_primary_key(self):
+        """A view has no key, and asserting one invites join validation."""
+        self.assertIsNone(self.g.value(self.view_uri, OBA.primaryKey))
+
+    def test_definition_and_label_are_carried(self):
+        self.assertIn(
+            "total_revenue", str(self.g.value(self.view_uri, OBA.viewDefinition))
+        )
+        self.assertEqual(str(self.g.value(self.view_uri, RDFS.label)), "v_revenue")
+
+    def test_tables_are_still_owl_classes(self):
+        self.assertIn((NS["sales"], RDF.type, OWL.Class), self.g)
+
+
+class TestDerivedFrom(unittest.TestCase):
+    def test_lineage_points_at_source_tables(self):
+        _, g = _generate()
+        sources = set(g.objects(NS["v_revenue"], OBA.derivedFrom))
+        self.assertEqual(sources, {NS["sales"], NS["clients"]})
+
+    def test_unknown_sources_are_omitted_not_guessed(self):
+        """A dangling link would be consumed as fact by anything reasoning
+        over provenance, so an unresolvable source is left out entirely."""
+        view = ViewInfo(
+            name="v_external",
+            schema="public",
+            source_tables=["sales", "table_in_another_schema"],
+        )
+        _, g = _generate([view])
+        sources = set(g.objects(NS["v_external"], OBA.derivedFrom))
+        self.assertEqual(sources, {NS["sales"]})
+
+    def test_no_lineage_emits_no_links(self):
+        view = ViewInfo(name="v_opaque", schema="public", source_tables=[])
+        _, g = _generate([view])
+        self.assertEqual(list(g.objects(NS["v_opaque"], OBA.derivedFrom)), [])
+
+
+class TestViewSourcesExcludeSelf(unittest.TestCase):
+    """DuckDB returns the whole CREATE VIEW statement."""
+
+    def test_create_target_is_not_a_source(self):
+        views = _annotate_view_sources(
+            [
+                {
+                    "name": "v_rev",
+                    "definition": "CREATE VIEW v_rev AS SELECT id FROM sales",
+                }
+            ],
+            dialect="duckdb",
+        )
+        self.assertEqual(views[0]["referenced_tables"], ["sales"])
+        self.assertNotIn("v_rev", views[0]["referenced_tables"])
+
+    def test_dialect_is_honoured(self):
+        """A Snowflake body read as PostgreSQL fails to parse, and the view
+        then silently carries no sources at all."""
+        snowflake_body = "SELECT v:customer.name::string AS nm FROM raw_events"
+        as_snowflake = _annotate_view_sources(
+            [{"name": "v", "definition": snowflake_body}], dialect="snowflake"
+        )
+        self.assertEqual(as_snowflake[0]["referenced_tables"], ["raw_events"])
+
+
+class TestOBQCReadsViewsFromOntology(unittest.TestCase):
+    def setUp(self):
+        _, g = _generate()
+        self.validator = OBQCValidator()
+        self.validator.load_ontology(g, BASE_URI)
+
+    def _errors(self, sql):
+        return [
+            i.message
+            for i in self.validator.validate(sql).issues
+            if i.severity == OBQCSeverity.ERROR
+        ]
+
+    def test_views_do_not_leak_into_the_table_cache(self):
+        """The whole point of the typing: table rules cannot see views."""
+        self.assertNotIn("v_revenue", self.validator._schema_cache.tables)
+        self.assertEqual(
+            sorted(self.validator._schema_cache.tables), ["clients", "sales"]
+        )
+
+    def test_view_is_registered_with_its_catalog_columns(self):
+        self.assertEqual(
+            self.validator._known_views["v_revenue"], {"name", "total_revenue"}
+        )
+
+    def test_querying_the_view_is_allowed(self):
+        self.assertEqual(self._errors("SELECT total_revenue FROM v_revenue"), [])
+
+    def test_bad_view_column_is_caught(self):
+        self.assertTrue(self._errors("SELECT v_revenue.nope FROM v_revenue"))
+
+    def test_joining_the_view_is_still_blocked(self):
+        errors = self._errors("SELECT * FROM v_revenue v JOIN sales s ON s.id = v.name")
+        self.assertTrue(any("cannot be joined" in e for e in errors), errors)
+
+    def test_a_table_only_ontology_leaves_views_registered(self):
+        """Loading an ontology without views must not silently drop a set the
+        session had already discovered."""
+        self.validator.load_views({"v_session": {"a"}})
+        ttl = OntologyGenerator(BASE_URI).generate_from_schema(TABLES)
+        graph = Graph()
+        graph.parse(data=ttl, format="turtle")
+        self.validator.load_ontology(graph, BASE_URI)
+        self.assertIn("v_session", self.validator._known_views)
+
+
+class TestShaclConformance(unittest.TestCase):
+    def test_generated_ontology_with_views_conforms(self):
+        from src.shacl_validator import shacl_available, validate_ontology
+
+        if not shacl_available():
+            self.skipTest("pyshacl not installed")
+
+        ttl, _ = _generate()
+        result = validate_ontology(ttl)
+        self.assertTrue(result["conforms"], result.get("report"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follows #94. Views now reach the ontology — but never as tables.

## The design decision

Views are emitted as `oba:View` with `oba:viewName`, and their columns as `oba:ViewColumn` — **not** `owl:Class`/`owl:DatatypeProperty` carrying `oba:tableName`.

That typing is the whole point. Every consumer that reads tables looks for `owl:Class` with `oba:tableName`: OBQC's schema extraction (`subjects(RDF.type, OWL.Class)`), the SHACL `TableShape`, relationship inference, disjointness and fan-trap reasoning. A view modelled as an ordinary class would be picked up as a base table by each of them, and would have to be excluded again — rule by rule, forever, including in rules not yet written.

Distinct types make the separation **structural**. Verified:

```
=== OBQC schema cache ===
  tables: ['clients', 'sales']
  v_rev leaked into tables?  False
  v_star leaked into tables? False
```

## Columns from the catalog, not from the SQL

This is the change that buys real correctness. `information_schema` knows the output of `SELECT *` and of an explicit `CREATE VIEW v (a, b)` header; parsing the body gets the second wrong and abandons the first.

```
SELECT * view columns
  via SQL parsing  : (gives up)
  via the ontology : ['amount', 'clientid', 'id']

SELECT id, amount FROM v_star            -> allowed
SELECT nonexistent FROM v_star           -> Column 'nonexistent' not found
SELECT * FROM v_star JOIN clients ON 1=1 -> View 'v_star' cannot be joined
```

So OBQC can now check the columns of a `SELECT *` view, which it previously had to leave unchecked entirely.

## Lineage, asserted only when certain

`oba:derivedFrom` records provenance for lineage and impact analysis — **not** a join path; a view's joins are already applied. It is asserted only for sources resolving to a table already in the ontology. A guessed link would be consumed as fact by anything reasoning over it, so an unresolvable source is omitted instead.

No primary key and no foreign keys are emitted, because a view has neither. SHACL now enforces that, plus the absence of `oba:tableName`, with explanatory `sh:message`s.

## Vocabulary

`ontology/oba.ttl` §8 and `ontology/oba-shacl.ttl` gain: `oba:View`, `oba:ViewColumn`, `oba:viewName`, `oba:viewDefinition`, `oba:derivedFrom`, `oba:viewColumnCount`, and `oba:ViewShape` / `oba:ViewColumnShape`. Generated ontologies with views **conform** (`conforms: True, violations: 0`).

Note `oba:tableType` was left alone — it is a semantic role (`fact`/`dimension`/`lookup`, SHACL-constrained), not a physical type, and a view can still be either.

## Two bugs fixed on the way

- **A view listed itself as its own source.** DuckDB returns the whole `CREATE VIEW` statement, whose target parses as an ordinary table. `v_rev derivedFrom ['clients','sales','v_rev']` → `['clients','sales']`.
- **Lineage parsing ignored the dialect.** Measured across real view bodies, sqlglot handles Snowflake semi-structured access, BigQuery structs, ClickHouse aggregates and LATERAL fine — and fails on a Snowflake body read as PostgreSQL. The connection's dialect is now threaded through.

Ontology generation also degrades to "no views" rather than failing if view resolution errors: an ontology describing the tables is useful, one that fails to generate is not.

## Verification

- 863 passed, 144 subtests (was 844) — 19 new tests in `tests/test_ontology_views.py`
- `ruff` / `black` / `isort` / `mypy --strict` clean
- SHACL conformance asserted in-test, skipped cleanly when pyshacl is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)