### PR TITLE
Fix the licence badge: BUSL-1.1, not BSL 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![Version 2.0.3](https://img.shields.io/badge/version-2.0.3-purple.svg)](https://github.com/ralforion/orionbelt-analytics/releases)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
-[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-analytics/blob/main/LICENSE)
+[![License: BUSL-1.1](https://img.shields.io/badge/License-BUSL--1.1-orange.svg)](https://github.com/ralforion/orionbelt-analytics/blob/main/LICENSE)
 [![FastMCP](https://img.shields.io/badge/FastMCP-3.3.1+-blue)](https://github.com/jlowin/fastmcp)
 [![RDF/OWL](https://img.shields.io/badge/RDF%2FOWL-Ontology-orange)](https://www.w3.org/OWL/)
 


### PR DESCRIPTION
The badge read **`License: BSL 1.1`**.

**BSL is not shorthand for BUSL.** `BSL-1.0` is the **Boost Software License** — permissive, and close to the opposite of this one — and `BSL-1.1` is not an SPDX identifier at all. The badge pointed a reader at a licence this project is not under, on the line they are most likely to read.

`BUSL-1.1` is what `LICENSE` and `pyproject.toml` already say, and what the badges in orionbelt-runner, orionbelt-ontology-builder and orionbelt-semantic-layer already use.

```diff
-[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)]
+[![License: BUSL-1.1](https://img.shields.io/badge/License-BUSL--1.1-orange.svg)]
```

README only — no other change.