### PR TITLE
ci: pin every Action to a SHA and verify the pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
 
+# Read-only by default: no job in this workflow writes to the repository, so
+# the token it gets cannot either. Anything that ever needs a scope gets it on
+# that single job, never here.
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -20,10 +26,10 @@ jobs:
       matrix:
         python-version: ["3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -56,10 +62,10 @@ jobs:
   notices:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: "3.13"
 
@@ -77,10 +83,10 @@ jobs:
       matrix:
         python-version: ["3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -89,3 +95,21 @@ jobs:
 
       - name: Type check (mypy)
         run: uv run mypy src
+
+  # Blocking gate: every `uses:` in every workflow is pinned to an immutable
+  # commit SHA whose version comment names the release it was really cut from.
+  #
+  # Pinning alone fixes which code runs but makes every reference unreadable,
+  # and nothing otherwise keeps a hash and the `# vX.Y.Z` beside it in
+  # agreement. A pull request could swap in a commit from a fork -- reachable
+  # under the real repository's URL, because forks share object storage --
+  # leave the comment untouched, and look exactly like a Dependabot bump. This
+  # job resolves each tag upstream and is the only thing that tells them apart.
+  pins:
+    name: pins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify every Action is pinned to its named release
+        run: ./scripts/check-action-pins.sh

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,6 +25,11 @@ on:
       - ".github/workflows/docker-build.yml"
   workflow_dispatch:
 
+# Builds only, pushes nothing. The registry credentials live in secrets and
+# are not used here at all, so a read-only repository token is all this needs.
+permissions:
+  contents: read
+
 concurrency:
   group: docker-build-${{ github.ref }}
   cancel-in-progress: true
@@ -33,13 +38,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           # Native amd64 only, and load into the local daemon so the smoke test

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,11 @@ on:
     tags: ["v*.*.*"]
   workflow_dispatch:
 
+# The publish targets are Docker Hub, reached with the secrets above. Neither
+# job writes anything back to this repository, so both run read-only.
+permissions:
+  contents: read
+
 env:
   IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/orionbelt-analytics
 
@@ -28,23 +33,31 @@ jobs:
     # Build/push only for released version tags — never for branch or PR pushes.
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # First thing after checkout, before any other action runs. An action
+      # that has already executed could have rewritten the workspace -- this
+      # script included -- so a verifier placed after it would only be checking
+      # whatever that action left behind. Checkout itself runs unverified and
+      # has to: nothing can be checked before the tree it fetches exists.
+      - name: Verify every Action is pinned to its named release
+        run: ./scripts/check-action-pins.sh
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Derive tags and labels
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.IMAGE }}
           tags: |
@@ -56,7 +69,7 @@ jobs:
             org.opencontainers.image.description=Ontology-based MCP server for relationship-aware Text-to-SQL.
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -72,10 +85,14 @@ jobs:
     # releases. Independent of the image build — no image is produced here.
     if: github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # As above: first thing after checkout, before any other action runs.
+      - name: Verify every Action is pinned to its named release
+        run: ./scripts/check-action-pins.sh
 
       - name: Sync Docker Hub description
-        uses: peter-evans/dockerhub-description@v5
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/mcp-audit.yml
+++ b/.github/workflows/mcp-audit.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: mcp-audit-${{ github.ref }}
   cancel-in-progress: true
@@ -19,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: "3.14"
 
@@ -65,7 +68,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mcp-audit-report
           path: |

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -13,6 +13,11 @@ on:
     tags: ["v*.*.*"]
   workflow_dispatch:
 
+# Read-only at the workflow level; the one job below adds the `id-token: write`
+# that Trusted Publishing needs, and nothing more.
+permissions:
+  contents: read
+
 jobs:
   pypi-publish:
     runs-on: ubuntu-latest
@@ -25,10 +30,18 @@ jobs:
       contents: read # actions/checkout
       id-token: write # required for Trusted Publishing
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # First thing after checkout, before any other action runs. An action
+      # that has already executed could have rewritten the workspace -- this
+      # script included -- so a verifier placed after it would only be checking
+      # whatever that action left behind. Checkout itself runs unverified and
+      # has to: nothing can be checked before the tree it fetches exists.
+      - name: Verify every Action is pinned to its named release
+        run: ./scripts/check-action-pins.sh
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           # The floor of requires-python (>=3.13): what most installs get.
           python-version: "3.13"
@@ -96,4 +109,4 @@ jobs:
           echo "Verified ${PKG_VERSION}: tag, licence metadata, ontology files."
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ scripts/*
 # Canonical licence texts the generator reproduces for packages that
 # ship none of their own.
 !scripts/license-texts/
+# Tracked: CI and both publishing workflows run it to verify that every
+# Action pin still matches the release its comment names.
+!scripts/check-action-pins.sh
 build/
 dist/
 wheels/

--- a/README.md
+++ b/README.md
@@ -242,6 +242,24 @@ execute_sql_query(query) -> generate_chart(data, "bar", ...)
 connect_database("postgresql") -> execute_sql_query(...)
 ```
 
+## Development
+
+`uv sync` installs everything; `uv run pytest`, `black`/`isort`/`ruff` and strict
+`mypy` are the gates. The [Development guide](docs/development.md) has the full
+setup, project layout, and contribution checklist.
+
+One thing worth knowing before you open a workflow file: every GitHub Action is
+pinned to a 40-character commit SHA carrying a `# vX.Y.Z` comment, which is why
+they are full of hex. A git tag is a movable label, so `actions/checkout@v7` runs
+whatever commit that label points at when the job starts; a SHA cannot move. The
+comments name exact patch releases rather than `# v7`, because a major tag moves
+with every upstream release. `./scripts/check-action-pins.sh` resolves each tag
+upstream and fails when the commit it names is not the one pinned -- which is the
+only thing that distinguishes a real bump from a hash quietly swapped for one
+taken from a fork. It runs as the `pins` job on every pull request and as the
+first step of both publishing workflows; `--offline` skips the upstream lookups
+and checks only the SHA and comment format.
+
 ## Documentation
 
 | Document                                           | Contents                                                                      |

--- a/docs/development.md
+++ b/docs/development.md
@@ -136,6 +136,59 @@ bandit -r src/
 safety check
 ```
 
+### Workflow action pins
+
+Every `uses:` in `.github/workflows/` is pinned to a 40-character commit SHA
+with a `# vX.Y.Z` comment naming the release it was cut from. That is why the
+workflows are full of hex. A git tag is a movable label, so `actions/checkout@v7`
+runs whatever commit that label points at when the job starts, and the owner of
+the action can repoint it at any time. A SHA cannot move.
+
+Pinning fixes *which* code runs, but it also makes every reference unreadable,
+and nothing otherwise keeps a hash and the comment beside it in agreement. A
+pull request could swap the hash for one taken from a fork -- reachable under
+the real repository's URL, because forks share object storage with their parent
+-- leave the comment saying `# v7.0.1`, and produce a diff that looks exactly
+like a routine Dependabot bump. Only resolving the tag tells the two apart:
+
+```bash
+# Verify every pin: SHA present, owner allowed, comment names an exact patch
+# release, and that release really is the commit pinned.
+./scripts/check-action-pins.sh
+
+# Same, minus the upstream `git ls-remote` lookups -- useful offline or when
+# you only want the format checks.
+./scripts/check-action-pins.sh --offline
+```
+
+The comment must name an exact patch release (`# v7.0.1`), never a major tag:
+`v7` moves with every upstream release and would turn the check red for a pin
+that is still perfectly good. Tags are resolved with `git ls-remote`, so the
+check needs no token and is not rate limited. It fails closed -- a lookup that
+could not be made at all is a failure, not a pass.
+
+The script's `ALLOWED_OWNERS` list carries the most weight of its three checks,
+because a SHA matching its own tag says nothing about whether the action
+belongs here at all: `evil/action@<sha> # v1.0.0` verifies perfectly well
+against evil's own tag. Adding an owner is a deliberate decision, not a
+formality. The `pins` job in `ci.yml` runs the check on every pull request, and
+both tag-publishing workflows run it as the first step after checkout, before
+any other action -- an action that has already executed could have rewritten
+the workspace, this script included.
+
+What it does not do: it does not judge whether an action is safe (a pinned SHA
+of a genuinely malicious release passes), it does not stop a downgrade to a
+real but ancient release, and it says nothing about upstream being compromised.
+`actions/checkout` runs before the check and is therefore unverified -- an
+irreducible bootstrap dependency, since nothing can be checked before the tree
+it fetches exists.
+
+To resolve a SHA yourself when bumping an action:
+
+```bash
+git ls-remote https://github.com/actions/checkout 'refs/tags/v7.0.1^{}'
+```
+
 ### Pre-commit hooks
 
 ```bash
@@ -384,6 +437,14 @@ docs: update configuration reference for BigQuery
    ```bash
    bandit -r src/
    ```
+
+7. **Verify action pins** if you touched anything under `.github/workflows/`:
+
+   ```bash
+   ./scripts/check-action-pins.sh
+   ```
+
+   The `pins` job in CI runs the same check and blocks the merge.
 
 ### Code standards
 

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#
+# Verify that every third-party Action used by the workflows is pinned to an
+# immutable commit SHA, comes from an owner we trust, and carries a version
+# comment that really does name the release that SHA was cut from.
+#
+#   ./scripts/check-action-pins.sh              # every check
+#   ./scripts/check-action-pins.sh --offline    # skip the upstream tag lookups
+#
+# A git tag is a movable label, so `uses: actions/checkout@v7` runs whichever
+# commit that label points at when the job starts, and the owner of the action
+# can repoint it at any time. Pinning to a SHA fixes the code, but it also
+# makes the reference unreadable to a human, and that is the weakness this
+# guards. A pull request can swap the hash for one taken from an attacker's
+# fork while leaving the reassuring `# v7.0.1` comment untouched, and the diff
+# then looks exactly like a routine Dependabot bump. Forks share object storage
+# with their parent, so such a commit is even reachable under the real
+# repository's URL. Only resolving the tag tells the two apart.
+#
+# Version comments must name exact patch releases, never major tags. A major
+# tag such as v7 moves with every release, so checking against it would turn CI
+# red the moment upstream ships v7.0.2, for a pin that is still perfectly good.
+# Patch tags never move, so this check stays quiet until something is wrong.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Only actions published by these owners may appear in a workflow. This is the
+# check that carries the most weight: a SHA matching its own tag says nothing
+# about whether the action belongs here at all, because `evil/action@<sha>
+# # v1` verifies perfectly well against evil's own v1 tag.
+#
+# Each owner here is a deliberate decision, not a convenience:
+#
+#   actions      GitHub's own first-party actions (checkout, setup-python,
+#                upload-artifact).
+#   astral-sh    setup-uv, from the authors of uv, which is how every job in
+#                this repo installs Python and the locked dependency tree.
+#   docker       the official buildx/qemu/login/metadata/build-push actions
+#                that build and publish the multi-arch image.
+#   peter-evans  dockerhub-description, which syncs README.md to the Docker Hub
+#                overview. The only individual maintainer on this list; it holds
+#                the Docker Hub token, so weigh any change to it accordingly.
+#   pypa         gh-action-pypi-publish, the Python Packaging Authority's
+#                Trusted Publishing uploader. A PyPI upload is irreversible.
+ALLOWED_OWNERS="actions astral-sh docker peter-evans pypa"
+
+offline=false
+case "${1:-}" in
+    --offline) offline=true ;;
+    "") ;;
+    *) echo "usage: $0 [--offline]" >&2; exit 2 ;;
+esac
+
+# Resolve a tag to the commit it names, following annotated tags through to
+# their target. git ls-remote needs no token and is not rate limited, unlike
+# the REST API, which matters because hosted runners share outbound addresses.
+#
+# Three outcomes have to stay distinguishable. A tag that resolves prints its
+# SHA. A tag that does not exist prints nothing and returns 0, because
+# ls-remote reports a missing ref as success. A lookup that could not be made
+# at all, from a network failure or a repository that is not there, returns
+# non-zero and writes the reason to stderr. Collapsing the last two would let
+# an unreachable network read as a verified pin, and swallowing the error under
+# set -e would kill the run with no file or line to point at.
+resolve_tag() {
+    out=$(git ls-remote "https://github.com/$1" "refs/tags/$2" "refs/tags/$2^{}" 2>&1) || {
+        status=$?
+        printf 'git ls-remote exit %s: %s\n' "$status" "$(printf '%s' "$out" | tr '\n' ' ')" >&2
+        return "$status"
+    }
+    printf '%s\n' "$out" |
+        awk '{ sha[$2] = $1 }
+             END { print (("refs/tags/'"$2"'^{}") in sha) \
+                          ? sha["refs/tags/'"$2"'^{}"] \
+                          : sha["refs/tags/'"$2"'"] }'
+}
+
+failures=0
+checked=0
+
+fail() {
+    echo "::error file=$1,line=$2::$3"
+    echo "  $1:$2: $3" >&2
+    failures=$((failures + 1))
+}
+
+# Every `uses:` line in every workflow, carrying its file and line number so a
+# failure points straight at the offending reference.
+while IFS=: read -r file line body; do
+    # `uses: owner/repo@ref  # comment`, with the step's leading "- " optional.
+    spec=$(printf '%s\n' "$body" | sed -E 's/^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*//; s/[[:space:]]*#.*$//; s/[[:space:]]*$//')
+    comment=$(printf '%s\n' "$body" | sed -nE 's/.*#[[:space:]]*(v[0-9][^[:space:]]*).*/\1/p')
+
+    # Actions living in this repository are covered by our own review.
+    case "$spec" in
+        ./*|.\\*) continue ;;
+    esac
+
+    checked=$((checked + 1))
+
+    # A container action is third-party executable code exactly as a repository
+    # action is, and an image tag such as :latest is every bit as movable as a
+    # git tag, so one cannot simply be waved through for having no git ref to
+    # resolve. A digest is what pins an image, and anything else is rejected.
+    # Note the residual gap: a digest fixes which image runs without saying
+    # whether it ought to run here, because there is no registry equivalent of
+    # ALLOWED_OWNERS. Adding a container action stays a deliberate act.
+    case "$spec" in
+        docker://*)
+            if ! printf '%s\n' "$spec" | grep -qE '^docker://[^@[:space:]]+@sha256:[0-9a-f]{64}$'; then
+                fail "$file" "$line" "$spec is a container action that is not pinned by digest; write it as docker://image@sha256:<64 hex digits>"
+            fi
+            continue
+            ;;
+    esac
+
+    repo=${spec%%@*}
+    ref=${spec#*@}
+    owner=${repo%%/*}
+
+    # A subdirectory action such as owner/repo/path@ref still pins the whole
+    # repository, so trim the path before resolving anything.
+    repo=$(printf '%s\n' "$repo" | cut -d/ -f1,2)
+
+    allowed=false
+    for candidate in $ALLOWED_OWNERS; do
+        [ "$owner" = "$candidate" ] && allowed=true
+    done
+    if [ "$allowed" = false ]; then
+        fail "$file" "$line" "owner '$owner' is not in ALLOWED_OWNERS ($ALLOWED_OWNERS); add it deliberately in scripts/check-action-pins.sh if this action is meant to run here"
+        continue
+    fi
+
+    if ! printf '%s\n' "$ref" | grep -qE '^[0-9a-f]{40}$'; then
+        fail "$file" "$line" "$repo is pinned to '$ref', which is a movable tag; pin it to the 40-character commit SHA that tag points at"
+        continue
+    fi
+
+    if [ -z "$comment" ]; then
+        fail "$file" "$line" "$repo@${ref:0:8} has no version comment; append '# vX.Y.Z' naming the release this SHA was cut from"
+        continue
+    fi
+
+    if ! printf '%s\n' "$comment" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+        fail "$file" "$line" "$repo carries the comment '# $comment'; name an exact patch release such as v7.0.1, because major tags move with every release and would fail this check for a good pin"
+        continue
+    fi
+
+    [ "$offline" = true ] && continue
+
+    # Folding stderr into the capture keeps the reason in $actual when the
+    # lookup fails, and the condition context exempts this from set -e so one
+    # unreachable repository cannot mask the findings on every later pin.
+    if ! actual=$(resolve_tag "$repo" "$comment" 2>&1); then
+        fail "$file" "$line" "could not resolve $repo $comment upstream: $actual"
+    elif [ -z "$actual" ]; then
+        fail "$file" "$line" "$repo has no tag $comment upstream"
+    elif [ "$actual" != "$ref" ]; then
+        fail "$file" "$line" "$repo $comment is upstream commit $actual, but the workflow pins $ref"
+    fi
+done < <(grep -rnE '^[[:space:]]*(-[[:space:]]+)?uses:' .github/workflows)
+
+if [ "$failures" -gt 0 ]; then
+    echo >&2
+    echo "$failures of $checked action pin(s) failed verification" >&2
+    exit 1
+fi
+
+echo "all $checked action pin(s) verified$([ "$offline" = true ] && echo " (offline: SHA and comment format only)")"


### PR DESCRIPTION
Ports [ralforion/qvd2parquet#55](https://github.com/ralforion/qvd2parquet/pull/55) and [#56](https://github.com/ralforion/qvd2parquet/pull/56) to this repo. Nothing here is language-specific.

## Pin every Action to a commit SHA

All 24 `uses:` references across the five workflows now name a 40-character commit SHA with a `# vX.Y.Z` comment. `actions/checkout@v7` ran whichever commit that label pointed at when the job started, and the owner of the action can repoint the label at any time. A SHA cannot move.

Each SHA was resolved from the tag that the major label currently points at, so this pins the code that was already running — no version changed:

| Action | Pin |
| --- | --- |
| `actions/checkout` | v7.0.1 |
| `actions/setup-python` | v7.0.0 |
| `actions/upload-artifact` | v7.0.1 |
| `astral-sh/setup-uv` | v7.6.0 |
| `docker/setup-qemu-action` | v4.2.0 |
| `docker/setup-buildx-action` | v4.3.0 |
| `docker/login-action` | v4.6.0 |
| `docker/metadata-action` | v6.2.0 |
| `docker/build-push-action` | v7.3.0 |
| `peter-evans/dockerhub-description` | v5.0.0 |
| `pypa/gh-action-pypi-publish` | v1.14.2 |

The last one was on the `release/v1` **branch**, which moves on every release rather than only on majors. Its head is v1.14.2, which is what it is now pinned to. Dependabot's `github-actions` ecosystem is already configured here and updates a SHA pin and its comment together, so bumps keep arriving as normal PRs.

## Read-only tokens

Every workflow gets `permissions: contents: read` at the top. Nothing in this repo writes back to the repository from CI — the image publish authenticates to Docker Hub with a stored secret, and the PyPI publish already kept its `id-token: write` on the one job that needs it. No write scope was added or moved; there was none at the workflow level to move.

## Verify the pins actually match their comments

Pinning fixed *which* code runs. It also made every reference unreadable, and nothing keeps a SHA and the comment beside it in agreement. A PR can swap the hash for one taken from a fork, leave the comment saying `# v7.0.1`, and the diff looks exactly like a routine Dependabot bump. Forks share object storage with their parent, so such a commit is reachable under the real repository's URL too. Only resolving the tag tells the two apart, and no human does that by eye on 40 hex characters.

`scripts/check-action-pins.sh` (verbatim from qvd2parquet apart from `ALLOWED_OWNERS`) walks every `uses:` line and requires a SHA, an allowed owner, and a comment naming an exact patch release — then resolves that tag upstream with `git ls-remote` and fails when the commit it names is not the one pinned. Container actions must be pinned by digest; local `./` actions are skipped; `--offline` checks only SHA and comment format.

`ALLOWED_OWNERS` is `actions astral-sh docker peter-evans pypa`, each annotated in the script with what it is for. It carries the most weight of the three checks: a SHA matching its own tag says nothing about whether the action belongs here at all, since `evil/action@<sha> # v1.0.0` verifies perfectly well against evil's own tag.

Tags are resolved with `git ls-remote` rather than the REST API, so the check needs no token, parses no JSON, and is not rate limited on hosted runners that share outbound addresses. It fails closed — a lookup that could not be made at all is a failure, not a pass — and one unreachable repository does not stop the loop and hide a forged pin behind it.

### Where it runs

- A new `pins` job in `ci.yml`, on every PR.
- First step after checkout in **both** tag-publishing workflows, `pypi-publish.yml` and `docker-publish.yml`. Ordering is the point: an action that has already executed could have rewritten the workspace, this script included, so a verifier placed after it would be checking whatever that action left behind. `actions/checkout` still runs unverified and has to — nothing can be checked before the tree it fetches exists.

`scripts/*` is gitignored here with an explicit allowlist, so `.gitignore` needed a negation for the script to be tracked at all.

## What this does not do

Documented in both the README and the development guide, because a pin check is easy to over-trust:

- It does not judge whether an action is safe. A pinned SHA of a genuinely malicious release passes.
- It does not stop a downgrade. Pinning to a real but ancient `# v6.0.0` passes, because that SHA does match that tag.
- It says nothing about upstream being compromised. If a tag is repointed you are pinned to the old code and correctly unaffected.
- A digest fixes which container image runs, not whether it ought to run here. There is no registry equivalent of `ALLOWED_OWNERS`.
- `actions/checkout` runs before the check and is therefore unverified — an irreducible bootstrap dependency, not an oversight.

## Testing

Run locally against this tree:

- `./scripts/check-action-pins.sh` → `all 24 action pin(s) verified`
- `./scripts/check-action-pins.sh --offline` → same, format checks only
- Negative tests, each failing as intended with the right file and line: a hash that does not match its `# v7.0.1` comment, an `evil/action@v1` step, and an undigested `docker://alpine:latest`.

All five workflow files parse as YAML.

## After merge

`pins` needs adding to the required status checks for `main`. The job does not exist on `main` until this merges, so that has to happen afterwards — and any PR opened from `main` before then would wait forever on a context that never reports.