### PR TITLE
ci: gate on advisories in the shipped dependency tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,26 @@ jobs:
       - name: Type check (mypy)
         run: uv run mypy src
 
+  # Blocking gate: no known advisory in the tree that actually ships.
+  #
+  # Dependabot alerts cover the whole lockfile including the dev group, which
+  # makes them wider than this gate on purpose -- a dev-only advisory should
+  # not stop a release. This job is the narrower question: is a user who
+  # installs the wheel exposed? The accepted-advisory list lives in the script
+  # beside the reason each one is unreachable, so it stays reviewable in diff.
+  deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          python-version: "3.13"
+
+      - name: Audit production dependencies (pip-audit)
+        run: ./scripts/audit-prod-deps.sh
+
   # Blocking gate: every `uses:` in every workflow is pinned to an immutable
   # commit SHA whose version comment names the release it was really cut from.
   #

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ scripts/*
 # Tracked: CI and both publishing workflows run it to verify that every
 # Action pin still matches the release its comment names.
 !scripts/check-action-pins.sh
+# Tracked: CI runs it as the `deps` gate, and it is the documented local
+# command for auditing the shipped dependency tree.
+!scripts/audit-prod-deps.sh
 build/
 dist/
 wheels/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ black src/ tests/ server.py && isort src/ tests/ server.py   # format
 ruff check src/ tests/ server.py         # lint (server.py is the root entry point)
 mypy src/                                # strict type check (disallow_untyped_defs etc.)
 bandit -r src/                           # security scan (run for SQL/credential changes)
+./scripts/audit-prod-deps.sh             # advisories in the shipped dep tree (CI job `deps`)
 uv run python scripts/gen-third-party-notices.py   # refresh THIRD_PARTY_NOTICES.md after a dependency change
 pre-commit run --all-files               # all of the above as configured hooks
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -133,14 +133,19 @@ mypy is configured with `disallow_untyped_defs`, `disallow_incomplete_defs`, `wa
 bandit -r src/
 
 # Dependency vulnerability scanning, against the tree that actually ships
-uv export --no-dev --no-emit-project --format requirements-txt \
-  | uvx pip-audit --disable-pip -r -
+./scripts/audit-prod-deps.sh
 ```
 
 Dependabot security updates scan the whole of `uv.lock`, so its alert list is
-wider than the shipped surface — it includes the dev group. The `pip-audit`
-command above is the narrower check: what a user installing the wheel is
-actually exposed to.
+wider than the shipped surface — it includes the dev group. `audit-prod-deps.sh`
+is the narrower check: what a user installing the wheel is actually exposed to.
+It runs in CI as the blocking `deps` job, so it is the same command locally and
+on a pull request.
+
+Advisories accepted as unreachable are listed at the top of that script, each
+with the reason it cannot be triggered from this codebase. Adding an entry there
+is a review decision, not a formality — it should mirror a Dependabot dismissal
+and be removed as soon as a fixed release exists.
 
 ### Workflow action pins
 

--- a/scripts/audit-prod-deps.sh
+++ b/scripts/audit-prod-deps.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Audit the dependency tree that actually ships for known advisories.
+#
+# Dependabot alerts scan the whole of uv.lock, dev group included, so its list
+# is always wider than what a user installing the wheel is exposed to. This
+# script is the narrower, blocking check: the production tree only.
+#
+# Why the flags are what they are:
+#   --no-dev            the dev group never reaches a user
+#   --no-emit-project   the project itself is not a third-party advisory target
+#   --no-hashes         pip-audit cannot parse uv's --hash lines
+#   --no-deps           the export is already fully resolved; re-resolving it
+#                       would need network installs and defeat --disable-pip
+#   --disable-pip       audit the locked versions, never whatever pip resolves
+#
+set -euo pipefail
+
+# Advisories accepted as not reachable from this codebase. Each entry must
+# mirror a Dependabot dismissal and say why, so the list stays auditable rather
+# than becoming a place vulnerabilities go to be forgotten.
+#
+# chromadb 1.5.9 -- four unpatched CVEs in the server HTTP API. Not reachable:
+# src/graphrag/vector_store_chromadb.py uses the embedded PersistentClient and
+# never starts or calls the server. Dismissed as not_used on 2026-08-31
+# (alerts #17, #34, #35, #36). Drop these the moment chromadb ships a fix.
+IGNORED=(
+  PYSEC-2026-311   # CVE-2026-45829
+  CVE-2026-45830
+  CVE-2026-45831
+  CVE-2026-45833
+)
+
+REQUIREMENTS="$(mktemp -t prod-requirements.XXXXXX)"
+trap 'rm -f "$REQUIREMENTS"' EXIT
+
+uv export --no-dev --no-emit-project --no-hashes \
+  --format requirements-txt -o "$REQUIREMENTS" --quiet
+
+ignore_args=()
+for vuln in "${IGNORED[@]}"; do
+  ignore_args+=(--ignore-vuln "$vuln")
+done
+
+echo "Auditing $(grep -c '==' "$REQUIREMENTS") production packages" \
+     "(${#IGNORED[@]} advisories ignored, see script header)."
+
+exec uv tool run pip-audit \
+  --disable-pip --no-deps -r "$REQUIREMENTS" "${ignore_args[@]}"


### PR DESCRIPTION
Adds a blocking `deps` CI job that audits the **production** dependency tree with `pip-audit`, plus `scripts/audit-prod-deps.sh` so the same command runs locally and in CI.

## Why a second scanner, when Dependabot exists

Dependabot scans the whole of `uv.lock`, dev group included. That is the right default for *alerts* but the wrong shape for a *release gate* — a dev-only advisory should not block a merge. #130 was exactly that case: a high-severity advisory with no available fix, in a package that never shipped.

This job asks the narrower question: **is a user who installs the wheel exposed?**

## The ignore list

`pip-audit` is red today on four unpatched `chromadb` advisories. They are ignored explicitly, in the script, next to the reason:

> `src/graphrag/vector_store_chromadb.py` uses the embedded `PersistentClient` and never starts or calls the server HTTP API the CVEs concern.

That mirrors the existing Dependabot dismissals (#17, #34, #35, #36, dismissed `not_used` on 2026-08-31). Keeping the list in the script — rather than a config file — means adding an entry shows up in review as a diff with its justification attached, and the header says to drop them the moment chromadb ships a fix.

## Fixes a broken command from #130

The `pip-audit` invocation I documented in #130 did not actually run:

- `pip-audit` cannot parse the `--hash=` lines `uv export` emits → needs `--no-hashes`
- `--disable-pip` is rejected on an unhashed file unless `--no-deps` is given (the export is already fully resolved, so re-resolving is both unnecessary and would require network installs)

`docs/development.md` now points at the script instead of an inline pipeline that can rot.

## Verification

- `./scripts/audit-prod-deps.sh` → `No known vulnerabilities found, 4 ignored`, exit 0.
- **Negative control:** removing one ID from the ignore list makes it report the advisory and exit **1** — the gate is not passing vacuously.
- `./scripts/check-action-pins.sh` → all 26 pins verified (the new job reuses existing pinned SHAs).
- `ci.yml` parses; jobs are `quality`, `notices`, `typecheck`, `deps`, `pins`.

Named `deps` rather than `audit` to avoid colliding with the existing `audit` job in `mcp-audit.yml`.

## Note for after merge

`deps` is **not** yet in the required status checks on `main` (currently `pins`, `notices`, `typecheck (3.13)`, `typecheck (3.14)`, `quality (3.13)`, `quality (3.14)`). It will run and display on PRs but will not block until added there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)