### PR TITLE
perf(docker): stop version bumps invalidating the dependency layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,17 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 
-# Install dependencies first (cached layer) using the lockfile
+# Install dependencies first (cached layer) using the lockfile.
+#
+# Only the three files this step actually reads are copied. src/__init__.py
+# used to be copied too, for the version [tool.hatch.version] reads -- but
+# --no-install-project does not build the project, so it was never needed, and
+# it made every version bump invalidate this layer and pay a full cold install
+# of chromadb, onnxruntime and pandas. The project's own version is now
+# dynamic, so none of these three change on a bump either, and the layer
+# survives a release. The project (and its version) is installed below, once
+# the source is present.
 COPY pyproject.toml uv.lock README.md ./
-COPY src/__init__.py ./src/__init__.py
 RUN uv sync --frozen --no-dev --no-install-project
 
 # Copy the rest of the project and install it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,13 @@
 [project]
 name = "orionbelt-analytics"
-version = "2.0.0"
+# Sourced from src/__init__.py via [tool.hatch.version] rather than repeated
+# here. Not only to avoid two places drifting: a static version is an input to
+# the Docker dependency layer (Dockerfile copies pyproject.toml and uv.lock
+# before installing), and it lands in uv.lock too, so a release bump used to
+# invalidate that layer and pay a full cold install of chromadb, onnxruntime
+# and pandas -- roughly six minutes, on exactly the PR that can least afford
+# it. Declared dynamic, a bump touches neither file.
+dynamic = ["version"]
 description = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "info@ralforion.com"}]
 readme = "README.md"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 # Bump the OrionBelt Analytics version everywhere it is recorded, in one step.
 #
-# Updates: src/__init__.py, pyproject.toml, server.json (both version fields),
-# the README badge, and prepends a CHANGELOG stub. Then runs `uv lock` so the
-# lockfile's pinned project version never drifts (the bug this script prevents:
-# uv.lock pins the editable project's own version and does NOT update on a bare
-# version edit — you must regenerate the lockfile).
+# Updates: src/__init__.py, server.json (both version fields), the README
+# badge, and prepends a CHANGELOG stub. Then runs `uv lock` to keep the
+# lockfile in step.
+#
+# pyproject.toml is NOT touched: [project] declares the version dynamic and
+# hatch reads it from src/__init__.py. That also keeps it, and uv.lock, out of
+# the churn — both are inputs to the Docker dependency layer, so a bump that
+# edited them forced a full cold reinstall on every release. `uv lock` is still
+# run because a bump can coincide with other manifest edits; it is now
+# expected to be a no-op for the version alone.
 #
 # Usage:
 #   ./scripts/bump-version.sh X.Y.Z
@@ -55,8 +60,11 @@ replace() {
     echo "  updated ${file}"
 }
 
+# pyproject.toml is deliberately absent: [project] declares the version
+# dynamic and hatch reads it from src/__init__.py above, so there is nothing
+# to replace. Keeping it out is what lets a bump leave the Docker dependency
+# layer's inputs untouched -- see the comment in pyproject.toml.
 replace src/__init__.py  "__version__ = \"${OLD_VERSION}\"" "__version__ = \"${NEW_VERSION}\""
-replace pyproject.toml   "version = \"${OLD_VERSION}\""      "version = \"${NEW_VERSION}\""
 replace server.json      "\"version\": \"${OLD_VERSION}\""   "\"version\": \"${NEW_VERSION}\""
 replace README.md        "version-${OLD_VERSION}"            "version-${NEW_VERSION}"
 replace README.md        "Version ${OLD_VERSION}"            "Version ${NEW_VERSION}"

--- a/uv.lock
+++ b/uv.lock
@@ -2493,7 +2493,6 @@ wheels = [
 
 [[package]]
 name = "orionbelt-analytics"
-version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Follows the v2.0.0 release, where the Docker build job took 6m37s.

## Where the time went

```
Set up Buildx   17:47:32
Build image     17:53:41     <- 6m09s of the 6m37s
```

All of it in one layer: `uv sync --frozen --no-dev --no-install-project`, a cold install of chromadb, onnxruntime and pandas. **The GHA cache was not broken** — the layer key genuinely changed, because all three of that layer's inputs carry the version:

- `src/__init__.py` — copied in for `[tool.hatch.version]`
- `pyproject.toml` — static `[project] version`
- `uv.lock` — records the editable project's own version

A release bump edits all three, so the expensive layer was invalidated on exactly the PR that can least afford it.

## The fix

**1. Drop `COPY src/__init__.py` from the dependency layer.** `--no-install-project` doesn't build the project, so the version source was never needed there. The project — and its version — is installed below, once `COPY . .` has run.

**2. Declare `[project] version` dynamic.** `[tool.hatch.version] path = "src/__init__.py"` already existed, so the static field was a second source of truth. Removing it also removes the version from `uv.lock`:

```
$ grep -A2 'name = "orionbelt-analytics"' uv.lock
name = "orionbelt-analytics"
source = { editable = "." }      # <- the `version = "..."` line is gone
```

Both were needed. Either alone leaves a second file changing on a bump.

## Verified, not assumed

Simulated a bump (`__version__` 2.0.0 → 2.0.1) and rebuilt:

```
#17 [builder 6/8] RUN uv sync --frozen --no-dev --no-install-project
#17 CACHED
```

And the image built from that cached layer is correct, not stale:

```
bumped image version = 2.0.1 | dist = 2.0.1
```

Ran the real `./scripts/bump-version.sh 2.0.1` end to end — it touched `src/__init__.py`, `server.json`, `README.md` and `CHANGELOG.md`, and left `pyproject.toml` and `uv.lock` byte-identical.

Also confirmed the full CI smoke sequence against the rebuilt image: venv interpreter resolves, `src.main` imports, `__version__` and dist metadata both correct, and `uv build` produces a wheel with `Version: 2.0.0`.

## On whether a more-cached build still proves anything

It does, for three reasons. The smoke test runs `docker run` against the **assembled image**, not the build log — the dangling-venv failure that motivated it is caught by running the image regardless of cache. Layer caching is content-addressed, so a hit means the inputs were byte-identical. And there's no half-working path here: either `uv sync --no-install-project` works without the version source or the build fails at that step. The `2.0.1` check above closes the one way it could have degraded quietly — a working image stamped with the wrong version.

`--frozen` plus the lockfile hashes remain the guard against stale *dependency content*; nothing here weakens that.

## Verification

- 907 passed, 144 subtests
- `ruff` / `black` / `isort` / `mypy --strict` clean
- Docker build + full smoke sequence, plus the cache-hit and correct-version checks above

🤖 Generated with [Claude Code](https://claude.com/claude-code)