### PR TITLE
chore(tooling): move the pre-commit isort rev to 9.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
 
   # Import sorting
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 9.0.1
     hooks:
       - id: isort
         args: ["--profile", "black"]


### PR DESCRIPTION
Companion change to #109, which Dependabot could not make itself.

isort is pinned in **two** places — the `dev` group in `pyproject.toml`
(now `>=5.13.0,<10.0.0`, locked at 9.0.1) and the `pycqa/isort` `rev` in
`.pre-commit-config.yaml`, which had been sitting at **5.13.2**.

The two had already diverged in practice. isort 5.13.2 collapses this
import in `tests/test_measure_semantics.py` onto one 87-char line:

```
from src.ontology_generator import OntologyGenerator, is_numeric_sql_type, sql_type_kind
```

black then re-explodes it on the magic trailing comma. So the local hook
and the CI check disagreed on a file that is correct by both black and
isort 9, and the hook would keep reverting it on every commit.

**Verified:** `pre-commit run isort --all-files` at rev 9.0.1 passes with
the tree unchanged; `uv run isort --check-only src/ tests/ server.py`
passes too.