### PR TITLE
ci: publish to PyPI on a version tag

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,99 @@
+name: Publish to PyPI
+
+# Publishes the package to PyPI on every version tag (v*.*.*), using PyPI
+# Trusted Publishing (OIDC) — no API token is stored. workflow_dispatch is
+# also enabled so an existing tag can be backfilled (run against that tag's ref).
+#
+# A PyPI upload is irreversible: a version can never be re-uploaded, even after
+# a delete. So the job runs from a clean checkout — `dist/` cannot inherit a
+# stale artefact from a previous version, as it once did locally — and verifies
+# what it built before handing it to the upload step.
+on:
+  push:
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+
+jobs:
+  pypi-publish:
+    runs-on: ubuntu-latest
+    # Only run for version tags or a manual dispatch.
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    environment:
+      name: pypi
+      url: https://pypi.org/project/orionbelt-analytics/
+    permissions:
+      contents: read # actions/checkout
+      id-token: write # required for Trusted Publishing
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          # The floor of requires-python (>=3.13): what most installs get.
+          python-version: "3.13"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Check artifacts
+        run: |
+          python -m pip install --upgrade twine
+          python -m twine check dist/*
+
+      # What twine cannot know about, all of it unfixable after an upload.
+      - name: Verify release artifacts
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF}" != refs/tags/v* ]]; then
+            echo "::error::Refusing to publish from ${GITHUB_REF}." \
+                 "Dispatch this workflow against a v*.*.* tag ref."
+            exit 1
+          fi
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+
+          # The version is dynamic — hatch reads it from src/__init__.py — so a
+          # tag can disagree with what actually gets built, and the wrong
+          # version number cannot be reclaimed.
+          PKG_VERSION="$(sed -nE 's/^__version__ = "([^"]+)".*/\1/p' src/__init__.py)"
+          if [[ "${TAG_VERSION}" != "${PKG_VERSION}" ]]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} does not match" \
+                 "__version__ ${PKG_VERSION} in src/__init__.py."
+            exit 1
+          fi
+
+          WHEEL="dist/orionbelt_analytics-${PKG_VERSION}-py3-none-any.whl"
+          if [[ ! -f "${WHEEL}" ]]; then
+            echo "::error::Expected ${WHEEL}, which the build did not produce."
+            ls -l dist/
+            exit 1
+          fi
+
+          METADATA="$(unzip -p "${WHEEL}" '*.dist-info/METADATA')"
+          for line in "License-Expression: BUSL-1.1" \
+                      "License-File: LICENSE" \
+                      "License-File: THIRD_PARTY_NOTICES.md"; do
+            if ! grep -qxF "${line}" <<<"${METADATA}"; then
+              echo "::error::Wheel metadata is missing: ${line}"
+              exit 1
+            fi
+          done
+
+          # ontology/*.ttl are force-included in pyproject.toml and load-bearing:
+          # a wheel without them installs cleanly and only fails later, when
+          # SHACL validation runs.
+          CONTENTS="$(unzip -Z1 "${WHEEL}")"
+          for required in ontology/oba.ttl ontology/oba-shacl.ttl; do
+            if ! grep -qxF "${required}" <<<"${CONTENTS}"; then
+              echo "::error::Wheel is missing ${required}"
+              exit 1
+            fi
+          done
+
+          echo "Verified ${PKG_VERSION}: tag, licence metadata, ontology files."
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,4 +57,12 @@ Config comes from `.env` (copy from `.env.template`). At minimum set credentials
   has a written notice. See `THIRD_PARTY_NOTICES.md`.
 - Type hints required on all public functions (strict mypy); Google-style docstrings; 88-char lines; async handlers.
 - Tests in `tests/` as `test_*.py`; `pytest-asyncio` in `auto` mode (no `@pytest.mark.asyncio` needed).
-- Releases are **squash-only** (merge commits disabled) and PyPI publish is irreversible — see `scripts/bump-version.sh` and the release-process note in memory before cutting a release.
+- Releases are **squash-only** (merge commits disabled). Tagging `v*.*.*` publishes
+  both artefacts: `docker-publish.yml` builds the multi-arch image, and
+  `pypi-publish.yml` builds, verifies and uploads the wheel. **The PyPI upload is
+  irreversible** — a version can never be re-uploaded — so it is gated behind the
+  `pypi` GitHub environment (Trusted Publishing, no stored token) and preceded by
+  `twine check` plus assertions on tag/version agreement, licence metadata and the
+  force-included ontology files. See
+  `scripts/bump-version.sh` and the release-process note in memory before cutting
+  a release.


### PR DESCRIPTION
Tagging already builds and pushes the Docker image; the wheel was still uploaded by hand. That is the one release step that cannot be undone — a version can never be re-uploaded to PyPI, even after a delete.

## Shape

Follows the workflow already in use in [`orionbelt-ontology-builder`](https://github.com/ralforion/orionbelt-ontology-builder/blob/main/.github/workflows/pypi-publish.yml): a single job gated on a `v*.*.*` tag, `setup-python` + `python -m build`, `twine check`, and `pypa/gh-action-pypi-publish` with Trusted Publishing over OIDC — no API token stored. Binding the job to the `pypi` environment lets protection rules there put a human in front of the upload.

Two differences from that template, both forced by this repo:

- **Python 3.13**, not 3.12 — `requires-python` is `>=3.13`.
- **Explicit `contents: read`** alongside `id-token: write`. A job-level `permissions` block sets every unlisted scope to `none`, and `actions/checkout` needs read.

## Added verification

`twine check` validates that the metadata renders. These three cover what it cannot see, each unfixable once uploaded:

| Check | Why |
| --- | --- |
| tag matches `__version__` | the version is dynamic (hatch reads `src/__init__.py`), so a tag can disagree with what gets built — and a wrong version number cannot be reclaimed |
| `BUSL-1.1` + both licence files in wheel metadata | holds the PEP 639 work from #104 in place |
| `ontology/oba.ttl`, `oba-shacl.ttl` present | force-included and load-bearing — a wheel without them installs cleanly and only fails later, at SHACL validation |

Building in CI also removes a standing footgun: the upload takes whatever is in `dist/`, and a stale artefact from a previous version has been re-sent by hand before (v1.7.1). A clean checkout has nothing to inherit.

## Verification

Tested against real 2.0.1 artefacts built with `python -m build` (not `uv build`, to match what the workflow actually runs): `twine check` passes on both, the happy path passes, and each failure path — non-tag ref, tag/version mismatch, stripped licence metadata, missing ontology file — produces its intended error.

## Required before the next tag

1. **PyPI** → `orionbelt-analytics` → Publishing → add a trusted publisher: owner `ralforion`, repo `orionbelt-analytics`, workflow `pypi-publish.yml`, environment `pypi`.
2. **GitHub** → Settings → Environments → create `pypi`, optionally with required reviewers.

**v2.0.1 is already tagged, so merging this does not publish it.** Once setup is done, dispatch the workflow against the `v2.0.1` tag ref to backfill it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
