### PR TITLE
chore(release): 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to OrionBelt Analytics will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2026-08-31
+
+No functional change — as with 2.0.2, not a line of `src/` differs, and the
+tool surface stays at 28. This release ships the full dependency re-resolve
+that 2.0.2 deliberately held back, so the Docker image is rebuilt on a current
+tree rather than one carrying a year of drift.
+
+### Changed
+- **Full lockfile re-resolve.** 127 packages moved, ten left the tree, one
+  arrived. Eighteen major-version jumps reach the production closure —
+  `protobuf` 6 → 7, `rpds-py` 0.27 → 2026.6.3, `websockets` 15 → 17, `rich`
+  14 → 15, `markdown-it-py` 3 → 4, `kubernetes` 35 → 36, `packaging` 25 → 26,
+  `pycparser` 2 → 3, `simplejson` 3 → 4, `more-itertools` 10 → 11, `cachetools`
+  6 → 7, `attrs` 25 → 26, `importlib-resources` 6 → 7, `rich-rst` 1 → 2, and
+  the date-shaped `certifi`, `pytz`, `tzdata`, `pywin32`. Four more are
+  development-only. Held back from 2.0.2 on purpose: a security fix that had to
+  ship was not the place to also move 127 packages. (#125)
+- **`zstd` 1.5.7.3 is gone**, which upstream had yanked as "buggy — not thread
+  safe" and which `uv` warned about on every resolve. It left the tree as a
+  consequence of the re-resolve rather than needing separate handling. (#125)
+
+### Fixed
+- **Three third-party licences were recorded incorrectly** and are now right.
+  `cffi`, `greenlet` and `simplejson` have adopted PEP 639 licence expressions,
+  and what they declare disagrees with what their previous classifiers implied.
+  The notices generator failed closed on all three rather than guessing — the
+  first time that gate has fired on real input — and each was resolved by
+  reading the package's own shipped licence text: `cffi` MIT → **MIT-0** (its
+  `LICENSE` reads "MIT No Attribution" and omits the attribution clause),
+  `greenlet` MIT AND Python-2.0 → **MIT AND PSF-2.0** (`LICENSE.PSF` is the
+  Python Software Foundation licence, covering the files derived from Stackless
+  Python), and `simplejson` MIT → **MIT OR AFL-2.1** (dual-licensed, per
+  `LICENSE.txt`). None is copyleft, so no new written notice is owed. (#125)
+
+### Removed
+- **`docutils` has left the dependency tree**, retiring the
+  `LicenseRef-Docutils-Mixed` entry — one fewer bundled dependency with
+  obligations beyond attribution. `THIRD_PARTY_NOTICES.md` now covers 190
+  packages, down from 197. (#125)
+
 ## [2.0.2] - 2026-08-31
 
 No functional change — not a line of `src/` differs from 2.0.1. This release

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <p align="center"><strong>The Ontology-based MCP server for your Text-2-SQL convenience.</strong></p>
 
-[![Version 2.0.2](https://img.shields.io/badge/version-2.0.2-purple.svg)](https://github.com/ralforion/orionbelt-analytics/releases)
+[![Version 2.0.3](https://img.shields.io/badge/version-2.0.3-purple.svg)](https://github.com/ralforion/orionbelt-analytics/releases)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-analytics/blob/main/LICENSE)
 [![FastMCP](https://img.shields.io/badge/FastMCP-3.3.1+-blue)](https://github.com/jlowin/fastmcp)

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.ralforion/orionbelt-analytics",
   "description": "Ontology-based MCP server for database schema analysis and RDF/OWL ontology generation",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "repository": {
     "url": "https://github.com/ralforion/orionbelt-analytics",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "pypi",
       "identifier": "orionbelt-analytics",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "transport": {
         "type": "stdio"
       }

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """OrionBelt Analytics - Ontology-based MCP server for your Text-2-SQL convenience."""
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 __author__ = "OrionBelt Analytics Contributors"
 __email__ = "contributors@example.com"
 __description__ = "OrionBelt Analytics - the Ontology-based MCP server for your Text-2-SQL convenience"


### PR DESCRIPTION
Patch release. **No functional change — not a line of `src/` differs from 2.0.2, tool surface unchanged at 28.**

Ships the full dependency re-resolve (#125) that 2.0.2 deliberately held back, so the Docker image is rebuilt on a current tree rather than one carrying accumulated drift. The image is the only artefact this affects: it bundles the whole production closure and is only ever built on a version tag. The PyPI wheel declares its dependencies rather than bundling them, so it stays functionally identical.

## Contents

**Full lockfile re-resolve** (#125) — 127 packages moved, ten left the tree, one arrived. Eighteen major-version jumps reach the production closure: `protobuf` 6→7, `rpds-py` 0.27→2026.6.3, `websockets` 15→17, `rich` 14→15, `markdown-it-py` 3→4, `kubernetes` 35→36, `packaging` 25→26, `pycparser` 2→3, `simplejson` 3→4, `more-itertools` 10→11, `cachetools` 6→7, `attrs` 25→26, `importlib-resources` 6→7, `rich-rst` 1→2, plus `certifi`/`pytz`/`tzdata`/`pywin32`. Four more are dev-only.

**`zstd` 1.5.7.3 is gone** — yanked upstream as "buggy — not thread safe", warned about on every resolve, and dropped as a consequence of the re-resolve rather than needing separate handling.

**Three licence records corrected.** `cffi`, `greenlet` and `simplejson` adopted PEP 639 expressions that disagree with their old classifiers. The notices generator failed closed on all three — the first time that gate has fired on real input — and each was resolved by reading the package's own shipped text: `cffi` MIT → **MIT-0**, `greenlet` MIT AND Python-2.0 → **MIT AND PSF-2.0**, `simplejson` MIT → **MIT OR AFL-2.1**. None copyleft.

**`docutils` left the tree**, retiring the `LicenseRef-Docutils-Mixed` entry — one fewer bundled dependency with obligations beyond attribution. Notices now cover 190 packages, down from 197.

## Not included

`chromadb` stays at 1.5.9 (#112) — still no patched release, still not reachable from an embedded `PersistentClient`.

## Release mechanics

Version updated in `src/__init__.py` (single source of truth), `server.json` (both fields) and the README badge via `scripts/bump-version.sh`. `pyproject.toml` and `uv.lock` untouched — `uv lock` was a no-op, keeping the Docker dependency layer cached.

The re-resolved tree already passed the full CI matrix on #125, including the Docker smoke test that boots the image and checks `/mcp` answers.