### PR TITLE
feat(ontology): classify measure semantics per column, no LLM needed

### DIFF
--- a/ontology/oba-shacl.ttl
+++ b/ontology/oba-shacl.ttl
@@ -92,11 +92,16 @@ oba:TableShape a sh:NodeShape ;
         sh:datatype xsd:string ;
         sh:name "semantic name"
     ] ;
+    # A real table is often both: a denormalized sales table holds additive
+    # measures next to dimension attributes, and the old enum could not say
+    # so.  "mixed" makes that expressible.  The role stays advisory either
+    # way -- what SUM() may touch is decided per column by oba:measureType,
+    # which is the granularity the question actually lives at.
     sh:property [
         sh:path oba:tableType ;
         sh:maxCount 1 ;
         sh:datatype xsd:string ;
-        sh:in ( "fact" "dimension" "lookup" ) ;
+        sh:in ( "fact" "dimension" "lookup" "mixed" ) ;
         sh:name "table type"
     ] ;
     sh:property [
@@ -139,6 +144,31 @@ oba:ColumnShape a sh:NodeShape ;
         sh:datatype xsd:string ;
         sh:name "SQL data type" ;
         sh:message "Every column property must have exactly one oba:sqlDataType (xsd:string)."
+    ] ;
+    # Measure semantics.  oba:measureBasis says how the classification was
+    # reached, because a structural fact (a key, a text column) can justify
+    # blocking a query while a name-pattern guess can only warn.
+    sh:property [
+        sh:path oba:measureType ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:in ( "additive" "semi_additive" "non_additive" "attribute" ) ;
+        sh:name "measure type" ;
+        sh:message "oba:measureType must be one of additive, semi_additive, non_additive, attribute."
+    ] ;
+    sh:property [
+        sh:path oba:measureBasis ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:in ( "structural" "name_pattern" "declared" ) ;
+        sh:name "measure basis" ;
+        sh:message "oba:measureBasis must be one of structural, name_pattern, declared."
+    ] ;
+    sh:property [
+        sh:path oba:measureReason ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "measure reason"
     ] ;
     sh:property [
         sh:path oba:sqlReference ;

--- a/ontology/oba.ttl
+++ b/ontology/oba.ttl
@@ -275,3 +275,31 @@ oba:viewColumnCount a owl:AnnotationProperty ;
     rdfs:label "view column count" ;
     rdfs:comment "Number of columns the view exposes." ;
     rdfs:range xsd:integer .
+
+# =============================================================================
+# 9. MEASURE SEMANTICS (used on owl:DatatypeProperty)
+# =============================================================================
+#
+# Additivity is a property of a column, not of the table holding it.  A
+# denormalized table carries additive measures next to attributes, so a
+# table-level role cannot express what SUM() is allowed to touch.
+#
+# Classified deterministically -- structural facts first (a key or a
+# non-numeric column can never be a measure), then column-name patterns.  A
+# column matching neither is left unannotated rather than guessed: consumers
+# read these as fact, so an absent value is safer than a wrong one.
+
+oba:measureType a owl:AnnotationProperty ;
+    rdfs:label "measure type" ;
+    rdfs:comment "How the column behaves under aggregation. 'additive': meaningful to SUM across every dimension. 'semi_additive': summable across entities but not across time (a balance, a stock level). 'non_additive': never meaningful to SUM (a unit price, a rate, a ratio) though AVG and MIN/MAX still are. 'attribute': not a measure at all (a key, a code, a label). Absent when it could not be determined without guessing." ;
+    rdfs:range xsd:string .
+
+oba:measureBasis a owl:AnnotationProperty ;
+    rdfs:label "measure basis" ;
+    rdfs:comment "How oba:measureType was arrived at: 'structural' when it follows from the data type or key membership and is therefore certain, 'name_pattern' when it was inferred from the column name and is therefore a heuristic, 'declared' when supplied by a client or semantic enrichment. Consumers weigh findings by this: a structural basis can justify blocking a query, a name pattern can only warn." ;
+    rdfs:range xsd:string .
+
+oba:measureReason a owl:AnnotationProperty ;
+    rdfs:label "measure reason" ;
+    rdfs:comment "Human-readable justification for the assigned oba:measureType, so a heuristic classification can be audited and corrected." ;
+    rdfs:range xsd:string .

--- a/ontology/oba.ttl
+++ b/ontology/oba.ttl
@@ -194,7 +194,7 @@ oba:semanticName a owl:AnnotationProperty ;
 
 oba:tableType a owl:AnnotationProperty ;
     rdfs:label "table type" ;
-    rdfs:comment "LLM-classified table role: 'fact', 'dimension', or 'lookup'." ;
+    rdfs:comment "LLM-classified table role: 'fact', 'dimension', 'lookup', or 'mixed' for a denormalized table that is both.  Advisory only: what may meaningfully be aggregated is decided per column by oba:measureType, because a single table holds additive measures beside dimension attributes." ;
     rdfs:range xsd:string .
 
 oba:usageNotes a owl:AnnotationProperty ;

--- a/ontology/spec.md
+++ b/ontology/spec.md
@@ -179,13 +179,42 @@ Cardinality:
 - at most one of each
 - if `oba:isDenormalized` is `true`, `oba:likelySourceTable` SHOULD be present
 
+### 6.7 Measure Semantics (on `owl:DatatypeProperty`)
+
+How a column behaves under aggregation. Placed on columns, not tables,
+because additivity is a property of the column: a denormalized table holds
+additive measures beside attributes, and no table-level role can say what
+`SUM()` may touch.
+
+Optional (present only when it could be determined without guessing):
+- `oba:measureType` --- `xsd:string`, one of `additive`, `semi_additive`,
+  `non_additive`, `attribute` (7.5)
+- `oba:measureBasis` --- `xsd:string`, one of `structural`, `name_pattern`,
+  `declared` (7.6)
+- `oba:measureReason` --- `xsd:string`, justification, so a heuristic
+  classification can be audited and corrected
+
+Cardinality:
+- at most one of each
+- if `oba:measureType` is present, `oba:measureBasis` SHOULD be present
+
+Consumers MUST weigh a finding by its basis: a `structural` classification
+is certain and may justify rejecting a query, whereas a `name_pattern`
+classification is a heuristic and SHOULD only warn.
+
+A column carrying no `oba:measureType` has not been classified. Consumers
+MUST NOT read that as `additive`.
+
 ### 6.6 Semantic Enrichment Properties (LLM-applied)
 
 These properties are added during LLM-driven semantic enrichment workflows. They are always optional.
 
 On `owl:Class` (tables):
 - `oba:semanticName` --- `xsd:string`, business-friendly name
-- `oba:tableType` --- `xsd:string`, `"fact"`, `"dimension"`, or `"lookup"`
+- `oba:tableType` --- `xsd:string`, `"fact"`, `"dimension"`, `"lookup"`, or
+  `"mixed"`. Advisory only. A denormalized table holds additive measures
+  beside dimension attributes, which is what `"mixed"` records; what may
+  actually be aggregated is decided per column by `oba:measureType` (6.7).
 - `oba:usageNotes` --- `xsd:string`, usage guidance
 
 On `owl:DatatypeProperty` (columns):
@@ -226,6 +255,21 @@ Cardinality:
 - `fact`
 - `dimension`
 - `lookup`
+- `mixed` --- both, as a denormalized table usually is
+
+Advisory. Aggregation is governed per column by `oba:measureType`, not by
+this value.
+
+### 7.5 Measure Types
+- `additive` --- meaningful to SUM across every dimension
+- `semi_additive` --- summable across entities but not across time
+- `non_additive` --- never meaningful to SUM (AVG and MIN/MAX still are)
+- `attribute` --- not a measure at all
+
+### 7.6 Measure Bases
+- `structural` --- follows from the SQL type or key membership; certain
+- `name_pattern` --- inferred from the column name; a heuristic
+- `declared` --- supplied by a client or semantic enrichment
 
 ## 8. Relationship to OBSL
 

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -35,6 +35,7 @@ class OBQCIssueType(Enum):
     NON_AGGREGATED_COLUMN = "non_aggregated_column"
     AMBIGUOUS_COLUMN = "ambiguous_column"
     VIEW_NOT_JOINABLE = "view_not_joinable"
+    INVALID_AGGREGATION = "invalid_aggregation"
 
 
 class OBQCSeverity(Enum):
@@ -347,6 +348,12 @@ class ColumnSchema:
     is_foreign_key: bool = False
     fk_referenced_table: str | None = None
     fk_referenced_column: str | None = None
+    # How the column behaves under aggregation, and how that was decided.
+    # None means the ontology did not say -- treated as "no opinion", never
+    # as "additive", so an unclassified column is never reported.
+    measure_type: str | None = None
+    measure_basis: str | None = None
+    measure_reason: str | None = None
 
 
 @dataclass
@@ -624,6 +631,15 @@ class OBQCValidator:
                         is_foreign_key=self._get_bool(
                             subject, self._oba_ns.isForeignKey, False
                         ),
+                        measure_type=self._get_literal(
+                            subject, self._oba_ns.measureType
+                        ),
+                        measure_basis=self._get_literal(
+                            subject, self._oba_ns.measureBasis
+                        ),
+                        measure_reason=self._get_literal(
+                            subject, self._oba_ns.measureReason
+                        ),
                     )
 
                     # Get XSD type from rdfs:range
@@ -793,6 +809,7 @@ class OBQCValidator:
         self._validate_joins(parsed, result)
         self._validate_type_compatibility(parsed, result)
         self._validate_aggregation_context(parsed, result)
+        self._validate_measure_aggregation(parsed, result)
         self._detect_fan_trap(result, blocking=not allow_fan_out)
 
         # Set overall validity
@@ -1859,6 +1876,117 @@ class OBQCValidator:
             found = True
 
         return found
+
+    def _validate_measure_aggregation(
+        self, parsed: exp.Expr, result: OBQCResult
+    ) -> None:
+        """Rule: SUM only what is meaningful to sum.
+
+        Independent of joins, and that is the point: ``SUM(unit_price)``
+        returns a number with no meaning even from a single table, and
+        nothing in OBQC could see that before. Additivity is a property of
+        the column, so a denormalized table holding measures beside
+        attributes is judged correctly without any table-level role.
+
+        Severity follows how the classification was reached, which the
+        ontology records. A structural finding is certain -- summing a
+        primary key or a text column is wrong by construction -- and blocks.
+        A name-pattern finding is a heuristic and only warns: a pattern that
+        misreads one schema's naming must not refuse to run its queries.
+
+        Only SUM is judged. AVG, MIN and MAX of a unit price are perfectly
+        ordinary, and COUNT does not read the value at all.
+
+        Args:
+            parsed: Parsed query.
+            result: Result to append issues to.
+        """
+        if self._schema_cache is None:
+            return
+
+        for select in parsed.find_all(exp.Select):
+            for agg in select.find_all(exp.Sum):
+                if agg.find_ancestor(exp.Select) is not select:
+                    continue
+
+                for column in self._value_columns(agg):
+                    schema = self._resolve_column_schema(column, select)
+                    if schema is None or schema.measure_type is None:
+                        continue
+                    if schema.measure_type in ("additive", "semi_additive"):
+                        continue
+
+                    structural = schema.measure_basis == "structural"
+                    label = f"{schema.table_name}.{schema.name}"
+                    if schema.measure_type == "attribute":
+                        headline = f"SUM({label}) sums a value that is not a measure"
+                    else:
+                        headline = (
+                            f"SUM({label}) sums a non-additive measure; the "
+                            "result has no meaning"
+                        )
+
+                    result.issues.append(
+                        OBQCIssue(
+                            issue_type=OBQCIssueType.INVALID_AGGREGATION,
+                            severity=(
+                                OBQCSeverity.ERROR
+                                if structural
+                                else OBQCSeverity.WARNING
+                            ),
+                            message=headline,
+                            location="SELECT list",
+                            suggestion=(
+                                schema.measure_reason
+                                or "Aggregate an additive measure instead."
+                            )
+                            + (
+                                ""
+                                if structural
+                                else " Classified from the column name, so"
+                                " override it if this schema means otherwise."
+                            ),
+                            related_entities=[label],
+                        )
+                    )
+
+    def _resolve_column_schema(
+        self, column: exp.Column, select: exp.Select
+    ) -> ColumnSchema | None:
+        """Find the ontology schema for *column* as referenced in *select*.
+
+        Args:
+            column: The column reference.
+            select: The SELECT providing its scope.
+
+        Returns:
+            The ColumnSchema, or None when it cannot be resolved unambiguously.
+        """
+        if self._schema_cache is None:
+            return None
+
+        col_key = (column.name or "").lower()
+        if not col_key:
+            return None
+
+        alias_map = self._build_alias_map(select)
+
+        qualifier = (column.table or "").lower()
+        if qualifier:
+            table_key = alias_map.get(qualifier, qualifier).lower()
+            table = self._schema_cache.tables.get(table_key)
+            return table.columns.get(col_key) if table else None
+
+        # Unqualified: only resolvable when exactly one table in scope has
+        # it. An ambiguous name is left alone rather than attributed to a
+        # guess, since the finding names the column it accuses.
+        matches = [
+            table.columns[col_key]
+            for name in {v.lower() for v in alias_map.values()}
+            if (table := self._schema_cache.tables.get(name)) is not None
+            and col_key in table.columns
+        ]
+        return matches[0] if len(matches) == 1 else None
 
     def _flag_view_joins(self, parsed: exp.Expr, result: OBQCResult) -> None:
         """Report SELECTs that join a view to anything else.

--- a/src/obqc_validator.py
+++ b/src/obqc_validator.py
@@ -1969,20 +1969,35 @@ class OBQCValidator:
         if not col_key:
             return None
 
-        alias_map = self._build_alias_map(select)
-
         qualifier = (column.table or "").lower()
         if qualifier:
-            table_key = alias_map.get(qualifier, qualifier).lower()
-            table = self._schema_cache.tables.get(table_key)
+            # Resolve the table *node*, not the name: whether a reference is
+            # a CTE is a property of that reference. A WITH alias may shadow
+            # a real table, and its columns are whatever its select list
+            # produced -- not the ontology's, whatever the name matches.
+            node = self._resolve_qualifier_table(select, qualifier)
+            if node is None or self._is_cte_reference(node):
+                return None
+            table = self._schema_cache.tables.get((node.name or "").lower())
             return table.columns.get(col_key) if table else None
 
-        # Unqualified: only resolvable when exactly one table in scope has
-        # it. An ambiguous name is left alone rather than attributed to a
-        # guess, since the finding names the column it accuses.
+        # Unqualified. A CTE in scope can legitimately provide this name, and
+        # nothing here can know its columns, so the whole scope is
+        # unjudgeable rather than resolved against a same-named base table.
+        scope_tables = [
+            t
+            for t in select.find_all(exp.Table)
+            if t.name and t.find_ancestor(exp.Select) is select
+        ]
+        if any(self._is_cte_reference(t) for t in scope_tables):
+            return None
+
+        # Only resolvable when exactly one table in scope has the column. An
+        # ambiguous name is left alone rather than attributed to a guess,
+        # since the finding names the column it accuses.
         matches = [
             table.columns[col_key]
-            for name in {v.lower() for v in alias_map.values()}
+            for name in {(t.name or "").lower() for t in scope_tables}
             if (table := self._schema_cache.tables.get(name)) is not None
             and col_key in table.columns
         ]

--- a/src/ontology_generator.py
+++ b/src/ontology_generator.py
@@ -26,6 +26,20 @@ _WORD_FREQ_THRESHOLD = 1e-6
 # These should NOT be flagged as cryptic on their own.
 _KNOWN_DB_SUFFIXES = {"id", "pk", "fk", "idx", "seq"}
 
+# Whole-word matcher for numeric SQL types, built from
+# OntologyGenerator.NUMERIC_SQL_TYPES below. Word boundaries matter: "int" is
+# a substring of POINT, INTERVAL and GEOPOINT, so substring matching reads a
+# geometry column as numeric.
+NUMERIC_TYPE_RE = re.compile(
+    r"\b(?:"
+    r"int|integer|bigint|smallint|tinyint|mediumint"
+    r"|serial|bigserial|smallserial"
+    r"|decimal|numeric|dec|fixed"
+    r"|float|double|real"
+    r"|money|smallmoney|number"
+    r")\b"
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -203,18 +217,31 @@ class OntologyGenerator:
     ]
 
     # SQL types that can hold a measure at all. Anything else is an
-    # attribute by construction -- SUM() of a string or a date is not a
-    # question about additivity, it is impossible.
+    # attribute by construction -- SUM() of a string, a date or a geometry
+    # is not a question about additivity, it is impossible.
+    #
+    # Matched with NUMERIC_TYPE_RE (whole words) rather than by substring:
+    # "int" is a substring of POINT, INTERVAL and GEOPOINT.
     NUMERIC_SQL_TYPES: ClassVar[list[str]] = [
         "int",
+        "integer",
+        "bigint",
+        "smallint",
+        "tinyint",
+        "mediumint",
         "serial",
+        "bigserial",
+        "smallserial",
         "decimal",
         "numeric",
         "float",
         "double",
         "real",
         "money",
+        "smallmoney",
         "number",
+        "dec",
+        "fixed",
     ]
 
     # Patterns for denormalized text fields
@@ -232,6 +259,11 @@ class OntologyGenerator:
 
         # OBA (OrionBelt Analytics) namespace for database schema annotations
         self.oba_ns = Namespace(OBA_NAMESPACE)
+
+        # (table, column) pairs this generator inferred to be foreign keys.
+        # Populated by generate_from_schema before any column is written, so
+        # classify_measure can treat an inferred key as the identifier it is.
+        self._inferred_fk_columns: set[tuple[str, str]] = set()
 
         self.graph.bind("ns", self.base_uri)
         self.graph.bind("oba", self.oba_ns)
@@ -319,6 +351,23 @@ class OntologyGenerator:
         self.graph.add((ontology_uri, RDFS.label, Literal(ONTOLOGY_TITLE)))
         self.graph.add((ontology_uri, RDFS.comment, Literal(ONTOLOGY_DESCRIPTION)))
 
+        # Relationships are inferred *before* the columns are written,
+        # because measure classification needs them: an inferred foreign key
+        # is an identifier just as much as a declared one, and the engines
+        # that most need inference (ClickHouse has no FKs at all; BigQuery
+        # and Dremio rarely carry them) are exactly the ones where every key
+        # would otherwise go unrecognised and SUM(customer_id) pass unseen.
+        # The relationship triples themselves are still added further down,
+        # once the classes they connect exist.
+        inferred = (
+            self._infer_implicit_relationships(tables_info)
+            if include_inferred_relationships
+            else []
+        )
+        self._inferred_fk_columns = {
+            (rel.source_table.lower(), rel.column.lower()) for rel in inferred
+        }
+
         # Add all tables and their columns/relationships
         for table_info in tables_info:
             self._add_table_to_ontology(table_info)
@@ -332,9 +381,9 @@ class OntologyGenerator:
         for view_info in views_info or []:
             self._add_view_to_ontology(view_info, known_tables)
 
-        # Infer implicit relationships from naming patterns
+        # Materialize the relationships inferred above, now that the classes
+        # they connect exist.
         if include_inferred_relationships:
-            inferred = self._infer_implicit_relationships(tables_info)
             self.quality_report.inferred_relationships = inferred
 
             for rel in inferred:
@@ -386,7 +435,9 @@ class OntologyGenerator:
         """
         return self.quality_report
 
-    def classify_measure(self, column: ColumnInfo) -> tuple[str, str, str] | None:
+    def classify_measure(
+        self, column: ColumnInfo, table_name: str | None = None
+    ) -> tuple[str, str, str] | None:
         """Classify how *column* behaves under aggregation.
 
         Deterministic, in two tiers of decreasing certainty, because the
@@ -409,6 +460,8 @@ class OntologyGenerator:
 
         Args:
             column: The column to classify.
+            table_name: Owning table, needed to recognise a key this
+                generator inferred rather than read from the catalog.
 
         Returns:
             ``(measure_type, basis, reason)``, or None when undeterminable.
@@ -429,14 +482,27 @@ class OntologyGenerator:
                 "structural",
                 "Foreign key: an identifier, not a measure",
             )
-        if not any(t in sql_type for t in self.NUMERIC_SQL_TYPES):
+        # A key this generator inferred is as much an identifier as a
+        # declared one. Several supported engines carry no FK metadata at
+        # all -- ClickHouse has no foreign keys, BigQuery and Dremio rarely
+        # declare them -- so without this their keys would all read as
+        # unclassified numerics and SUM(customer_id) would pass unseen.
+        if table_name and (table_name.lower(), name) in self._inferred_fk_columns:
+            return (
+                "attribute",
+                "structural",
+                "Inferred foreign key: an identifier, not a measure",
+            )
+        # Whole-word match, not substring. "int" is contained in POINT,
+        # INTERVAL and GEOPOINT, all of which would otherwise be read as
+        # numeric and then fall through unclassified -- leaving SUM(location)
+        # on a POINT column entirely unreported.
+        if not NUMERIC_TYPE_RE.search(sql_type):
             return (
                 "attribute",
                 "structural",
                 f"Non-numeric SQL type '{column.data_type}' cannot be aggregated as a measure",
             )
-        # "int" matches "point"/"interval" but bool/date/time do not reach
-        # here anyway; guard the one real overlap explicitly.
         if any(t in sql_type for t in ("bool", "date", "time", "interval")):
             return (
                 "attribute",
@@ -641,7 +707,7 @@ class OntologyGenerator:
         # because a denormalized table holds additive measures next to
         # attributes and a table-level role cannot express that. Omitted
         # entirely when it could not be determined without guessing.
-        measure = self.classify_measure(column)
+        measure = self.classify_measure(column, table_name)
         if measure is not None:
             measure_type, basis, reason = measure
             self.graph.add((prop_uri, self.oba_ns.measureType, Literal(measure_type)))

--- a/src/ontology_generator.py
+++ b/src/ontology_generator.py
@@ -26,19 +26,99 @@ _WORD_FREQ_THRESHOLD = 1e-6
 # These should NOT be flagged as cryptic on their own.
 _KNOWN_DB_SUFFIXES = {"id", "pk", "fk", "idx", "seq"}
 
-# Whole-word matcher for numeric SQL types, built from
-# OntologyGenerator.NUMERIC_SQL_TYPES below. Word boundaries matter: "int" is
-# a substring of POINT, INTERVAL and GEOPOINT, so substring matching reads a
-# geometry column as numeric.
-NUMERIC_TYPE_RE = re.compile(
-    r"\b(?:"
-    r"int|integer|bigint|smallint|tinyint|mediumint"
-    r"|serial|bigserial|smallserial"
-    r"|decimal|numeric|dec|fixed"
-    r"|float|double|real"
-    r"|money|smallmoney|number"
-    r")\b"
+# Alphabetic runs of a SQL type name. Splitting on everything else does the
+# normalization on its own: the width suffixes fall away (INT64 -> int,
+# Float64 -> float, Decimal128 -> decimal) and wrappers surrender their inner
+# type (Nullable(Float64) -> nullable, float; ARRAY<INT64> -> array, int).
+_TYPE_TOKEN_RE = re.compile(r"[a-z]+")
+
+# Numeric type names across every supported dialect, as tokens. Membership
+# rather than substring: "int" is contained in POINT, INTERVAL and GEOPOINT,
+# and matching those as numeric leaves SUM(location) unreported. Membership
+# rather than word-boundary regex: BigQuery writes INT64 and BIGNUMERIC,
+# ClickHouse UInt64 and Float32, DuckDB HUGEINT and UTINYINT -- none of which
+# contain a numeric *word*, so a \b matcher rejects them and every measure on
+# those engines is misread as an attribute.
+_NUMERIC_TYPE_TOKENS = frozenset(
+    {
+        # integers
+        "int",
+        "integer",
+        "bigint",
+        "smallint",
+        "tinyint",
+        "mediumint",
+        "byteint",
+        "hugeint",
+        "int2",
+        "int4",
+        "int8",
+        # auto-increment integers
+        "serial",
+        "bigserial",
+        "smallserial",
+        # exact decimals
+        "decimal",
+        "numeric",
+        "bignumeric",
+        "dec",
+        "fixed",
+        "number",
+        # floating point
+        "float",
+        "double",
+        "real",
+        "float4",
+        "float8",
+        # currency
+        "money",
+        "smallmoney",
+    }
 )
+
+# Composite types. Scalar aggregation does not apply to them, whatever they
+# contain: SUM(Array(Float64)) is not a question about additivity.
+_COMPOSITE_TYPE_TOKENS = frozenset(
+    {
+        "array",
+        "map",
+        "tuple",
+        "struct",
+        "nested",
+        "json",
+        "jsonb",
+        "variant",
+        "object",
+        "list",
+        "row",
+        "set",
+        "geometry",
+        "geography",
+    }
+)
+
+
+def is_numeric_sql_type(sql_type: str) -> bool:
+    """True when *sql_type* holds a scalar number in any supported dialect.
+
+    Args:
+        sql_type: The SQL type as the catalog reports it.
+
+    Returns:
+        True for a scalar numeric type, False for anything else --
+        composites included, since they cannot be summed at all.
+    """
+    tokens = set(_TYPE_TOKEN_RE.findall((sql_type or "").lower()))
+    if tokens & _COMPOSITE_TYPE_TOKENS:
+        return False
+    # The unsigned prefix generically: ClickHouse UInt64 and DuckDB
+    # UTINYINT/UBIGINT are the signed name with a "u" in front.
+    return any(
+        token in _NUMERIC_TYPE_TOKENS
+        or (token.startswith("u") and token[1:] in _NUMERIC_TYPE_TOKENS)
+        for token in tokens
+    )
+
 
 logger = logging.getLogger(__name__)
 
@@ -493,11 +573,11 @@ class OntologyGenerator:
                 "structural",
                 "Inferred foreign key: an identifier, not a measure",
             )
-        # Whole-word match, not substring. "int" is contained in POINT,
-        # INTERVAL and GEOPOINT, all of which would otherwise be read as
-        # numeric and then fall through unclassified -- leaving SUM(location)
-        # on a POINT column entirely unreported.
-        if not NUMERIC_TYPE_RE.search(sql_type):
+        # Token membership, not substring and not word boundaries. Both of
+        # those fail on real dialect spellings in opposite directions: "int"
+        # is a substring of POINT, and INT64 / UInt64 / HUGEINT contain no
+        # numeric word at all.
+        if not is_numeric_sql_type(sql_type):
             return (
                 "attribute",
                 "structural",

--- a/src/ontology_generator.py
+++ b/src/ontology_generator.py
@@ -129,6 +129,94 @@ class OntologyGenerator:
         "amt",
     ]
 
+    # Column-name patterns for measure semantics. Ordered most specific
+    # first at the point of use: "unit_price" is non-additive even though it
+    # contains "price", and "total_amount" is additive even though a bare
+    # "total" could be either.
+    #
+    # Never meaningful to SUM: a rate, a ratio, a per-unit value. AVG and
+    # MIN/MAX of these are perfectly ordinary, so only SUM is at issue.
+    NON_ADDITIVE_PATTERNS: ClassVar[list[str]] = [
+        "unit_price",
+        "unitprice",
+        "unit_cost",
+        "unitcost",
+        "_rate",
+        "rate_",
+        "_pct",
+        "_percent",
+        "percentage",
+        "_ratio",
+        "ratio_",
+        "margin",
+        "_avg",
+        "avg_",
+        "average",
+        "_price",
+        "price_",
+        "discount_pct",
+        "tax_rate",
+        "exchange_rate",
+        "score",
+        "rating",
+        "temperature",
+        "latitude",
+        "longitude",
+    ]
+
+    # Summable across entities but not across time: a snapshot of a level
+    # rather than a flow. Summing balances over months double-counts.
+    SEMI_ADDITIVE_PATTERNS: ClassVar[list[str]] = [
+        "balance",
+        "_level",
+        "level_",
+        "stock",
+        "on_hand",
+        "onhand",
+        "inventory",
+        "headcount",
+        "occupancy",
+        "_snapshot",
+    ]
+
+    # Meaningful to SUM across every dimension.
+    ADDITIVE_PATTERNS: ClassVar[list[str]] = [
+        "amount",
+        "_amt",
+        "amt_",
+        "quantity",
+        "_qty",
+        "qty_",
+        "revenue",
+        "sales",
+        "_total",
+        "total_",
+        "_sum",
+        "sum_",
+        "_count",
+        "count_",
+        "cost",
+        "profit",
+        "spend",
+        "volume",
+        "weight",
+    ]
+
+    # SQL types that can hold a measure at all. Anything else is an
+    # attribute by construction -- SUM() of a string or a date is not a
+    # question about additivity, it is impossible.
+    NUMERIC_SQL_TYPES: ClassVar[list[str]] = [
+        "int",
+        "serial",
+        "decimal",
+        "numeric",
+        "float",
+        "double",
+        "real",
+        "money",
+        "number",
+    ]
+
     # Patterns for denormalized text fields
     DENORM_SUFFIXES: ClassVar[list[str]] = [
         "name",
@@ -298,6 +386,97 @@ class OntologyGenerator:
         """
         return self.quality_report
 
+    def classify_measure(self, column: ColumnInfo) -> tuple[str, str, str] | None:
+        """Classify how *column* behaves under aggregation.
+
+        Deterministic, in two tiers of decreasing certainty, because the
+        consumer weighs them differently: a structural finding can justify
+        refusing a query, a name-pattern finding can only warn.
+
+        Tier 1, structural and certain. A key is an identifier, not a
+        measure -- ``SUM(order_id)`` is nonsense however numeric it is. A
+        non-numeric column cannot be summed at all. Both follow from schema
+        metadata alone, with no interpretation.
+
+        Tier 2, column-name patterns. A unit price or a rate is never
+        meaningful to SUM; a balance is summable across accounts but not
+        across time. Heuristic, so it is recorded with its reason and marked
+        ``name_pattern`` for the consumer to discount.
+
+        A numeric non-key column matching no pattern returns None -- left
+        unannotated rather than assumed additive. Consumers read these as
+        fact, so an absent value is safer than a wrong one.
+
+        Args:
+            column: The column to classify.
+
+        Returns:
+            ``(measure_type, basis, reason)``, or None when undeterminable.
+        """
+        name = (column.name or "").lower()
+        sql_type = (column.data_type or "").lower()
+
+        # -- Tier 1: structural -------------------------------------------
+        if column.is_primary_key:
+            return (
+                "attribute",
+                "structural",
+                "Primary key: an identifier, not a measure",
+            )
+        if column.is_foreign_key:
+            return (
+                "attribute",
+                "structural",
+                "Foreign key: an identifier, not a measure",
+            )
+        if not any(t in sql_type for t in self.NUMERIC_SQL_TYPES):
+            return (
+                "attribute",
+                "structural",
+                f"Non-numeric SQL type '{column.data_type}' cannot be aggregated as a measure",
+            )
+        # "int" matches "point"/"interval" but bool/date/time do not reach
+        # here anyway; guard the one real overlap explicitly.
+        if any(t in sql_type for t in ("bool", "date", "time", "interval")):
+            return (
+                "attribute",
+                "structural",
+                f"Temporal or boolean SQL type '{column.data_type}' is not a measure",
+            )
+
+        # -- Tier 2: name patterns ----------------------------------------
+        # Most specific first: "unit_price" is non-additive despite
+        # containing neither an additive nor a semi-additive token, and
+        # "total_amount" must not be read as non-additive via "_avg".
+        for pattern in self.NON_ADDITIVE_PATTERNS:
+            if pattern in name:
+                return (
+                    "non_additive",
+                    "name_pattern",
+                    f"Column name contains '{pattern}': a per-unit value, rate or "
+                    "ratio is not meaningful to SUM (AVG and MIN/MAX still are)",
+                )
+        for pattern in self.SEMI_ADDITIVE_PATTERNS:
+            if pattern in name:
+                return (
+                    "semi_additive",
+                    "name_pattern",
+                    f"Column name contains '{pattern}': a level or snapshot is "
+                    "summable across entities but not across time",
+                )
+        for pattern in self.ADDITIVE_PATTERNS:
+            if pattern in name:
+                return (
+                    "additive",
+                    "name_pattern",
+                    f"Column name contains '{pattern}': a flow quantity, "
+                    "summable across every dimension",
+                )
+
+        # Numeric, not a key, no pattern matched. Unknowable without
+        # guessing, so say nothing.
+        return None
+
     def _add_view_to_ontology(
         self, view_info: Any, known_tables: dict[str, str]
     ) -> None:
@@ -457,6 +636,17 @@ class OntologyGenerator:
         self.graph.add((prop_uri, self.oba_ns.tableName, Literal(table_name)))
         self.graph.add((prop_uri, self.oba_ns.sqlDataType, Literal(column.data_type)))
         self.graph.add((prop_uri, self.oba_ns.isNullable, Literal(column.is_nullable)))
+
+        # Measure semantics: what SUM() may meaningfully touch. Per column,
+        # because a denormalized table holds additive measures next to
+        # attributes and a table-level role cannot express that. Omitted
+        # entirely when it could not be determined without guessing.
+        measure = self.classify_measure(column)
+        if measure is not None:
+            measure_type, basis, reason = measure
+            self.graph.add((prop_uri, self.oba_ns.measureType, Literal(measure_type)))
+            self.graph.add((prop_uri, self.oba_ns.measureBasis, Literal(basis)))
+            self.graph.add((prop_uri, self.oba_ns.measureReason, Literal(reason)))
         self.graph.add(
             (prop_uri, self.oba_ns.isPrimaryKey, Literal(column.is_primary_key))
         )

--- a/tests/test_measure_semantics.py
+++ b/tests/test_measure_semantics.py
@@ -1,0 +1,242 @@
+"""Tests for per-column measure semantics.
+
+Additivity is a property of a column, not of the table holding it. A
+denormalized table carries additive measures next to attributes, so a
+table-level role cannot express what SUM() is allowed to touch -- which is
+why oba:tableType stayed advisory and this went on columns.
+
+Classification is deterministic, in two tiers. Structural findings follow
+from the data type or key membership and are certain, so they block. Name
+patterns are heuristics and only warn: a pattern that misreads one schema's
+naming must not refuse to run its queries.
+"""
+
+import unittest
+
+from rdflib import Graph, Namespace
+
+from src.constants import OBA_NAMESPACE
+from src.database_manager import ColumnInfo, TableInfo
+from src.obqc_validator import OBQCIssueType, OBQCSeverity, OBQCValidator
+from src.ontology_generator import OntologyGenerator
+
+BASE_URI = "http://test.com/ontology/"
+OBA = Namespace(OBA_NAMESPACE)
+
+
+def _col(name, data_type, pk=False, fk=False):
+    return ColumnInfo(
+        name=name,
+        data_type=data_type,
+        is_nullable=True,
+        is_primary_key=pk,
+        is_foreign_key=fk,
+    )
+
+
+# One denormalized table holding facts and dimensions side by side.
+MIXED_TABLE = TableInfo(
+    name="sales",
+    schema="public",
+    columns=[
+        _col("sale_id", "INTEGER", pk=True),
+        _col("customer_id", "INTEGER", fk=True),
+        _col("region_name", "TEXT"),
+        _col("sale_date", "DATE"),
+        _col("amount", "DECIMAL"),
+        _col("quantity", "INTEGER"),
+        _col("unit_price", "DECIMAL"),
+        _col("account_balance", "DECIMAL"),
+        _col("mystery_number", "DECIMAL"),
+    ],
+    primary_keys=["sale_id"],
+    foreign_keys=[],
+)
+
+
+class TestStructuralClassification(unittest.TestCase):
+    """Tier 1: certain, from schema metadata alone."""
+
+    def setUp(self):
+        self.gen = OntologyGenerator(BASE_URI)
+
+    def _classify(self, column):
+        return self.gen.classify_measure(column)
+
+    def test_primary_key_is_an_attribute(self):
+        kind, basis, _ = self._classify(_col("sale_id", "INTEGER", pk=True))
+        self.assertEqual((kind, basis), ("attribute", "structural"))
+
+    def test_foreign_key_is_an_attribute(self):
+        kind, basis, _ = self._classify(_col("customer_id", "INTEGER", fk=True))
+        self.assertEqual((kind, basis), ("attribute", "structural"))
+
+    def test_text_column_is_an_attribute(self):
+        kind, basis, _ = self._classify(_col("region_name", "TEXT"))
+        self.assertEqual((kind, basis), ("attribute", "structural"))
+
+    def test_date_column_is_an_attribute(self):
+        kind, basis, _ = self._classify(_col("sale_date", "DATE"))
+        self.assertEqual((kind, basis), ("attribute", "structural"))
+
+    def test_structural_wins_over_a_measure_sounding_name(self):
+        """A key named like a measure is still a key."""
+        kind, basis, _ = self._classify(_col("amount_id", "INTEGER", pk=True))
+        self.assertEqual((kind, basis), ("attribute", "structural"))
+
+
+class TestNamePatternClassification(unittest.TestCase):
+    """Tier 2: heuristic, and marked as such."""
+
+    def setUp(self):
+        self.gen = OntologyGenerator(BASE_URI)
+
+    def _kind(self, name, data_type="DECIMAL"):
+        result = self.gen.classify_measure(_col(name, data_type))
+        return result[0] if result else None
+
+    def test_additive_measures(self):
+        for name in ("amount", "total_revenue", "quantity", "line_cost"):
+            self.assertEqual(self._kind(name), "additive", name)
+
+    def test_non_additive_measures(self):
+        for name in ("unit_price", "tax_rate", "discount_pct", "profit_margin"):
+            self.assertEqual(self._kind(name), "non_additive", name)
+
+    def test_semi_additive_measures(self):
+        for name in ("account_balance", "stock_level", "inventory_on_hand"):
+            self.assertEqual(self._kind(name), "semi_additive", name)
+
+    def test_non_additive_beats_additive_on_overlap(self):
+        """unit_cost contains "cost" but a per-unit value is not additive."""
+        self.assertEqual(self._kind("unit_cost"), "non_additive")
+
+    def test_basis_is_recorded_as_name_pattern(self):
+        _, basis, reason = self.gen.classify_measure(_col("unit_price", "DECIMAL"))
+        self.assertEqual(basis, "name_pattern")
+        self.assertIn("unit_price", reason)
+
+    def test_unmatched_numeric_column_is_left_unset(self):
+        """Not "assume additive" -- consumers read these as fact."""
+        self.assertIsNone(self.gen.classify_measure(_col("mystery_number", "DECIMAL")))
+
+
+class TestOntologyEmission(unittest.TestCase):
+    def setUp(self):
+        ttl = OntologyGenerator(BASE_URI).generate_from_schema([MIXED_TABLE])
+        self.ttl = ttl
+        self.g = Graph()
+        self.g.parse(data=ttl, format="turtle")
+        self.ns = Namespace(BASE_URI)
+
+    def _measure(self, column):
+        return self.g.value(self.ns[f"sales_{column}"], OBA.measureType)
+
+    def test_one_table_carries_several_measure_kinds(self):
+        """The whole point: a table is not one role."""
+        kinds = {
+            str(self._measure(c))
+            for c in ("sale_id", "amount", "unit_price", "account_balance")
+        }
+        self.assertEqual(
+            kinds, {"attribute", "additive", "non_additive", "semi_additive"}
+        )
+
+    def test_basis_and_reason_are_emitted(self):
+        uri = self.ns["sales_unit_price"]
+        self.assertEqual(str(self.g.value(uri, OBA.measureBasis)), "name_pattern")
+        self.assertIsNotNone(self.g.value(uri, OBA.measureReason))
+
+    def test_unclassified_column_gets_no_triples(self):
+        uri = self.ns["sales_mystery_number"]
+        self.assertIsNone(self.g.value(uri, OBA.measureType))
+        self.assertIsNone(self.g.value(uri, OBA.measureBasis))
+
+    def test_shacl_conformance(self):
+        from src.shacl_validator import shacl_available, validate_ontology
+
+        if not shacl_available():
+            self.skipTest("pyshacl not installed")
+        result = validate_ontology(self.ttl)
+        self.assertTrue(result["conforms"], result.get("report"))
+
+
+class TestOBQCMeasureRule(unittest.TestCase):
+    """Judged without any join: SUM(unit_price) is wrong from one table."""
+
+    def setUp(self):
+        ttl = OntologyGenerator(BASE_URI).generate_from_schema([MIXED_TABLE])
+        g = Graph()
+        g.parse(data=ttl, format="turtle")
+        self.validator = OBQCValidator()
+        self.validator.load_ontology(g, BASE_URI)
+
+    def _findings(self, sql):
+        return [
+            i
+            for i in self.validator.validate(sql).issues
+            if i.issue_type is OBQCIssueType.INVALID_AGGREGATION
+        ]
+
+    def test_summing_an_additive_measure_is_clean(self):
+        self.assertEqual(self._findings("SELECT SUM(amount) FROM sales"), [])
+
+    def test_summing_a_key_is_a_blocking_error(self):
+        found = self._findings("SELECT SUM(sale_id) FROM sales")
+        self.assertEqual(found[0].severity, OBQCSeverity.ERROR)
+
+    def test_summing_a_text_column_is_a_blocking_error(self):
+        found = self._findings("SELECT SUM(region_name) FROM sales")
+        self.assertEqual(found[0].severity, OBQCSeverity.ERROR)
+
+    def test_summing_a_non_additive_measure_only_warns(self):
+        """A name pattern must not refuse to run a query."""
+        found = self._findings("SELECT SUM(unit_price) FROM sales")
+        self.assertEqual(found[0].severity, OBQCSeverity.WARNING)
+
+    def test_semi_additive_sum_is_allowed(self):
+        """Summable across entities; only across time is it wrong, and the
+        query does not say."""
+        self.assertEqual(self._findings("SELECT SUM(account_balance) FROM sales"), [])
+
+    def test_avg_of_a_non_additive_measure_is_fine(self):
+        self.assertEqual(self._findings("SELECT AVG(unit_price) FROM sales"), [])
+
+    def test_min_max_and_count_are_not_judged(self):
+        for sql in (
+            "SELECT MAX(unit_price) FROM sales",
+            "SELECT MIN(unit_price) FROM sales",
+            "SELECT COUNT(sale_id) FROM sales",
+        ):
+            self.assertEqual(self._findings(sql), [], sql)
+
+    def test_unclassified_column_is_never_reported(self):
+        self.assertEqual(self._findings("SELECT SUM(mystery_number) FROM sales"), [])
+
+    def test_qualified_and_aliased_references_resolve(self):
+        self.assertTrue(self._findings("SELECT SUM(s.sale_id) FROM sales s"))
+
+    def test_reason_travels_with_the_finding(self):
+        found = self._findings("SELECT SUM(unit_price) FROM sales")
+        self.assertIn("unit_price", found[0].suggestion)
+        self.assertIn("override", found[0].suggestion)
+
+
+class TestTableTypeAllowsMixed(unittest.TestCase):
+    def test_mixed_is_a_valid_table_type(self):
+        from src.shacl_validator import shacl_available, validate_ontology
+
+        if not shacl_available():
+            self.skipTest("pyshacl not installed")
+
+        ttl = OntologyGenerator(BASE_URI).generate_from_schema([MIXED_TABLE])
+        ttl += (
+            "\n<http://test.com/ontology/sales> "
+            '<https://ralforion.com/ns/oba#tableType> "mixed" .\n'
+        )
+        result = validate_ontology(ttl)
+        self.assertTrue(result["conforms"], result.get("report"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_measure_semantics.py
+++ b/tests/test_measure_semantics.py
@@ -222,6 +222,112 @@ class TestOBQCMeasureRule(unittest.TestCase):
         self.assertIn("override", found[0].suggestion)
 
 
+class TestCTEShadowingIsNotJudged(unittest.TestCase):
+    """A WITH alias may shadow a base table, and its columns are the query's
+    own. Resolving against the same-named ontology table blocked valid CTEs."""
+
+    def setUp(self):
+        ttl = OntologyGenerator(BASE_URI).generate_from_schema([MIXED_TABLE])
+        g = Graph()
+        g.parse(data=ttl, format="turtle")
+        self.validator = OBQCValidator()
+        self.validator.load_ontology(g, BASE_URI)
+
+    def _findings(self, sql):
+        return [
+            i
+            for i in self.validator.validate(sql).issues
+            if i.issue_type is OBQCIssueType.INVALID_AGGREGATION
+        ]
+
+    def test_qualified_reference_to_a_shadowing_cte_is_not_judged(self):
+        self.assertEqual(
+            self._findings(
+                "WITH sales AS (SELECT 1 AS sale_id) "
+                "SELECT SUM(sales.sale_id) FROM sales"
+            ),
+            [],
+        )
+
+    def test_unqualified_reference_with_a_cte_in_scope_is_not_judged(self):
+        self.assertEqual(
+            self._findings(
+                "WITH sales AS (SELECT 1 AS sale_id) SELECT SUM(sale_id) FROM sales"
+            ),
+            [],
+        )
+
+    def test_the_real_table_is_still_judged_outside_the_cte(self):
+        """Shadowing must not disable the rule everywhere."""
+        self.assertTrue(self._findings("SELECT SUM(sale_id) FROM sales"))
+
+
+class TestInferredForeignKeys(unittest.TestCase):
+    """Several supported engines carry no FK metadata at all."""
+
+    def _validator(self, tables):
+        ttl = OntologyGenerator(BASE_URI).generate_from_schema(tables)
+        g = Graph()
+        g.parse(data=ttl, format="turtle")
+        validator = OBQCValidator()
+        validator.load_ontology(g, BASE_URI)
+        return validator
+
+    def test_inferred_fk_is_an_attribute(self):
+        """customer_id -> customers is inferred, though never declared."""
+        sales = TableInfo(
+            name="sales",
+            schema="public",
+            columns=[_col("id", "INTEGER", pk=True), _col("customer_id", "INTEGER")],
+            primary_keys=["id"],
+            foreign_keys=[],
+        )
+        customers = TableInfo(
+            name="customers",
+            schema="public",
+            columns=[_col("id", "INTEGER", pk=True), _col("name", "TEXT")],
+            primary_keys=["id"],
+            foreign_keys=[],
+        )
+        validator = self._validator([sales, customers])
+        found = [
+            i
+            for i in validator.validate("SELECT SUM(customer_id) FROM sales").issues
+            if i.issue_type is OBQCIssueType.INVALID_AGGREGATION
+        ]
+        self.assertTrue(found)
+        self.assertEqual(found[0].severity, OBQCSeverity.ERROR)
+        self.assertIn("Inferred foreign key", found[0].suggestion)
+
+
+class TestNumericTypeMatchingIsWholeWord(unittest.TestCase):
+    """ "int" is a substring of POINT, INTERVAL and GEOPOINT."""
+
+    def setUp(self):
+        self.gen = OntologyGenerator(BASE_URI)
+
+    def test_geometry_types_are_attributes(self):
+        for sql_type in ("POINT", "GEOPOINT", "POLYGON", "GEOGRAPHY"):
+            result = self.gen.classify_measure(_col("location", sql_type))
+            self.assertIsNotNone(result, sql_type)
+            self.assertEqual((result[0], result[1]), ("attribute", "structural"))
+
+    def test_interval_is_an_attribute(self):
+        result = self.gen.classify_measure(_col("duration", "INTERVAL"))
+        self.assertEqual(result[0], "attribute")
+
+    def test_real_numeric_types_still_match(self):
+        for sql_type in (
+            "INTEGER",
+            "BIGINT",
+            "DECIMAL(18,2)",
+            "DOUBLE PRECISION",
+            "NUMERIC",
+        ):
+            result = self.gen.classify_measure(_col("amount", sql_type))
+            self.assertEqual(result[0], "additive", sql_type)
+
+
 class TestTableTypeAllowsMixed(unittest.TestCase):
     def test_mixed_is_a_valid_table_type(self):
         from src.shacl_validator import shacl_available, validate_ontology

--- a/tests/test_measure_semantics.py
+++ b/tests/test_measure_semantics.py
@@ -18,7 +18,7 @@ from rdflib import Graph, Namespace
 from src.constants import OBA_NAMESPACE
 from src.database_manager import ColumnInfo, TableInfo
 from src.obqc_validator import OBQCIssueType, OBQCSeverity, OBQCValidator
-from src.ontology_generator import OntologyGenerator
+from src.ontology_generator import OntologyGenerator, is_numeric_sql_type
 
 BASE_URI = "http://test.com/ontology/"
 OBA = Namespace(OBA_NAMESPACE)
@@ -300,32 +300,98 @@ class TestInferredForeignKeys(unittest.TestCase):
         self.assertIn("Inferred foreign key", found[0].suggestion)
 
 
-class TestNumericTypeMatchingIsWholeWord(unittest.TestCase):
-    """ "int" is a substring of POINT, INTERVAL and GEOPOINT."""
+class TestNumericTypeDetection(unittest.TestCase):
+    """Substring and word-boundary matching both fail on real dialect
+    spellings, in opposite directions: "int" is a substring of POINT, while
+    INT64, UInt64 and HUGEINT contain no numeric word at all. The second is
+    the worse failure -- it misreads every measure on an engine as an
+    attribute and blocks valid SUMs."""
 
-    def setUp(self):
-        self.gen = OntologyGenerator(BASE_URI)
-
-    def test_geometry_types_are_attributes(self):
-        for sql_type in ("POINT", "GEOPOINT", "POLYGON", "GEOGRAPHY"):
-            result = self.gen.classify_measure(_col("location", sql_type))
-            self.assertIsNotNone(result, sql_type)
-            self.assertEqual((result[0], result[1]), ("attribute", "structural"))
-
-    def test_interval_is_an_attribute(self):
-        result = self.gen.classify_measure(_col("duration", "INTERVAL"))
-        self.assertEqual(result[0], "attribute")
-
-    def test_real_numeric_types_still_match(self):
+    def test_ansi_spellings(self):
         for sql_type in (
             "INTEGER",
             "BIGINT",
+            "SMALLINT",
             "DECIMAL(18,2)",
-            "DOUBLE PRECISION",
             "NUMERIC",
+            "DOUBLE PRECISION",
+            "REAL",
+            "smallserial",
+            "money",
         ):
-            result = self.gen.classify_measure(_col("amount", sql_type))
+            self.assertTrue(is_numeric_sql_type(sql_type), sql_type)
+
+    def test_bigquery_spellings(self):
+        for sql_type in ("INT64", "FLOAT64", "NUMERIC", "BIGNUMERIC"):
+            self.assertTrue(is_numeric_sql_type(sql_type), sql_type)
+
+    def test_clickhouse_spellings(self):
+        for sql_type in (
+            "Int8",
+            "Int256",
+            "UInt64",
+            "Float32",
+            "Float64",
+            "Decimal128",
+            "Nullable(Float64)",
+            "LowCardinality(UInt32)",
+        ):
+            self.assertTrue(is_numeric_sql_type(sql_type), sql_type)
+
+    def test_duckdb_and_snowflake_spellings(self):
+        for sql_type in (
+            "HUGEINT",
+            "UTINYINT",
+            "UBIGINT",
+            "UINTEGER",
+            "BYTEINT",
+            "FLOAT4",
+            "FLOAT8",
+            "NUMBER(38,0)",
+        ):
+            self.assertTrue(is_numeric_sql_type(sql_type), sql_type)
+
+    def test_geometry_and_temporal_types_are_not_numeric(self):
+        for sql_type in (
+            "POINT",
+            "GEOPOINT",
+            "POLYGON",
+            "GEOGRAPHY",
+            "GEOMETRY",
+            "INTERVAL",
+            "DATE",
+            "TIMESTAMP",
+            "BOOLEAN",
+            "VARCHAR(50)",
+            "UUID",
+        ):
+            self.assertFalse(is_numeric_sql_type(sql_type), sql_type)
+
+    def test_composites_are_not_numeric_whatever_they_contain(self):
+        """SUM(Array(Float64)) is not a question about additivity."""
+        for sql_type in (
+            "ARRAY<INT64>",
+            "Array(Float64)",
+            "STRUCT<a INT64>",
+            "MAP<STRING,INT64>",
+            "Tuple(Int64, String)",
+            "JSON",
+        ):
+            self.assertFalse(is_numeric_sql_type(sql_type), sql_type)
+
+    def test_measures_classify_on_every_dialect_spelling(self):
+        """Regression: a measure misread as an attribute makes OBQC block
+        SUM(amount) -- a valid query -- across that whole engine."""
+        gen = OntologyGenerator(BASE_URI)
+        for sql_type in ("INT64", "Float64", "UInt64", "HUGEINT", "NUMBER(38,2)"):
+            result = gen.classify_measure(_col("amount", sql_type))
             self.assertEqual(result[0], "additive", sql_type)
+
+    def test_geometry_columns_are_attributes(self):
+        gen = OntologyGenerator(BASE_URI)
+        for sql_type in ("POINT", "GEOPOINT", "POLYGON", "GEOGRAPHY"):
+            result = gen.classify_measure(_col("location", sql_type))
+            self.assertEqual((result[0], result[1]), ("attribute", "structural"))
 
 
 class TestTableTypeAllowsMixed(unittest.TestCase):


### PR DESCRIPTION
Follows #95. Answers "a table can contain facts and dimensions — how is that handled?"

## What I found first

`oba:tableType` was **write-only**: written in one place (applying LLM semantic enrichment) and read by **zero** code paths. So a mixed table caused no incorrect behaviour — but the annotation carried less than its presence suggested, and SHACL's `sh:maxCount 1` + `sh:in ("fact" "dimension" "lookup")` meant a denormalized table couldn't even be labelled honestly.

Meanwhile the reasoning that actually drives OBQC is structural and per-relationship: `_add_disjoint_axioms` derives sibling facts from FK topology, and fan-out is judged per join direction (#85). Nothing asks "is this table a fact?"

## The fix: additivity belongs on columns

One denormalized table, classified per column:

```
sale_id            attribute      [structural]
customer_id        attribute      [structural]
region_name        attribute      [structural]
sale_date          attribute      [structural]
amount             additive       [name_pattern]
quantity           additive       [name_pattern]
unit_price         non_additive   [name_pattern]
account_balance    semi_additive  [name_pattern]
mystery_number     (unset)        [no guess]
```

**No LLM roundtrip.** Two deterministic tiers, matching the existing `QUANTITY_PATTERNS` → `type_override` → recorded `reason` design:

- **Tier 1, structural and certain** — a key is an identifier (`SUM(order_id)` is nonsense however numeric), a non-numeric column cannot be summed. From `ColumnInfo` alone, no interpretation.
- **Tier 2, name patterns** — a unit price or rate is never meaningful to SUM; a balance is summable across accounts but not across time. Heuristic, so recorded with its reason and marked `name_pattern`.
- **No match → unannotated.** Not "assume additive". Consumers read these as fact, so an absent value beats a wrong one — the same principle as `derive_view_columns` and `oba:derivedFrom`.

The `enrich_with_llm` path can still override via `measureBasis: declared`, but nothing depends on it.

## The new OBQC rule fires without a join

```
SELECT SUM(amount) FROM sales           -> clean
SELECT SUM(unit_price) FROM sales       -> WARNING  sums a non-additive measure
SELECT SUM(sale_id) FROM sales          -> ERROR    not a measure
SELECT SUM(region_name) FROM sales      -> ERROR    not a measure
SELECT SUM(account_balance) FROM sales  -> clean    (semi-additive: fine across entities)
SELECT AVG(unit_price) FROM sales       -> clean    (only SUM is judged)
SELECT SUM(mystery_number) FROM sales   -> clean    (unclassified, never reported)
```

`SUM(unit_price)` is meaningless from a *single table* — no fan-out required — and OBQC could not see it at all before.

Severity follows the recorded basis, as agreed: **structural blocks, name-pattern warns.** A heuristic that misreads one schema's naming must not refuse to run its queries. Warning findings carry the reason plus "override it if this schema means otherwise".

## Vocabulary

`oba:measureType` / `oba:measureBasis` / `oba:measureReason`, with SHACL `sh:in` enums for the first two. `oba:tableType` gains `"mixed"` so a denormalized table can be labelled honestly — it stays advisory, since what `SUM()` may touch is now decided per column.

## Verification

- 889 passed, 144 subtests (was 863) — 26 new tests
- SHACL conforms (`violations: 0`), asserted in-test
- `ruff` / `black` / `isort` / `mypy --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)