### PR TITLE
Name every version as the Licensed Work, not 1.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ Business Source License 1.1
 Parameters
 
 Licensor: RALFORION d.o.o.
-Licensed Work: OrionBelt Analytics 1.0
+Licensed Work: OrionBelt Analytics, all versions
 The Licensed Work is (c) 2025 RALFORION d.o.o.
 Additional Use Grant: You may use the Licensed Work for any purpose,
 including production use, PROVIDED THAT you may


### PR DESCRIPTION
The `Licensed Work` parameter read **`OrionBelt Analytics 1.0`**.

BUSL grants its terms for the work it names, so pinning a version leaves later ones — everything actually shipped since — outside what the licence describes, and a reader has to guess whether that was deliberate.

```diff
-Licensed Work: OrionBelt Analytics 1.0
+Licensed Work: OrionBelt Analytics, all versions
```

`all versions` is the wording **orionbelt-semantic-layer** and **orionbelt-ontology-builder** already use, and **orionbelt-runner** reached the same place from the other direction by dropping the version outright in `4130069`. This and mcp-xray were the last two outliers.

Nothing else changes — Licensor, Change Date, Change License and the Additional Use Grant are untouched. This broadens the grant, so it cannot disadvantage anyone who already holds a copy.