### PR TITLE
chore(release): 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to OrionBelt Analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-08-29
+
+No functional change. This release exists so the published artefacts carry the
+third-party attribution the Docker image owes, and to ship three weeks of
+accumulated dependency updates.
+
+### Added
+- **Third-party attribution.** `THIRD_PARTY_NOTICES.md` indexes every bundled
+  dependency with its SPDX licence, generated from the locked production tree
+  by `scripts/gen-third-party-notices.py`. The Docker image bundles the whole
+  production closure, so publishing it redistributes ~197 packages plus a
+  Debian base and chromium, and the MIT/BSD/Apache-2.0 attribution clauses
+  apply to it in a way they never did to the PyPI wheel, which only declares
+  its dependencies. (#104)
+- **Verbatim licence texts in the image** at `/app/licenses/THIRD_PARTY_LICENSES.txt`,
+  collected at build time from each package's own distribution, alongside the
+  Debian copyright files already under `/usr/share/doc/`. Packages that ship no
+  licence file of their own carry a notice naming their licence, upstream
+  source and recorded attribution; a package covered by neither fails the
+  build rather than being dropped silently. (#104)
+- **Written notices for the four dependencies with obligations beyond
+  attribution**: psycopg2's LGPL-3.0 source offer, the CC-BY-SA 4.0 data
+  bundled in wordfreq (with the Google Books Ngrams and SUBTLEX credits it
+  requires), the MPL-2.0 file-level copyleft in certifi/orjson/tqdm, and
+  docutils' mixed per-file terms. (#104)
+- **A CI gate** that fails on stale notices, a missing licence text, or a new
+  copyleft dependency that nobody has read — the path such an obligation would
+  realistically take into this repo, given how much of the dependency tree
+  moves by automated bump. (#104)
+
+### Changed
+- The project licence is now declared per PEP 639 as the SPDX expression
+  `BUSL-1.1`, replacing the deprecated (and now mutually exclusive) `License ::`
+  classifier. The wheel carries `LICENSE` and `THIRD_PARTY_NOTICES.md` under
+  `dist-info/licenses/`. No change to the licence itself. (#104)
+- Dependency updates, including cryptography 49 → 50, fastmcp 3.4.7, and the
+  python-minor-patch group. (#99, #100, #101, #102, #103)
+
 ## [2.0.0] - 2026-08-08
 
 Database views become first-class, and the ontology learns which columns can

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center"><strong>The Ontology-based MCP server for your Text-2-SQL convenience.</strong></p>
 
-[![Version 2.0.0](https://img.shields.io/badge/version-2.0.0-purple.svg)](https://github.com/ralforion/orionbelt-analytics/releases)
+[![Version 2.0.1](https://img.shields.io/badge/version-2.0.1-purple.svg)](https://github.com/ralforion/orionbelt-analytics/releases)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-analytics/blob/main/LICENSE)
 [![FastMCP](https://img.shields.io/badge/FastMCP-3.3.1+-blue)](https://github.com/jlowin/fastmcp)

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.ralforion/orionbelt-analytics",
   "description": "Ontology-based MCP server for database schema analysis and RDF/OWL ontology generation",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "repository": {
     "url": "https://github.com/ralforion/orionbelt-analytics",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "pypi",
       "identifier": "orionbelt-analytics",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "transport": {
         "type": "stdio"
       }

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """OrionBelt Analytics - Ontology-based MCP server for your Text-2-SQL convenience."""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __author__ = "OrionBelt Analytics Contributors"
 __email__ = "contributors@example.com"
 __description__ = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"


### PR DESCRIPTION
No functional change. This release exists so the published artefacts actually carry the third-party attribution the Docker image owes — the notices merged in #104 only reach anyone once an image is built and pushed — and to ship three weeks of accumulated dependency updates.

## What ships

- **Third-party attribution** (#104): `THIRD_PARTY_NOTICES.md`, the verbatim licence bundle at `/app/licenses/THIRD_PARTY_LICENSES.txt` in the image, written notices for the four dependencies with obligations beyond attribution (psycopg2's LGPL source offer, wordfreq's CC-BY-SA data credits, the MPL-2.0 components, docutils' mixed terms), and a CI gate against future drift.
- **PEP 639 licence metadata** (#104): `BUSL-1.1` as an SPDX expression, replacing the deprecated classifier.
- **Dependency updates** (#99, #100, #101, #102, #103), including cryptography 49 → 50 and fastmcp 3.4.7.

## Why now

The published `:2.0.0` and `:latest` images redistribute ~197 packages with no notices index, no LGPL source offer, and seven packages whose licence text is absent outright. Nothing on `main` changes that until a tag fires the Docker publish.

## Release mechanics

`pyproject.toml` and `uv.lock` are deliberately untouched — since #98 the version is dynamic and read from `src/__init__.py`, so the bump leaves the Docker dependency layer cached. `uv lock` was a no-op, as expected.

After merge: tag `v2.0.1` → Docker Hub multi-arch build fires automatically. PyPI publish is manual and stays gated on explicit sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
