### PR TITLE
chore(release): bump version to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,115 @@ All notable changes to OrionBelt Analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-08-08
+
+Database views become first-class, and the ontology learns which columns can
+actually be aggregated. Both change what `execute_sql_query` accepts, hence the
+major version — though the practical break is narrow, and one of the two
+changes only ever *unblocks* queries. Tool surface unchanged at 28 tools.
+
+Also fixes the **DuckDB driver, which could not connect at all** in 1.8.0.
+
+### Breaking Changes
+- **`SUM()` of a key or a non-numeric column is now rejected.** `SUM(order_id)`
+  returns a number with no meaning, and OBQC previously allowed it. Queries
+  that ran before and depended on this will now fail. Blocking is limited to
+  classifications the ontology records as `structural` — certain by
+  construction. Name-pattern classifications (e.g. `SUM(unit_price)`) attach as
+  warnings and never block. (#96)
+- **A view cannot be joined.** A view has already applied its own joins and
+  grain and carries no key, no foreign keys and no declared cardinality, so a
+  join to one cannot be validated — and an unvalidatable join between an
+  aggregate view and a fact table is what silently multiplies rows. Note this
+  breaks nothing that previously worked: before this release *every* view query
+  was rejected outright, so the net effect is strictly more queries succeed.
+  (#94)
+
+### Added
+- **Database views are discovered and indexed.** Every `information_schema`
+  driver filtered discovery to `table_type = 'BASE TABLE'`, so views never
+  reached the ontology — and OBQC blocks any table the ontology does not
+  describe. Every query against a view failed with "Table 'v_x' not found in
+  ontology", the same false-positive class fixed for catalog tables (#83) and
+  CTEs (#87). Implemented for all eight drivers. (#94)
+- **Views are searchable in GraphRAG** as their own element type, carrying the
+  view body — analyst-authored SQL naming the measures and joins someone
+  already validated. Measured on a sales schema, "which clients have the best
+  profit margin" moved from an irrelevant top hit (`clients.name`, on a query
+  vector with one non-zero dimension) to `v_profit_margin` at 0.605.
+  `graphrag_search(element_type="view")` filters to them. (#94)
+- **Views are modelled in the ontology as `oba:View`**, typed apart from
+  `owl:Class`, with columns as `oba:ViewColumn` and provenance as
+  `oba:derivedFrom`. The typing is load-bearing: every consumer that reads
+  tables looks for `owl:Class` carrying `oba:tableName`, so a view modelled as
+  an ordinary class would be picked up as a base table by each of them and
+  would have to be excluded again, rule by rule. Distinct types make the
+  separation structural. (#95)
+- **View columns come from the database catalog**, not from parsing the view
+  body. `information_schema` knows the output of `SELECT *` and of an explicit
+  `CREATE VIEW v (a, b)` header; parsing gets the second wrong and abandons the
+  first. OBQC can therefore column-check a `SELECT *` view, which it previously
+  had to leave unchecked. (#95)
+- **Per-column measure semantics** — `oba:measureType`
+  (`additive`/`semi_additive`/`non_additive`/`attribute`), `oba:measureBasis`
+  and `oba:measureReason`. Additivity is a property of a column, not of a
+  table: a denormalized table holds additive measures beside dimension
+  attributes, which no table-level role can express. Classified
+  deterministically with **no LLM call** — structural facts first (a key is an
+  identifier; a non-numeric column cannot be summed), then column-name
+  patterns. A column matching neither is left unannotated rather than assumed
+  additive. (#96)
+- **`oba:tableType` accepts `"mixed"`** so a denormalized table can be labelled
+  honestly. It remains advisory; what may be aggregated is decided per column.
+  (#96)
+
+### Fixed
+- **The DuckDB driver could not connect at all.** `connect_args={"timeout":
+  ...}` is a `TypeError` inside `duckdb.connect()`, which accepts only
+  `(database, read_only, config)`, so `connect()` returned `False` for every
+  path including `:memory:`. There were no DuckDB tests, which is why CI never
+  saw it; this release adds eight running against a real in-process database.
+  (#94)
+- **The metadata cache served a previous connection's answers.** Cache keys are
+  `operation:schema` with nothing identifying the connection, and while
+  `disconnect()` cleared the cache, the eight `connect_*` paths did not.
+  Connecting to a second database answered `get_tables("public")` from the
+  first for the full 5-minute TTL. Not a views bug — `get_tables()` had the
+  same hole since long before views existed. Driver assignment now routes
+  through one place that invalidates. (#94)
+- **A view listed itself among its own sources.** DuckDB returns the whole
+  `CREATE VIEW` statement, whose target parses as an ordinary table. (#95)
+- **View lineage ignored the SQL dialect.** sqlglot handles Snowflake
+  semi-structured access, BigQuery structs and ClickHouse aggregates without
+  complaint, and fails on a Snowflake body read as PostgreSQL — so the dialect,
+  not the SQL, was the difference between lineage and silence. (#95)
+- **ChromaDB statistics omitted element types.** The per-type breakdown
+  hard-coded three types, silently dropping views and — since 1.8.0 —
+  `semantic_context`. Now sourced from a single `ELEMENT_TYPES` tuple. (#94)
+- OBQC no longer misreads a CTE that shadows a base table as that table when
+  judging aggregation. (#96)
+- Inferred foreign keys are recognised as identifiers. ClickHouse has no
+  foreign keys at all and BigQuery and Dremio rarely declare them, so without
+  this every key on those engines read as an unclassified numeric. (#96)
+- Numeric SQL types are matched by token, not substring or word boundary. Both
+  of those fail on real dialect spellings in opposite directions: `int` is a
+  substring of `POINT`, while `INT64`, `UInt64` and `HUGEINT` contain no
+  numeric word at all — the latter misreading every measure on four supported
+  engines as an attribute. (#96)
+- An **unrecognised** SQL type is now left unclassified rather than assumed
+  non-numeric. Assuming made an unfamiliar type name a blocking error on a
+  valid `SUM`, which no amount of further enumeration would have fixed. (#96)
+
+### Internal
+- Verified end-to-end against a real PostgreSQL 17 — view discovery through
+  `pg_catalog.pg_views`, catalog columns through both `SELECT *` and an
+  explicit column header, lineage, OBQC isolation and query execution.
+  Previously only DuckDB had been exercised.
+- `ontology/spec.md` documents the view and measure vocabularies (§6.7, §7.4–7.6),
+  including that a column carrying no `oba:measureType` MUST NOT be read as
+  additive.
+- 907 tests, up from 795.
+
 ## [1.8.0] - 2026-08-05
 
 Feature release centred on OBQC correctness and GraphRAG schema search. **OBQC

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center"><strong>The Ontology-based MCP server for your Text-2-SQL convenience.</strong></p>
 
-[![Version 1.8.0](https://img.shields.io/badge/version-1.8.0-purple.svg)](https://github.com/ralforion/orionbelt-analytics/releases)
+[![Version 2.0.0](https://img.shields.io/badge/version-2.0.0-purple.svg)](https://github.com/ralforion/orionbelt-analytics/releases)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-analytics/blob/main/LICENSE)
 [![FastMCP](https://img.shields.io/badge/FastMCP-3.3.1+-blue)](https://github.com/jlowin/fastmcp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-analytics"
-version = "1.8.0"
+version = "2.0.0"
 description = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "info@ralforion.com"}]
 readme = "README.md"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.ralforion/orionbelt-analytics",
   "description": "Ontology-based MCP server for database schema analysis and RDF/OWL ontology generation",
-  "version": "1.8.0",
+  "version": "2.0.0",
   "repository": {
     "url": "https://github.com/ralforion/orionbelt-analytics",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "pypi",
       "identifier": "orionbelt-analytics",
-      "version": "1.8.0",
+      "version": "2.0.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """OrionBelt Analytics - Ontology-based MCP server for your Text-2-SQL convenience."""
 
-__version__ = "1.8.0"
+__version__ = "2.0.0"
 __author__ = "OrionBelt Analytics Contributors"
 __email__ = "contributors@example.com"
 __description__ = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"

--- a/src/ontology_generator.py
+++ b/src/ontology_generator.py
@@ -98,26 +98,120 @@ _COMPOSITE_TYPE_TOKENS = frozenset(
 )
 
 
-def is_numeric_sql_type(sql_type: str) -> bool:
-    """True when *sql_type* holds a scalar number in any supported dialect.
+# Types that certainly cannot hold a measure. Enumerated in their own right
+# rather than inferred from "not numeric", so an unfamiliar type name is
+# *unknown* instead of assumed non-numeric -- see sql_type_kind.
+_NON_NUMERIC_TYPE_TOKENS = frozenset(
+    {
+        # character
+        "char",
+        "varchar",
+        "nchar",
+        "nvarchar",
+        "text",
+        "string",
+        "clob",
+        "nvarchar2",
+        "varchar2",
+        "enum",
+        # temporal
+        "date",
+        "time",
+        "datetime",
+        "timestamp",
+        "timestamptz",
+        "datetime2",
+        "smalldatetime",
+        "interval",
+        "year",
+        "datetimeoffset",
+        # boolean
+        "bool",
+        "boolean",
+        "bit",
+        # binary and identifiers
+        "binary",
+        "varbinary",
+        "blob",
+        "bytea",
+        "bytes",
+        "uuid",
+        "guid",
+        "uniqueidentifier",
+        # spatial
+        "point",
+        "geopoint",
+        "polygon",
+        "linestring",
+        "multipoint",
+        # network / documents
+        "inet",
+        "cidr",
+        "macaddr",
+        "xml",
+    }
+)
+
+
+def sql_type_kind(sql_type: str) -> str:
+    """Classify *sql_type* as "numeric", "non_numeric" or "unknown".
+
+    Three outcomes, not two, and the third is the point. Treating
+    "unrecognized" as "non-numeric" makes an unfamiliar type name a blocking
+    error on a perfectly good ``SUM`` -- which is how INT64, UInt64 and
+    HUGEINT once blocked every measure on four supported engines. Enumerating
+    harder does not fix that; it only postpones it to the next dialect.
+
+    So both sets are positive statements, and anything in neither is
+    admitted as unknown. That matches how the rest of this vocabulary is
+    populated: an absent fact beats an invented one, because consumers read
+    what is asserted as certain.
 
     Args:
         sql_type: The SQL type as the catalog reports it.
 
     Returns:
-        True for a scalar numeric type, False for anything else --
-        composites included, since they cannot be summed at all.
+        "numeric" for a scalar number, "non_numeric" for something that
+        certainly cannot be one, "unknown" otherwise.
     """
     tokens = set(_TYPE_TOKEN_RE.findall((sql_type or "").lower()))
+    if not tokens:
+        return "unknown"
+
+    # Composites first: a composite of numbers is still not summable, so the
+    # inner type must not decide it.
     if tokens & _COMPOSITE_TYPE_TOKENS:
-        return False
+        return "non_numeric"
+
     # The unsigned prefix generically: ClickHouse UInt64 and DuckDB
     # UTINYINT/UBIGINT are the signed name with a "u" in front.
-    return any(
+    if any(
         token in _NUMERIC_TYPE_TOKENS
         or (token.startswith("u") and token[1:] in _NUMERIC_TYPE_TOKENS)
         for token in tokens
-    )
+    ):
+        return "numeric"
+
+    if tokens & _NON_NUMERIC_TYPE_TOKENS:
+        return "non_numeric"
+
+    return "unknown"
+
+
+def is_numeric_sql_type(sql_type: str) -> bool:
+    """True when *sql_type* is recognised as holding a scalar number.
+
+    Note the asymmetry: False covers both "certainly not a number" and "not
+    recognised". Callers that act on the difference -- anything that blocks
+    -- must use :func:`sql_type_kind` instead.
+
+    Args:
+        sql_type: The SQL type as the catalog reports it.
+
+    Returns:
+        True only for a recognised scalar numeric type.
+    """
+    return sql_type_kind(sql_type) == "numeric"
 
 
 logger = logging.getLogger(__name__)
@@ -573,22 +667,27 @@ class OntologyGenerator:
                 "structural",
                 "Inferred foreign key: an identifier, not a measure",
             )
-        # Token membership, not substring and not word boundaries. Both of
-        # those fail on real dialect spellings in opposite directions: "int"
-        # is a substring of POINT, and INT64 / UInt64 / HUGEINT contain no
-        # numeric word at all.
-        if not is_numeric_sql_type(sql_type):
+        # Three outcomes, because only two of them are safe to act on. A type
+        # recognised as non-numeric certainly is not a measure. A type we do
+        # not recognise says nothing -- and since this classification blocks
+        # queries, reading "unrecognised" as "not a measure" would reject a
+        # valid SUM on any dialect spelling not yet enumerated. That is
+        # exactly how INT64 and UInt64 once blocked every measure on four
+        # supported engines.
+        kind = sql_type_kind(sql_type)
+        if kind == "non_numeric":
             return (
                 "attribute",
                 "structural",
-                f"Non-numeric SQL type '{column.data_type}' cannot be aggregated as a measure",
+                f"SQL type '{column.data_type}' cannot hold a measure",
             )
-        if any(t in sql_type for t in ("bool", "date", "time", "interval")):
-            return (
-                "attribute",
-                "structural",
-                f"Temporal or boolean SQL type '{column.data_type}' is not a measure",
+        if kind == "unknown":
+            logger.debug(
+                f"Unrecognised SQL type '{column.data_type}' on "
+                f"{table_name}.{column.name}; leaving it unclassified rather "
+                "than assuming it is not a measure."
             )
+            return None
 
         # -- Tier 2: name patterns ----------------------------------------
         # Most specific first: "unit_price" is non-additive despite

--- a/tests/test_measure_semantics.py
+++ b/tests/test_measure_semantics.py
@@ -18,7 +18,11 @@ from rdflib import Graph, Namespace
 from src.constants import OBA_NAMESPACE
 from src.database_manager import ColumnInfo, TableInfo
 from src.obqc_validator import OBQCIssueType, OBQCSeverity, OBQCValidator
-from src.ontology_generator import OntologyGenerator, is_numeric_sql_type
+from src.ontology_generator import (
+    OntologyGenerator,
+    is_numeric_sql_type,
+    sql_type_kind,
+)
 
 BASE_URI = "http://test.com/ontology/"
 OBA = Namespace(OBA_NAMESPACE)
@@ -392,6 +396,69 @@ class TestNumericTypeDetection(unittest.TestCase):
         for sql_type in ("POINT", "GEOPOINT", "POLYGON", "GEOGRAPHY"):
             result = gen.classify_measure(_col("location", sql_type))
             self.assertEqual((result[0], result[1]), ("attribute", "structural"))
+
+
+class TestUnrecognisedTypesDoNotBlock(unittest.TestCase):
+    """Three outcomes, because only two are safe to act on.
+
+    Reading "unrecognised" as "not a measure" rejects a valid SUM on any
+    dialect spelling not yet enumerated -- which is how INT64 and UInt64 once
+    blocked every measure on four supported engines. Enumerating harder only
+    postpones that to the next dialect; admitting "unknown" removes it.
+    """
+
+    def setUp(self):
+        self.gen = OntologyGenerator(BASE_URI)
+
+    def _classify(self, sql_type):
+        return self.gen.classify_measure(_col("amount", sql_type))
+
+    def test_unfamiliar_numeric_types_are_unknown_not_blocked(self):
+        for sql_type in ("DECFLOAT", "SMALLDECIMAL", "SOMETHING_NEW"):
+            self.assertEqual(sql_type_kind(sql_type), "unknown", sql_type)
+            self.assertIsNone(self._classify(sql_type), sql_type)
+
+    def test_recognised_non_numeric_types_still_block(self):
+        for sql_type in ("TEXT", "DATE", "BOOLEAN", "UUID", "POINT", "GEOGRAPHY"):
+            self.assertEqual(sql_type_kind(sql_type), "non_numeric", sql_type)
+            result = self._classify(sql_type)
+            self.assertEqual((result[0], result[1]), ("attribute", "structural"))
+
+    def test_composites_are_non_numeric_not_unknown(self):
+        """A composite of numbers is still not summable, so the inner type
+        must not decide it."""
+        for sql_type in ("ARRAY<INT64>", "Array(Float64)", "MAP<STRING,INT64>"):
+            self.assertEqual(sql_type_kind(sql_type), "non_numeric", sql_type)
+
+    def test_recognised_numeric_types_classify(self):
+        for sql_type in ("INT64", "UInt64", "HUGEINT", "DECIMAL(18,2)"):
+            self.assertEqual(sql_type_kind(sql_type), "numeric", sql_type)
+            self.assertEqual(self._classify(sql_type)[0], "additive", sql_type)
+
+    def test_an_unknown_type_never_reaches_obqc_as_a_finding(self):
+        table = TableInfo(
+            name="t",
+            schema="public",
+            columns=[_col("id", "INTEGER", pk=True), _col("amount", "DECFLOAT")],
+            primary_keys=["id"],
+            foreign_keys=[],
+        )
+        ttl = OntologyGenerator(BASE_URI).generate_from_schema([table])
+        g = Graph()
+        g.parse(data=ttl, format="turtle")
+        validator = OBQCValidator()
+        validator.load_ontology(g, BASE_URI)
+        found = [
+            i
+            for i in validator.validate("SELECT SUM(amount) FROM t").issues
+            if i.issue_type is OBQCIssueType.INVALID_AGGREGATION
+        ]
+        self.assertEqual(found, [])
+
+    def test_is_numeric_sql_type_keeps_its_two_valued_contract(self):
+        self.assertTrue(is_numeric_sql_type("INT64"))
+        self.assertFalse(is_numeric_sql_type("TEXT"))
+        self.assertFalse(is_numeric_sql_type("DECFLOAT"))
 
 
 class TestTableTypeAllowsMixed(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -2493,7 +2493,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-analytics"
-version = "1.8.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release preparation for **v2.0.0**, plus one fix found while assessing readiness.

## The fix (a6510c3)

`sql_type_kind()` now answers **numeric / non_numeric / unknown**, and the third is the point. Treating "unrecognised" as "non-numeric" made an unfamiliar type name a *blocking* error on a valid `SUM` — exactly how `INT64`, `UInt64` and `HUGEINT` once blocked every measure on four supported engines. Enumerating harder doesn't remove that failure mode, it postpones it to the next dialect.

```
DECFLOAT      kind=unknown      -> unclassified, SUM(amount) allowed
SMALLDECIMAL  kind=unknown      -> unclassified, SUM(amount) allowed
TEXT / POINT  kind=non_numeric  -> still blocks
INT64         kind=numeric      -> additive
```

Both sets are positive statements now; anything in neither is admitted as unknown. Same discipline as `derive_view_columns` and `oba:derivedFrom` — an absent fact beats an invented one.

## Verified against real PostgreSQL 17

First time this pipeline has run outside DuckDB. All of it works:

```
views discovered (pg_catalog.pg_views), definitions present
  v_star     columns=['sale_id','clientid','amount','quantity','unit_price','sale_date','location']
  v_aliased  columns=['client_label','revenue']        <- explicit CREATE VIEW (a,b) header
lineage      v_revenue_by_client -> ['clients','sales']  (no self-reference)
OBQC tables  ['clients','sales']                         <- views stay out
SUM(amount)  allowed      SUM(sale_id) BLOCKED      SUM(unit_price) warn
v_star JOIN clients -> BLOCKED (view is a single entity)
view queries execute, 2 rows each
```

Both hard cases came back right from the catalog: `SELECT *` columns, and an explicit column header renaming the output.

## Why 2.0.0

Two changes to what `execute_sql_query` accepts:

- **`SUM(key)` / `SUM(non-numeric)` now rejected** — a real break; these ran before. Limited to `structural` classifications; name-pattern ones only warn.
- **Views cannot be joined** — breaks nothing that previously worked, since *every* view query was rejected before this release. Net effect is strictly more queries succeed.

So one genuine regression, narrow in scope, alongside a large amount of additive value. 1.8.0 shipped a `feat(obqc)!` under a minor bump; doing that twice would make the version numbers stop meaning anything.

## Known trade-off

A column whose type the driver cannot map (PostgreSQL `point` arrives as `data_type="NULL"` via SQLAlchemy) is now unclassified, so `SUM(location)` is allowed rather than blocked. That is the safe direction of the same trade: a missed detection, not a false block.

## Verification

- 907 passed, 144 subtests (was 795 at v1.8.0)
- `ruff` / `black` / `isort` / `mypy --strict` clean
- Real PostgreSQL 17 smoke test above

🤖 Generated with [Claude Code](https://claude.com/claude-code)