### PR TITLE
ci: take setup-uv v10.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           python-version: "3.13"
 
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/mcp-audit.yml
+++ b/.github/workflows/mcp-audit.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           python-version: "3.14"
 


### PR DESCRIPTION
Three majors in one step (7.6.0 → 10.0.1), so each breaking change was checked against what this repo actually does rather than taken on the release notes’ word.

| release | breaking change | effect here |
|---|---|---|
| **v8.0.0** | removed the deprecated custom version-manifest format | **none** — `enable-cache` is the only input passed anywhere; no `manifest-file`, `version-file` or `tool-versions` |
| **v9.0.0** | `prune-cache` default → `false` | **real but benign** — the Actions cache will grow where it previously trimmed itself. Set `prune-cache: true` if the quota becomes a problem |
| **v10.0.0** | with `enable-cache: auto`, cache **disabled** for `pull_request_target`, `workflow_run`, `release` (cache-poisoning defence) | **none** — `ci.yml` and `mcp-audit.yml` run on `push` and `pull_request` only |

The v10 change is the one worth understanding: an explicit `enable-cache: true` is precisely what waives that protection. Nothing here uses the affected triggers, so nothing is being waived — but revisit it if a `release`-triggered job is ever added.

The pinned SHA is the same one already in **orionbelt-runner**, **orionbelt-chat**, **orionbelt-ontology-builder** and **orionbelt-semantic-layer-mcp**, and `scripts/check-action-pins.sh` resolves it against the `v10.0.1` tag upstream — verified locally, all 24 pins pass.